### PR TITLE
feat: move `Surreal.toOrdinal` to new file

### DIFF
--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -1,4 +1,3 @@
--- Imports all other modules in the library.
 import CombinatorialGames.Game.Basic
 import CombinatorialGames.Game.Birthday
 import CombinatorialGames.Game.Domineering
@@ -8,7 +7,7 @@ import CombinatorialGames.Game.Ordinal
 import CombinatorialGames.Game.PGame
 import CombinatorialGames.Game.Short
 import CombinatorialGames.Game.State
-
 import CombinatorialGames.Surreal.Basic
 import CombinatorialGames.Surreal.Dyadic
 import CombinatorialGames.Surreal.Multiplication
+import CombinatorialGames.Surreal.Ordinal

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import CombinatorialGames.Game.Basic
+import Mathlib.SetTheory.Game.Basic
 import Mathlib.SetTheory.Ordinal.NaturalOps
 
 /-!
@@ -17,9 +17,8 @@ The map to surreals is defined in `Ordinal.toSurreal`.
 # Main declarations
 
 - `Ordinal.toPGame`: The canonical map between ordinals and pre-games.
-- `Ordinal.toPGameEmbedding`: The order embedding version of the previous map.
+- `Ordinal.toGame`: The canonical map between ordinals and games.
 -/
-
 
 universe u
 
@@ -28,6 +27,8 @@ open SetTheory PGame
 open scoped NaturalOps PGame
 
 namespace Ordinal
+
+/-! ### `Ordinal` to `PGame` -/
 
 /-- Converts an ordinal into the corresponding pre-game. -/
 noncomputable def toPGame (o : Ordinal.{u}) : PGame.{u} :=
@@ -155,6 +156,8 @@ noncomputable def toPGameEmbedding : Ordinal.{u} ↪o PGame.{u} where
   toFun := Ordinal.toPGame
   inj' := toPGame_injective
   map_rel_iff' := @toPGame_le_iff
+
+/-! ### `Ordinal` to `Game` -/
 
 /-- Converts an ordinal into the corresponding game. -/
 noncomputable def toGame : Ordinal.{u} ↪o Game.{u} where

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import Mathlib.SetTheory.Game.Basic
+import CombinatorialGames.Game.Basic
 import Mathlib.SetTheory.Ordinal.NaturalOps
 
 /-!

--- a/CombinatorialGames/Game/PGame.lean
+++ b/CombinatorialGames/Game/PGame.lean
@@ -26,7 +26,7 @@ We may denote a game as $\{L | R\}$, where $L$ and $R$ stand for the collections
 moves. This notation is not currently used in Mathlib.
 
 Combinatorial games themselves, as a quotient of pregames, are constructed in
-`Mathlib.SetTheory.Game.Basic`.
+`CombinatorialGames.Game.Basic`.
 
 ## Conway induction
 

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -30,7 +30,7 @@ Surreal numbers inherit the relations `≤` and `<` from games (`Surreal.instLE`
 
 In this file, we show that the surreals form a linear ordered commutative group.
 
-In `Mathlib.SetTheory.Surreal.Multiplication`, we define multiplication and show that the
+In `CombinatorialGames.Surreal.Multiplication`, we define multiplication and show that the
 surreals form a linear ordered commutative ring.
 
 One can also map all the ordinals into the surreals!

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kim Morrison
 -/
 import Mathlib.Algebra.Order.Hom.Monoid
-import CombinatorialGames.Game.Ordinal
+import Mathlib.SetTheory.Game.Basic
 
 /-!
 # Surreal numbers
@@ -24,7 +24,7 @@ besides!) but we do not yet have a complete development.
 ## Order properties
 
 Surreal numbers inherit the relations `≤` and `<` from games (`Surreal.instLE` and
-`Surreal.instLT`), and these relations satisfy the axioms of a partial order.
+`Surreal.instLT`), and these relations satisfy the axioms of a linear order.
 
 ## Algebraic operations
 
@@ -249,12 +249,6 @@ theorem numeric_nat : ∀ n : ℕ, Numeric n
   | 0 => numeric_zero
   | n + 1 => (numeric_nat n).add numeric_one
 
-/-- Ordinal games are numeric. -/
-theorem numeric_toPGame (o : Ordinal) : o.toPGame.Numeric := by
-  induction' o using Ordinal.induction with o IH
-  apply numeric_of_isEmpty_rightMoves
-  simpa using fun i => IH _ (Ordinal.toLeftMovesToPGame_symm_lt i)
-
 end PGame
 
 end SetTheory
@@ -435,13 +429,3 @@ lemma bddBelow_of_small (s : Set Surreal.{u}) [Small.{u} s] : BddBelow s := by
 end Surreal
 
 open Surreal
-
-namespace Ordinal
-
-/-- Converts an ordinal into the corresponding surreal. -/
-noncomputable def toSurreal : Ordinal ↪o Surreal where
-  toFun o := mk _ (numeric_toPGame o)
-  inj' a b h := toPGame_equiv_iff.1 (by apply Quotient.exact h) -- Porting note: Added `by apply`
-  map_rel_iff' := @toPGame_le_iff
-
-end Ordinal

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kim Morrison
 -/
 import Mathlib.Algebra.Order.Hom.Monoid
-import Mathlib.SetTheory.Game.Basic
+import CombinatorialGames.Game.Basic
 
 /-!
 # Surreal numbers

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -3,8 +3,8 @@ Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import Mathlib.SetTheory.Game.Ordinal
-import Mathlib.SetTheory.Surreal.Basic
+import CombinatorialGames.Game.Ordinal
+import CombinatorialGames.Surreal.Basic
 
 /-!
 # Surreals as games

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2022 Violeta Hernández Palacios. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Violeta Hernández Palacios
+-/
+import Mathlib.SetTheory.Game.Ordinal
+import Mathlib.SetTheory.Surreal.Basic
+
+/-!
+# Surreals as games
+
+We define the canonical map `Ordinal → Surreal` in terms of the map `Ordinal.toPGame`.
+
+# Main declarations
+
+- `Ordinal.toSurreal`: The canonical map between ordinals and surreal numbers.
+-/
+
+open Surreal SetTheory PGame
+
+namespace Ordinal
+
+/-- Ordinal games are numeric. -/
+theorem numeric_toPGame (o : Ordinal) : o.toPGame.Numeric := by
+  induction' o using Ordinal.induction with o IH
+  apply numeric_of_isEmpty_rightMoves
+  simpa using fun i => IH _ (Ordinal.toLeftMovesToPGame_symm_lt i)
+
+/-- Converts an ordinal into the corresponding surreal. -/
+noncomputable def toSurreal : Ordinal ↪o Surreal where
+  toFun o := .mk _ o.numeric_toPGame
+  inj' _ _ h := toPGame_equiv_iff.1 (Quotient.exact h :)
+  map_rel_iff' := @toPGame_le_iff
+
+end Ordinal


### PR DESCRIPTION
Mathlib PR [#21980](https://github.com/leanprover-community/mathlib4/pull/21980).