### PR TITLE
chore: address most porting notes

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -802,7 +802,8 @@ def inv'Zero : inv' 0 ≡r 1 := by
   refine ⟨?_, ?_, fun i => ?_, IsEmpty.elim ?_⟩
   · apply Equiv.equivPUnit (InvTy _ _ _)
   · apply Equiv.equivPEmpty (InvTy _ _ _)
-  · simpa using Relabelling.refl _
+  · simp
+    rfl
   · dsimp
     infer_instance
 
@@ -825,7 +826,8 @@ def inv'One : inv' 1 ≡r (1 : PGame.{u}) := by
   refine ⟨?_, ?_, fun i => ?_, IsEmpty.elim ?_⟩ <;> dsimp
   · apply Equiv.equivPUnit
   · apply Equiv.equivOfIsEmpty
-  · simpa using Relabelling.refl _
+  · simp
+    rfl
   · infer_instance
 
 theorem inv'_one_equiv : inv' 1 ≈ 1 :=

--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -437,12 +437,8 @@ def negMulRelabelling (x y : PGame.{u}) : -x * y ≡r -(x * y) :=
       rintro (⟨i, j⟩ | ⟨i, j⟩) <;>
       · apply ((negAddRelabelling _ _).trans _).symm
         apply ((negAddRelabelling _ _).trans (Relabelling.addCongr _ _)).subCongr
-        -- Porting note: we used to just do `<;> exact (negMulRelabelling _ _).symm` from here.
         · exact (negMulRelabelling _ _).symm
         · exact (negMulRelabelling _ _).symm
-        -- Porting note: not sure what has gone wrong here.
-        -- The goal is hideous here, and the `exact` doesn't work,
-        -- but if we just `change` it to look like the mathlib3 goal then we're fine!?
         change -(mk xl xr xL xR * _) ≡r _
         exact (negMulRelabelling _ _).symm
   termination_by (x, y)
@@ -478,8 +474,7 @@ theorem quot_mul_neg (x y : PGame) : ⟦x * -y⟧ = (-⟦x * y⟧ : Game) :=
 theorem quot_neg_mul_neg (x y : PGame) : ⟦-x * -y⟧ = (⟦x * y⟧ : Game) := by simp
 
 @[simp]
-theorem quot_left_distrib (x y z : PGame) : (⟦x * (y + z)⟧ : Game) = ⟦x * y⟧ + ⟦x * z⟧ :=
-  match x, y, z with
+theorem quot_left_distrib : ∀ x y z : PGame, (⟦x * (y + z)⟧ : Game) = ⟦x * y⟧ + ⟦x * z⟧
   | mk xl xr xL xR, mk yl yr yL yR, mk zl zr zL zR => by
     let x := mk xl xr xL xR
     let y := mk yl yr yL yR
@@ -487,63 +482,49 @@ theorem quot_left_distrib (x y z : PGame) : (⟦x * (y + z)⟧ : Game) = ⟦x * 
     refine quot_eq_of_mk'_quot_eq ?_ ?_ ?_ ?_
     · fconstructor
       · rintro (⟨_, _ | _⟩ | ⟨_, _ | _⟩) <;>
-          solve_by_elim (config := { maxDepth := 6 }) [Sum.inl, Sum.inr, Prod.mk]
+          solve_by_elim (maxDepth := 6) [Sum.inl, Sum.inr, Prod.mk]
       · rintro (⟨⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, _⟩ | ⟨_, _⟩) <;>
-          solve_by_elim (config := { maxDepth := 6 }) [Sum.inl, Sum.inr, Prod.mk]
+          solve_by_elim (maxDepth := 6) [Sum.inl, Sum.inr, Prod.mk]
       · rintro (⟨_, _ | _⟩ | ⟨_, _ | _⟩) <;> rfl
       · rintro (⟨⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, _⟩ | ⟨_, _⟩) <;> rfl
     · fconstructor
       · rintro (⟨_, _ | _⟩ | ⟨_, _ | _⟩) <;>
-          solve_by_elim (config := { maxDepth := 6 }) [Sum.inl, Sum.inr, Prod.mk]
+          solve_by_elim (maxDepth := 6) [Sum.inl, Sum.inr, Prod.mk]
       · rintro (⟨⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, _⟩ | ⟨_, _⟩) <;>
