### PR TITLE
feat: basic API for `Surreal.toOrdinal`

### DIFF
--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -273,6 +273,7 @@ instance : Inhabited Surreal :=
   ⟨0⟩
 
 lemma mk_eq_mk {x y : PGame.{u}} {hx hy} : mk x hx = mk y hy ↔ x ≈ y := Quotient.eq
+alias ⟨_, mk_eq⟩ := mk_eq_mk
 
 lemma mk_eq_zero {x : PGame.{u}} {hx} : mk x hx = 0 ↔ x ≈ 0 := Quotient.eq
 

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -16,7 +16,7 @@ We define the canonical map `Ordinal → Surreal` in terms of the map `Ordinal.t
 - `Ordinal.toSurreal`: The canonical map between ordinals and surreal numbers.
 -/
 
-open Surreal SetTheory PGame
+open Surreal PGame
 
 namespace Ordinal
 

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -48,14 +48,9 @@ theorem toSurreal_one : toSurreal 1 = 1 :=
 theorem toSurreal_injective : Function.Injective toSurreal :=
   toSurreal.injective
 
-theorem toSurreal_le_iff {a b : Ordinal} : a.toSurreal ≤ b.toSurreal ↔ a ≤ b :=
-  toPGame_le_iff
-
-theorem toSurreal_lt_iff {a b : Ordinal} : a.toSurreal < b.toSurreal ↔ a < b :=
-  toPGame_lt_iff
-
-theorem toSurreal_inj {a b : Ordinal} : a.toSurreal = b.toSurreal ↔ a = b :=
-  toSurreal.inj
+theorem toSurreal_le_iff {a b : Ordinal} : a.toSurreal ≤ b.toSurreal ↔ a ≤ b := by simp
+theorem toSurreal_lt_iff {a b : Ordinal} : a.toSurreal < b.toSurreal ↔ a < b := by simp
+theorem toSurreal_inj {a b : Ordinal} : a.toSurreal = b.toSurreal ↔ a = b := by simp
 
 theorem toSurreal_nadd (a b : Ordinal) : (a ♯ b).toSurreal = a.toSurreal + b.toSurreal :=
   mk_eq (toPGame_nadd a b)

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
 import CombinatorialGames.Game.Ordinal
-import CombinatorialGames.Surreal.Basic
+import CombinatorialGames.Surreal.Multiplication
 
 /-!
 # Surreals as games
@@ -17,6 +17,7 @@ We define the canonical map `Ordinal → Surreal` in terms of the map `Ordinal.t
 -/
 
 open PGame Surreal
+open scoped NaturalOps PGame
 
 namespace Ordinal
 

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -32,4 +32,34 @@ noncomputable def toSurreal : Ordinal ↪o Surreal where
   inj' _ _ h := toPGame_equiv_iff.1 (Quotient.exact h :)
   map_rel_iff' := @toPGame_le_iff
 
+@[simp]
+theorem _root_.Surreal.mk_toPGame (o : Ordinal) : .mk _ (numeric_toPGame o) = o.toSurreal :=
+  rfl
+
+@[simp]
+theorem toSurreal_zero : toSurreal 0 = 0 :=
+  Surreal.mk_eq toPGame_zero
+
+@[simp]
+theorem toSurreal_one : toSurreal 1 = 1 :=
+  Surreal.mk_eq toPGame_one
+
+theorem toSurreal_injective : Function.Injective toSurreal :=
+  toSurreal.injective
+
+theorem toSurreal_le_iff {a b : Ordinal} : a.toSurreal ≤ b.toSurreal ↔ a ≤ b :=
+  toPGame_le_iff
+
+theorem toSurreal_lt_iff {a b : Ordinal} : a.toSurreal < b.toSurreal ↔ a < b :=
+  toPGame_lt_iff
+
+theorem toSurreal_inj {a b : Ordinal} : a.toSurreal = b.toSurreal ↔ a = b :=
+  toSurreal.inj
+
+theorem toSurreal_nadd (a b : Ordinal) : (a ♯ b).toSurreal = a.toSurreal + b.toSurreal :=
+  mk_eq (toPGame_nadd a b)
+
+theorem toSurreal_nmul (a b : Ordinal) : (a ⨳ b).toSurreal = a.toSurreal * b.toSurreal :=
+  mk_eq (toPGame_nmul a b)
+
 end Ordinal

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -16,7 +16,7 @@ We define the canonical map `Ordinal → Surreal` in terms of the map `Ordinal.t
 - `Ordinal.toSurreal`: The canonical map between ordinals and surreal numbers.
 -/
 
-open Surreal PGame
+open PGame Surreal
 
 namespace Ordinal
 


### PR DESCRIPTION
Mathlib PR [#21979](https://github.com/leanprover-community/mathlib4/pull/21979).