### PR TITLE
chore: add vscode ruler

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.rulers" : [100]
+}


### PR DESCRIPTION
artificially imposes the 100-character line limit in vscode with a visual ruler.