-          solve_by_elim (config := { maxDepth := 6 }) [Sum.inl, Sum.inr, Prod.mk]
+          solve_by_elim (maxDepth := 6) [Sum.inl, Sum.inr, Prod.mk]
       · rintro (⟨_, _ | _⟩ | ⟨_, _ | _⟩) <;> rfl
       · rintro (⟨⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, _⟩ | ⟨_, _⟩) <;> rfl
-    · rintro (⟨i, j | k⟩ | ⟨i, j | k⟩)
-      · change ⟦xL i * (y + z) + x * (yL j + z) - xL i * (yL j + z)⟧ =
-          ⟦xL i * y + x * yL j - xL i * yL j + x * z⟧
-        simp only [quot_sub, quot_add]
-        repeat rw [quot_left_distrib]
-        abel
-      · change ⟦xL i * (y + z) + x * (y + zL k) - xL i * (y + zL k)⟧ =
-          ⟦x * y + (xL i * z + x * zL k - xL i * zL k)⟧
-        simp only [quot_sub, quot_add]
-        repeat rw [quot_left_distrib]
-        abel
-      · change ⟦xR i * (y + z) + x * (yR j + z) - xR i * (yR j + z)⟧ =
-          ⟦xR i * y + x * yR j - xR i * yR j + x * z⟧
-        simp only [quot_sub, quot_add]
-        repeat rw [quot_left_distrib]
-        abel
-      · change ⟦xR i * (y + z) + x * (y + zR k) - xR i * (y + zR k)⟧ =
-          ⟦x * y + (xR i * z + x * zR k - xR i * zR k)⟧
-        simp only [quot_sub, quot_add]
-        repeat rw [quot_left_distrib]
-        abel
-    · rintro (⟨i, j | k⟩ | ⟨i, j | k⟩)
-      · change ⟦xL i * (y + z) + x * (yR j + z) - xL i * (yR j + z)⟧ =
-          ⟦xL i * y + x * yR j - xL i * yR j + x * z⟧
-        simp only [quot_sub, quot_add]
-        repeat rw [quot_left_distrib]
-        abel
-      · change ⟦xL i * (y + z) + x * (y + zR k) - xL i * (y + zR k)⟧ =
-          ⟦x * y + (xL i * z + x * zR k - xL i * zR k)⟧
-        simp only [quot_sub, quot_add]
-        repeat rw [quot_left_distrib]
-        abel
-      · change ⟦xR i * (y + z) + x * (yL j + z) - xR i * (yL j + z)⟧ =
-          ⟦xR i * y + x * yL j - xR i * yL j + x * z⟧
-        simp only [quot_sub, quot_add]
-        repeat rw [quot_left_distrib]
-        abel
-      · change ⟦xR i * (y + z) + x * (y + zL k) - xR i * (y + zL k)⟧ =
-          ⟦x * y + (xR i * z + x * zL k - xR i * zL k)⟧
-        simp only [quot_sub, quot_add]
-        repeat rw [quot_left_distrib]
-        abel
-termination_by (x, y, z)
+    all_goals rintro (⟨i, j | k⟩ | ⟨i, j | k⟩)
+    on_goal 1 =>
+      change ⟦xL i * (y + z) + x * (yL j + z) - xL i * (yL j + z)⟧ =
+        ⟦xL i * y + x * yL j - xL i * yL j + x * z⟧
+    on_goal 2 =>
+      change ⟦xL i * (y + z) + x * (y + zL k) - xL i * (y + zL k)⟧ =
+        ⟦x * y + (xL i * z + x * zL k - xL i * zL k)⟧
+    on_goal 3 =>
+      change ⟦xR i * (y + z) + x * (yR j + z) - xR i * (yR j + z)⟧ =
+        ⟦xR i * y + x * yR j - xR i * yR j + x * z⟧
+    on_goal 4 =>
+      change ⟦xR i * (y + z) + x * (y + zR k) - xR i * (y + zR k)⟧ =
+        ⟦x * y + (xR i * z + x * zR k - xR i * zR k)⟧
+    on_goal 5 =>
+      change ⟦xL i * (y + z) + x * (yR j + z) - xL i * (yR j + z)⟧ =
+        ⟦xL i * y + x * yR j - xL i * yR j + x * z⟧
+    on_goal 6 =>
+      change ⟦xL i * (y + z) + x * (y + zR k) - xL i * (y + zR k)⟧ =
+        ⟦x * y + (xL i * z + x * zR k - xL i * zR k)⟧
+    on_goal 7 =>
+      change ⟦xR i * (y + z) + x * (yL j + z) - xR i * (yL j + z)⟧ =
+        ⟦xR i * y + x * yL j - xR i * yL j + x * z⟧
+    on_goal 8 =>
+      change ⟦xR i * (y + z) + x * (y + zL k) - xR i * (y + zL k)⟧ =
+        ⟦x * y + (xR i * z + x * zL k - xR i * zL k)⟧
+    all_goals
+      simp only [quot_sub, quot_add]
+      repeat rw [quot_left_distrib]
+      abel
+termination_by x y z => (x, y, z)
 
-#exit
 /-- `x * (y + z)` is equivalent to `x * y + x * z`. -/
 theorem left_distrib_equiv (x y z : PGame) : x * (y + z) ≈ x * y + x * z :=
   Quotient.exact <| quot_left_distrib _ _ _
@@ -569,19 +550,15 @@ theorem quot_right_distrib_sub (x y z : PGame) : (⟦(y - z) * x⟧ : Game) = �
 /-- `x * 1` has the same moves as `x`. -/
 def mulOneRelabelling : ∀ x : PGame.{u}, x * 1 ≡r x
   | ⟨xl, xr, xL, xR⟩ => by
-    -- Porting note: the next four lines were just `unfold has_one.one,`
-    show _ * One.one ≡r _
-    unfold One.one
-    unfold instOnePGame
     change mk _ _ _ _ * mk _ _ _ _ ≡r _
     refine ⟨(Equiv.sumEmpty _ _).trans (Equiv.prodPUnit _),
       (Equiv.emptySum _ _).trans (Equiv.prodPUnit _), ?_, ?_⟩ <;>
-    (try rintro (⟨i, ⟨⟩⟩ | ⟨i, ⟨⟩⟩)) <;>
-    { dsimp
+    · rintro (⟨i, ⟨⟩⟩ | ⟨i, ⟨⟩⟩)
+      dsimp
       apply (Relabelling.subCongr (Relabelling.refl _) (mulZeroRelabelling _)).trans
       rw [sub_zero_eq_add_zero]
       exact (addZeroRelabelling _).trans <|
-        (((mulOneRelabelling _).addCongr (mulZeroRelabelling _)).trans <| addZeroRelabelling _) }
+        (((mulOneRelabelling _).addCongr (mulZeroRelabelling _)).trans <| addZeroRelabelling _)
 
 /-- `1 * x` has the same moves as `x`. -/
 protected lemma one_mul : ∀ (x : PGame), 1 * x ≡ x
@@ -615,8 +592,7 @@ theorem quot_one_mul (x : PGame) : (⟦1 * x⟧ : Game) = ⟦x⟧ :=
 theorem one_mul_equiv (x : PGame) : 1 * x ≈ x :=
   Quotient.exact <| quot_one_mul x
 
-theorem quot_mul_assoc (x y z : PGame) : (⟦x * y * z⟧ : Game) = ⟦x * (y * z)⟧ :=
-  match x, y, z with
+theorem quot_mul_assoc : ∀ x y z : PGame, (⟦x * y * z⟧ : Game) = ⟦x * (y * z)⟧
   | mk xl xr xL xR, mk yl yr yL yR, mk zl zr zL zR => by
     let x := mk xl xr xL xR
     let y := mk yl yr yL yR
@@ -624,141 +600,73 @@ theorem quot_mul_assoc (x y z : PGame) : (⟦x * y * z⟧ : Game) = ⟦x * (y * 
     refine quot_eq_of_mk'_quot_eq ?_ ?_ ?_ ?_
     · fconstructor
       · rintro (⟨⟨_, _⟩ | ⟨_, _⟩, _⟩ | ⟨⟨_, _⟩ | ⟨_, _⟩, _⟩) <;>
-          solve_by_elim (config := { maxDepth := 8 }) [Sum.inl, Sum.inr, Prod.mk]
+          solve_by_elim (maxDepth := 8) [Sum.inl, Sum.inr, Prod.mk]
       · rintro (⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩) <;>
-          solve_by_elim (config := { maxDepth := 8 }) [Sum.inl, Sum.inr, Prod.mk]
+          solve_by_elim (maxDepth := 8) [Sum.inl, Sum.inr, Prod.mk]
       · rintro (⟨⟨_, _⟩ | ⟨_, _⟩, _⟩ | ⟨⟨_, _⟩ | ⟨_, _⟩, _⟩) <;> rfl
       · rintro (⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩) <;> rfl
     · fconstructor
       · rintro (⟨⟨_, _⟩ | ⟨_, _⟩, _⟩ | ⟨⟨_, _⟩ | ⟨_, _⟩, _⟩) <;>
-          solve_by_elim (config := { maxDepth := 8 }) [Sum.inl, Sum.inr, Prod.mk]
+          solve_by_elim (maxDepth := 8) [Sum.inl, Sum.inr, Prod.mk]
       · rintro (⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩) <;>
-          solve_by_elim (config := { maxDepth := 8 }) [Sum.inl, Sum.inr, Prod.mk]
+          solve_by_elim (maxDepth := 8) [Sum.inl, Sum.inr, Prod.mk]
       · rintro (⟨⟨_, _⟩ | ⟨_, _⟩, _⟩ | ⟨⟨_, _⟩ | ⟨_, _⟩, _⟩) <;> rfl
       · rintro (⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩ | ⟨_, ⟨_, _⟩ | ⟨_, _⟩⟩) <;> rfl
-    · rintro (⟨⟨i, j⟩ | ⟨i, j⟩, k⟩ | ⟨⟨i, j⟩ | ⟨i, j⟩, k⟩)
-      · change
-          ⟦(xL i * y + x * yL j - xL i * yL j) * z + x * y * zL k -
-                (xL i * y + x * yL j - xL i * yL j) * zL k⟧ =
-            ⟦xL i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k) -
-                xL i * (yL j * z + y * zL k - yL j * zL k)⟧
-        simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
-                   quot_left_distrib_sub, quot_left_distrib]
-        rw [quot_mul_assoc (xL i) (mk yl yr yL yR) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yL j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (xL i) (yL j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (mk yl yr yL yR) (zL k)]
-        rw [quot_mul_assoc (xL i) (mk yl yr yL yR) (zL k)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yL j) (zL k)]
-        rw [quot_mul_assoc (xL i) (yL j) (zL k)]
-        abel
-      · change
-          ⟦(xR i * y + x * yR j - xR i * yR j) * z + x * y * zL k -
-                (xR i * y + x * yR j - xR i * yR j) * zL k⟧ =
-            ⟦xR i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k) -
-                xR i * (yR j * z + y * zL k - yR j * zL k)⟧
-        simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
-                   quot_left_distrib_sub, quot_left_distrib]
-        rw [quot_mul_assoc (xR i) (mk yl yr yL yR) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yR j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (xR i) (yR j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (mk yl yr yL yR) (zL k)]
-        rw [quot_mul_assoc (xR i) (mk yl yr yL yR) (zL k)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yR j) (zL k)]
-        rw [quot_mul_assoc (xR i) (yR j) (zL k)]
-        abel
-      · change
-          ⟦(xL i * y + x * yR j - xL i * yR j) * z + x * y * zR k -
-                (xL i * y + x * yR j - xL i * yR j) * zR k⟧ =
-            ⟦xL i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k) -
-                xL i * (yR j * z + y * zR k - yR j * zR k)⟧
-        simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
-                   quot_left_distrib_sub, quot_left_distrib]
-        rw [quot_mul_assoc (xL i) (mk yl yr yL yR) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yR j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (xL i) (yR j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (mk yl yr yL yR) (zR k)]
-        rw [quot_mul_assoc (xL i) (mk yl yr yL yR) (zR k)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yR j) (zR k)]
-        rw [quot_mul_assoc (xL i) (yR j) (zR k)]
-        abel
-      · change
-          ⟦(xR i * y + x * yL j - xR i * yL j) * z + x * y * zR k -
-                (xR i * y + x * yL j - xR i * yL j) * zR k⟧ =
-            ⟦xR i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k) -
-                xR i * (yL j * z + y * zR k - yL j * zR k)⟧
-        simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
-                   quot_left_distrib_sub, quot_left_distrib]
-        rw [quot_mul_assoc (xR i) (mk yl yr yL yR) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yL j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (xR i) (yL j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (mk yl yr yL yR) (zR k)]
-        rw [quot_mul_assoc (xR i) (mk yl yr yL yR) (zR k)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yL j) (zR k)]
-        rw [quot_mul_assoc (xR i) (yL j) (zR k)]
-        abel
-    · rintro (⟨⟨i, j⟩ | ⟨i, j⟩, k⟩ | ⟨⟨i, j⟩ | ⟨i, j⟩, k⟩)
-      · change
-          ⟦(xL i * y + x * yL j - xL i * yL j) * z + x * y * zR k -
-                (xL i * y + x * yL j - xL i * yL j) * zR k⟧ =
-            ⟦xL i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k) -
-                xL i * (yL j * z + y * zR k - yL j * zR k)⟧
-        simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
-                   quot_left_distrib_sub, quot_left_distrib]
-        rw [quot_mul_assoc (xL i) (mk yl yr yL yR) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yL j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (xL i) (yL j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (mk yl yr yL yR) (zR k)]
-        rw [quot_mul_assoc (xL i) (mk yl yr yL yR) (zR k)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yL j) (zR k)]
-        rw [quot_mul_assoc (xL i) (yL j) (zR k)]
-        abel
-      · change
-          ⟦(xR i * y + x * yR j - xR i * yR j) * z + x * y * zR k -
-                (xR i * y + x * yR j - xR i * yR j) * zR k⟧ =
-            ⟦xR i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k) -
-                xR i * (yR j * z + y * zR k - yR j * zR k)⟧
-        simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
-                   quot_left_distrib_sub, quot_left_distrib]
-        rw [quot_mul_assoc (xR i) (mk yl yr yL yR) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yR j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (xR i) (yR j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (mk yl yr yL yR) (zR k)]
-        rw [quot_mul_assoc (xR i) (mk yl yr yL yR) (zR k)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yR j) (zR k)]
-        rw [quot_mul_assoc (xR i) (yR j) (zR k)]
-        abel
-      · change
-          ⟦(xL i * y + x * yR j - xL i * yR j) * z + x * y * zL k -
-                (xL i * y + x * yR j - xL i * yR j) * zL k⟧ =
-            ⟦xL i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k) -
-                xL i * (yR j * z + y * zL k - yR j * zL k)⟧
-        simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
-                   quot_left_distrib_sub, quot_left_distrib]
-        rw [quot_mul_assoc (xL i) (mk yl yr yL yR) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yR j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (xL i) (yR j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (mk yl yr yL yR) (zL k)]
-        rw [quot_mul_assoc (xL i) (mk yl yr yL yR) (zL k)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yR j) (zL k)]
-        rw [quot_mul_assoc (xL i) (yR j) (zL k)]
-        abel
-      · change
-          ⟦(xR i * y + x * yL j - xR i * yL j) * z + x * y * zL k -
-                (xR i * y + x * yL j - xR i * yL j) * zL k⟧ =
-            ⟦xR i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k) -
-                xR i * (yL j * z + y * zL k - yL j * zL k)⟧
-        simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
-                   quot_left_distrib_sub, quot_left_distrib]
-        rw [quot_mul_assoc (xR i) (mk yl yr yL yR) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yL j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (xR i) (yL j) (mk zl zr zL zR)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (mk yl yr yL yR) (zL k)]
-        rw [quot_mul_assoc (xR i) (mk yl yr yL yR) (zL k)]
-        rw [quot_mul_assoc (mk xl xr xL xR) (yL j) (zL k)]
-        rw [quot_mul_assoc (xR i) (yL j) (zL k)]
-        abel
-  termination_by (x, y, z)
+    all_goals rintro (⟨⟨i, j⟩ | ⟨i, j⟩, k⟩ | ⟨⟨i, j⟩ | ⟨i, j⟩, k⟩)
+    on_goal 1 =>
+      change
+        ⟦(xL i * y + x * yL j - xL i * yL j) * z + x * y * zL k -
+          (xL i * y + x * yL j - xL i * yL j) * zL k⟧ =
+        ⟦xL i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k) -
+          xL i * (yL j * z + y * zL k - yL j * zL k)⟧
+    on_goal 2 =>
+      change
+        ⟦(xR i * y + x * yR j - xR i * yR j) * z + x * y * zL k -
+          (xR i * y + x * yR j - xR i * yR j) * zL k⟧ =
+        ⟦xR i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k) -
+          xR i * (yR j * z + y * zL k - yR j * zL k)⟧
+    on_goal 3 =>
+      change
+        ⟦(xL i * y + x * yR j - xL i * yR j) * z + x * y * zR k -
+          (xL i * y + x * yR j - xL i * yR j) * zR k⟧ =
+        ⟦xL i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k) -
+          xL i * (yR j * z + y * zR k - yR j * zR k)⟧
+    on_goal 4 =>
+      change
+        ⟦(xR i * y + x * yL j - xR i * yL j) * z + x * y * zR k -
+          (xR i * y + x * yL j - xR i * yL j) * zR k⟧ =
+        ⟦xR i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k) -
+          xR i * (yL j * z + y * zR k - yL j * zR k)⟧
+    on_goal 5 =>
+      change
+        ⟦(xL i * y + x * yL j - xL i * yL j) * z + x * y * zR k -
+          (xL i * y + x * yL j - xL i * yL j) * zR k⟧ =
+        ⟦xL i * (y * z) + x * (yL j * z + y * zR k - yL j * zR k) -
+          xL i * (yL j * z + y * zR k - yL j * zR k)⟧
+    on_goal 6 =>
+      change
+        ⟦(xR i * y + x * yR j - xR i * yR j) * z + x * y * zR k -
+          (xR i * y + x * yR j - xR i * yR j) * zR k⟧ =
+        ⟦xR i * (y * z) + x * (yR j * z + y * zR k - yR j * zR k) -
+          xR i * (yR j * z + y * zR k - yR j * zR k)⟧
+    on_goal 7 =>
+      change
+        ⟦(xL i * y + x * yR j - xL i * yR j) * z + x * y * zL k -
+          (xL i * y + x * yR j - xL i * yR j) * zL k⟧ =
+        ⟦xL i * (y * z) + x * (yR j * z + y * zL k - yR j * zL k) -
+          xL i * (yR j * z + y * zL k - yR j * zL k)⟧
+    on_goal 8 =>
+      change
+        ⟦(xR i * y + x * yL j - xR i * yL j) * z + x * y * zL k -
+          (xR i * y + x * yL j - xR i * yL j) * zL k⟧ =
+        ⟦xR i * (y * z) + x * (yL j * z + y * zL k - yL j * zL k) -
+          xR i * (yL j * z + y * zL k - yL j * zL k)⟧
+    all_goals
+      simp only [quot_sub, quot_add, quot_right_distrib_sub, quot_right_distrib,
+        quot_left_distrib_sub, quot_left_distrib]
+      repeat rw [quot_mul_assoc]
+      abel
+termination_by x y z => (x, y, z)
 
 /-- `x * y * z` is equivalent to `x * (y * z)`. -/
 theorem mul_assoc_equiv (x y z : PGame) : x * y * z ≈ x * (y * z) :=
@@ -894,10 +802,7 @@ def inv'Zero : inv' 0 ≡r 1 := by
   refine ⟨?_, ?_, fun i => ?_, IsEmpty.elim ?_⟩
   · apply Equiv.equivPUnit (InvTy _ _ _)
   · apply Equiv.equivPEmpty (InvTy _ _ _)
-  · -- Porting note: we added `rfl` after the `simp`
-    -- (because `simp` now uses `rfl` only at reducible transparency)
-    -- Can we improve the simp set so it is not needed?
-    simp; rfl
+  · simpa using Relabelling.refl _
   · dsimp
     infer_instance
 
@@ -920,8 +825,7 @@ def inv'One : inv' 1 ≡r (1 : PGame.{u}) := by
   refine ⟨?_, ?_, fun i => ?_, IsEmpty.elim ?_⟩ <;> dsimp
   · apply Equiv.equivPUnit
   · apply Equiv.equivOfIsEmpty
-  · -- Porting note: had to add `rfl`, because `simp` only uses the built-in `rfl`.
-    simp; rfl
+  · simpa using Relabelling.refl _
   · infer_instance
 
 theorem inv'_one_equiv : inv' 1 ≈ 1 :=

--- a/CombinatorialGames/Game/Domineering.lean
+++ b/CombinatorialGames/Game/Domineering.lean
@@ -36,8 +36,6 @@ def shiftRight : ℤ × ℤ ≃ ℤ × ℤ :=
   (Equiv.addRight (1 : ℤ)).prodCongr (Equiv.refl ℤ)
 
 /-- A Domineering board is an arbitrary finite subset of `ℤ × ℤ`. -/
--- Porting note: reducibility cannot be `local`. For now there are no dependents of this file so
--- being globally reducible is fine.
 abbrev Board :=
   Finset (ℤ × ℤ)
 

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -138,9 +138,7 @@ theorem toPGame_lt_iff {a b : Ordinal} : a.toPGame < b.toPGame ↔ a < b :=
 
 @[simp]
 theorem toPGame_equiv_iff {a b : Ordinal} : (a.toPGame ≈ b.toPGame) ↔ a = b := by
-  -- Porting note: was `rw [PGame.Equiv]`
-  change _ ≤_ ∧ _ ≤ _ ↔ _
-  rw [le_antisymm_iff, toPGame_le_iff, toPGame_le_iff]
+  rw [equiv_def, AntisymmRel, le_antisymm_iff, toPGame_le_iff, toPGame_le_iff]
 
 theorem toPGame_injective : Function.Injective Ordinal.toPGame := fun _ _ h ↦
   toPGame_equiv_iff.1 (.of_eq h)

--- a/CombinatorialGames/Game/PGame.lean
+++ b/CombinatorialGames/Game/PGame.lean
@@ -650,7 +650,6 @@ theorem lf_of_le_of_lf {x y z : PGame} (h₁ : x ≤ y) (h₂ : y ⧏ z) : x ⧏
   rw [← PGame.not_le] at h₂ ⊢
   exact fun h₃ => h₂ (h₃.trans h₁)
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10754): added instance
 instance : Trans (· ≤ ·) (· ⧏ ·) (· ⧏ ·) := ⟨lf_of_le_of_lf⟩
 
 @[trans]
@@ -658,7 +657,6 @@ theorem lf_of_lf_of_le {x y z : PGame} (h₁ : x ⧏ y) (h₂ : y ≤ z) : x ⧏
   rw [← PGame.not_le] at h₁ ⊢
   exact fun h₃ => h₁ (h₂.trans h₃)
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/10754): added instance
 instance : Trans (· ⧏ ·) (· ≤ ·) (· ⧏ ·) := ⟨lf_of_lf_of_le⟩
 
 alias _root_.LE.le.trans_lf := lf_of_le_of_lf
@@ -1223,7 +1221,6 @@ theorem relabel_moveRight {x : PGame} {xl' xr'} (el : xl' ≃ x.LeftMoves) (er :
 /-- The game obtained by relabelling the next moves is a relabelling of the original game. -/
 def relabelRelabelling {x : PGame} {xl' xr'} (el : xl' ≃ x.LeftMoves) (er : xr' ≃ x.RightMoves) :
     x ≡r relabel el er :=
-  -- Porting note: needed to add `rfl`
   Relabelling.mk' el er (fun i => by simp; rfl) (fun j => by simp; rfl)
 
 /-! ### Negation -/

--- a/CombinatorialGames/Game/Short.lean
+++ b/CombinatorialGames/Game/Short.lean
@@ -73,7 +73,6 @@ decreasing_by all_goals {
 def Short.mk' {x : PGame} [Fintype x.LeftMoves] [Fintype x.RightMoves]
     (sL : ∀ i : x.LeftMoves, Short (x.moveLeft i))
     (sR : ∀ j : x.RightMoves, Short (x.moveRight j)) : Short x := by
-  -- Porting note: Old proof relied on `unfreezingI`, which doesn't exist in Lean 4.
   convert Short.mk sL sR
   cases x
   dsimp
@@ -127,7 +126,6 @@ def moveRightShort' {xl xr} (xL xR) [S : Short (mk xl xr xL xR)] (j : xr) : Shor
 attribute [local instance] moveRightShort'
 
 theorem short_birthday (x : PGame.{u}) : [Short x] → x.birthday < Ordinal.omega0 := by
-  -- Porting note: Again `induction` is used instead of `pgame_wf_tac`
   induction x with
   | mk xl xr xL xR ihl ihr =>
     intro hs

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -235,7 +235,7 @@ theorem add : ∀ {x y : PGame} (_ : Numeric x) (_ : Numeric y), Numeric (x + y)
       · rintro (jx | jy)
         · apply (ox.moveRight jx).add oy
         · apply ox.add (oy.moveRight jy)⟩
-termination_by x y => (x, y) -- Porting note: Added `termination_by`
+termination_by x y => (x, y)
 
 theorem sub {x y : PGame} (ox : Numeric x) (oy : Numeric y) : Numeric (x - y) :=
   ox.add oy.neg


### PR DESCRIPTION
We address most porting notes, remove obsolete ones, and clean up proofs along the way.

There's three remaining porting notes in the `Short` file, but those will get cleaned up anyways once we refactor the titular definition.