### PR TITLE
chore: replace `fun _ => _` by `fun _ ↦ _`

### DIFF
--- a/CombinatorialGames/Counterexamples/Multiplication.lean
+++ b/CombinatorialGames/Counterexamples/Multiplication.lean
@@ -37,7 +37,7 @@ theorem star'_equiv_star : star' ≈ star := by
       fin_cases i
       · exact zero_lf_star
       · exact (neg_lt_zero_iff.2 PGame.zero_lt_one).trans_lf zero_lf_star
-    · exact fun _ => lf_zero_le.2 ⟨⟨0, Nat.zero_lt_two⟩, le_rfl⟩
+    · exact fun _ ↦ lf_zero_le.2 ⟨⟨0, Nat.zero_lt_two⟩, le_rfl⟩
   constructor
   case' right => dsimp; rw [← neg_le_neg_iff, neg_star, neg_star']
   assumption'

--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -39,11 +39,11 @@ namespace Game
 
 /-- Negation of games. -/
 instance : Neg Game where
-  neg := Quot.map Neg.neg <| fun _ _ => (neg_equiv_neg_iff).2
+  neg := Quot.map Neg.neg fun _ _ ↦ (neg_equiv_neg_iff).2
 
 instance : Zero Game where zero := ⟦0⟧
 instance : Add Game where
-  add := Quotient.map₂ HAdd.hAdd <| fun _ _ hx _ _ hy => PGame.add_congr hx hy
+  add := Quotient.map₂ HAdd.hAdd fun _ _ hx _ _ hy ↦ PGame.add_congr hx hy
 
 instance instAddCommGroupWithOneGame : AddCommGroupWithOne Game where
   zero := ⟦0⟧
@@ -57,7 +57,7 @@ instance instAddCommGroupWithOneGame : AddCommGroupWithOne Game where
   add_assoc := by
     rintro ⟨x⟩ ⟨y⟩ ⟨z⟩
     exact Quot.sound add_assoc_equiv
-  neg_add_cancel := Quotient.ind <| fun x => Quot.sound (neg_add_cancel_equiv x)
+  neg_add_cancel := Quotient.ind fun x ↦ Quot.sound (neg_add_cancel_equiv x)
   add_comm := by
     rintro ⟨x⟩ ⟨y⟩
     exact Quot.sound add_comm_equiv
@@ -77,7 +77,7 @@ instance instPartialOrderGame : PartialOrder Game :=
 
 If `0 ⧏ x` (less or fuzzy with), then Left can win `x` as the first player. -/
 def LF : Game → Game → Prop :=
-  Quotient.lift₂ PGame.LF fun _ _ _ _ hx hy => propext (lf_congr hx hy)
+  Quotient.lift₂ PGame.LF fun _ _ _ _ hx hy ↦ propext (lf_congr hx hy)
 
 /-- On `Game`, simp-normal inequalities should use as few negations as possible. -/
 @[simp]
@@ -95,7 +95,7 @@ theorem not_lf : ∀ {x y : Game}, ¬Game.LF x y ↔ y ≤ x := by
 
 If `x ‖ 0`, then the first player can always win `x`. -/
 def Fuzzy : Game → Game → Prop :=
-  Quotient.lift₂ PGame.Fuzzy fun _ _ _ _ hx hy => propext (fuzzy_congr hx hy)
+  Quotient.lift₂ PGame.Fuzzy fun _ _ _ _ hx hy ↦ propext (fuzzy_congr hx hy)
 
 instance : IsTrichotomous Game LF :=
   ⟨by
@@ -210,8 +210,8 @@ theorem quot_natCast : ∀ n : ℕ, ⟦(n : PGame)⟧ = (n : Game)
 theorem quot_eq_of_mk'_quot_eq {x y : PGame} (L : x.LeftMoves ≃ y.LeftMoves)
     (R : x.RightMoves ≃ y.RightMoves) (hl : ∀ i, (⟦x.moveLeft i⟧ : Game) = ⟦y.moveLeft (L i)⟧)
     (hr : ∀ j, (⟦x.moveRight j⟧ : Game) = ⟦y.moveRight (R j)⟧) : (⟦x⟧ : Game) = ⟦y⟧ :=
-  game_eq (equiv_of_equiv L R (fun _ => equiv_iff_game_eq.2 (hl _))
-    (fun _ => equiv_iff_game_eq.2 (hr _)))
+  game_eq (equiv_of_equiv L R (fun _ ↦ equiv_iff_game_eq.2 (hl _))
+    (fun _ ↦ equiv_iff_game_eq.2 (hr _)))
 
 /-! Multiplicative operations can be defined at the level of pre-games,
 but to prove their properties we need to use the abelian group structure of games.
@@ -221,7 +221,7 @@ Hence we define them here. -/
 /-- The product of `x = {xL | xR}` and `y = {yL | yR}` is
 `{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, xR*y + x*yL - xR*yL}`. -/
 instance : Mul PGame.{u} :=
-  ⟨fun x y => by
+  ⟨fun x y ↦ by
     induction x generalizing y with | mk xl xr _ _ IHxl IHxr => _
     induction y with | mk yl yr yL yR IHyl IHyr => _
     have y := mk yl yr yL yR
@@ -684,11 +684,7 @@ lemma mulOption_neg_neg {x} (y) {i j} :
 
 /-- The left options of `x * y` agree with that of `y * x` up to equivalence. -/
 lemma mulOption_symm (x y) {i j} : ⟦mulOption x y i j⟧ = (⟦mulOption y x j i⟧ : Game) := by
-  dsimp only [mulOption, quot_sub, quot_add]
-  rw [add_comm]
-  congr 1
-  on_goal 1 => congr 1
-  all_goals rw [quot_mul_comm]
+  simp [mulOption, add_comm, quot_mul_comm]
 
 /-- The left options of `x * y` of the second kind are the left options of `(-x) * (-y)` of the
   first kind, up to equivalence. -/
@@ -706,11 +702,8 @@ lemma leftMoves_mul_iff {x y : PGame} (P : Game → Prop) :
     · exact h.1 i j
     convert h.2 i j using 1
   all_goals
-    dsimp only [mk_mul_moveLeft_inr, quot_sub, quot_add, neg_def, mulOption, moveLeft_mk]
-    rw [← neg_def, ← neg_def]
-    congr 1
-    on_goal 1 => congr 1
-    all_goals rw [quot_neg_mul_neg]
+    dsimp [mulOption]
+    simp [← neg_def, quot_neg_mul_neg]
 
 /-- The right options of `x * y` are the left options of `x * (-y)` and of `(-x) * y` of the first
   kind, up to equivalence. -/
@@ -785,8 +778,8 @@ definition, the sets and elements are inductively generated. -/
 def inv' : PGame → PGame
   | ⟨l, r, L, R⟩ =>
     let l' := { i // 0 < L i }
-    let L' : l' → PGame := fun i => L i.1
-    let IHl' : l' → PGame := fun i => inv' (L i.1)
+    let L' : l' → PGame := fun i ↦ L i.1
+    let IHl' : l' → PGame := fun i ↦ inv' (L i.1)
     let IHr i := inv' (R i)
     let x := mk l r L R
     ⟨InvTy l' r false, InvTy l' r true, invVal L' R IHl' IHr x, invVal L' R IHl' IHr x⟩
@@ -799,7 +792,7 @@ theorem zero_lf_inv' : ∀ x : PGame, 0 ⧏ inv' x
 /-- `inv' 0` has exactly the same moves as `1`. -/
 def inv'Zero : inv' 0 ≡r 1 := by
   change mk _ _ _ _ ≡r 1
-  refine ⟨?_, ?_, fun i => ?_, IsEmpty.elim ?_⟩
+  refine ⟨?_, ?_, fun i ↦ ?_, IsEmpty.elim ?_⟩
   · apply Equiv.equivPUnit (InvTy _ _ _)
   · apply Equiv.equivPEmpty (InvTy _ _ _)
   · simp
@@ -823,7 +816,7 @@ def inv'One : inv' 1 ≡r (1 : PGame.{u}) := by
   have : IsEmpty { _i : PUnit.{u + 1} // (0 : PGame.{u}) < 0 } := by
     rw [lt_self_iff_false]
     infer_instance
-  refine ⟨?_, ?_, fun i => ?_, IsEmpty.elim ?_⟩ <;> dsimp
+  refine ⟨?_, ?_, fun i ↦ ?_, IsEmpty.elim ?_⟩ <;> dsimp
   · apply Equiv.equivPUnit
   · apply Equiv.equivOfIsEmpty
   · simp
@@ -835,10 +828,10 @@ theorem inv'_one_equiv : inv' 1 ≈ 1 :=
 
 /-- The inverse of a pre-game in terms of the inverse on positive pre-games. -/
 noncomputable instance : Inv PGame :=
-  ⟨by classical exact fun x => if x ≈ 0 then 0 else if 0 < x then inv' x else -inv' (-x)⟩
+  ⟨by classical exact fun x ↦ if x ≈ 0 then 0 else if 0 < x then inv' x else -inv' (-x)⟩
 
 noncomputable instance : Div PGame :=
-  ⟨fun x y => x * y⁻¹⟩
+  ⟨fun x y ↦ x * y⁻¹⟩
 
 theorem inv_eq_of_equiv_zero {x : PGame} (h : x ≈ 0) : x⁻¹ = 0 := by classical exact if_pos h
 

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -43,12 +43,12 @@ birthdays of its left and right games. It may be thought as the "step" in which 
 constructed. -/
 noncomputable def birthday : PGame.{u} → Ordinal.{u}
   | ⟨_, _, xL, xR⟩ =>
-    max (lsub.{u, u} fun i => birthday (xL i)) (lsub.{u, u} fun i => birthday (xR i))
+    max (lsub.{u, u} fun i ↦ birthday (xL i)) (lsub.{u, u} fun i ↦ birthday (xR i))
 
 theorem birthday_def (x : PGame) :
     birthday x =
-      max (lsub.{u, u} fun i => birthday (x.moveLeft i))
-        (lsub.{u, u} fun i => birthday (x.moveRight i)) := by
+      max (lsub.{u, u} fun i ↦ birthday (x.moveLeft i))
+        (lsub.{u, u} fun i ↦ birthday (x.moveRight i)) := by
   cases x; rw [birthday]; rfl
 
 theorem birthday_moveLeft_lt {x : PGame} (i : x.LeftMoves) :
@@ -120,7 +120,7 @@ theorem birthday_ordinalToPGame (o : Ordinal) : o.toPGame.birthday = o := by
 theorem le_birthday : ∀ x : PGame, x ≤ x.birthday.toPGame
   | ⟨xl, _, xL, _⟩ =>
     le_def.2
-      ⟨fun i =>
+      ⟨fun i ↦
         Or.inl ⟨toLeftMovesToPGame ⟨_, birthday_moveLeft_lt i⟩, by simp [le_birthday (xL i)]⟩,
         isEmptyElim⟩
 

--- a/CombinatorialGames/Game/Impartial.lean
+++ b/CombinatorialGames/Game/Impartial.lean
@@ -37,7 +37,7 @@ class Impartial (G : PGame) : Prop where
   out : ImpartialAux G
 
 private theorem impartial_iff_aux {G : PGame} : G.Impartial ↔ G.ImpartialAux :=
-  ⟨fun h => h.1, fun h => ⟨h⟩⟩
+  ⟨fun h ↦ h.1, fun h ↦ ⟨h⟩⟩
 
 theorem impartial_def {G : PGame} :
     G.Impartial ↔ G ≈ -G ∧ (∀ i, Impartial (G.moveLeft i)) ∧ ∀ j, Impartial (G.moveRight j) := by
@@ -74,13 +74,13 @@ instance moveRight_impartial {G : PGame} [h : G.Impartial] (j : G.RightMoves) :
 theorem impartial_congr {G H : PGame} (e : G ≡r H) [G.Impartial] : H.Impartial :=
   impartial_def.2
     ⟨e.symm.equiv.trans ((neg_equiv_self G).trans (neg_equiv_neg_iff.2 e.equiv)),
-      fun i => impartial_congr (e.moveLeftSymm i), fun j => impartial_congr (e.moveRightSymm j)⟩
+      fun i ↦ impartial_congr (e.moveLeftSymm i), fun j ↦ impartial_congr (e.moveRightSymm j)⟩
 termination_by G
 
 instance impartial_add (G H : PGame) [G.Impartial] [H.Impartial] : (G + H).Impartial := by
   rw [impartial_def]
   refine ⟨(add_congr (neg_equiv_self G) (neg_equiv_self _)).trans
-      (negAddRelabelling _ _).equiv.symm, fun k => ?_, fun k => ?_⟩
+      (negAddRelabelling _ _).equiv.symm, fun k ↦ ?_, fun k ↦ ?_⟩
   · apply leftMoves_add_cases k
     all_goals
       intro i; simp only [add_moveLeft_inl, add_moveLeft_inr]
@@ -93,7 +93,7 @@ termination_by (G, H)
 
 instance impartial_neg (G : PGame) [G.Impartial] : (-G).Impartial := by
   rw [impartial_def]
-  refine ⟨?_, fun i => ?_, fun i => ?_⟩
+  refine ⟨?_, fun i ↦ ?_, fun i ↦ ?_⟩
   · rw [neg_neg]
     exact (neg_equiv_self G).symm
   · rw [moveLeft_neg]

--- a/CombinatorialGames/Game/Nim.lean
+++ b/CombinatorialGames/Game/Nim.lean
@@ -28,7 +28,6 @@ moves. We expose `toLeftMovesNim` and `toRightMovesNim` to conveniently convert 
 `o` into a left or right move of `nim o`, and vice versa.
 -/
 
-
 noncomputable section
 
 universe u
@@ -42,8 +41,8 @@ namespace PGame
   take a positive number of stones from it on their turn. -/
 noncomputable def nim (o : Ordinal.{u}) : PGame.{u} :=
   ⟨o.toType, o.toType,
-    fun x => nim ((enumIsoToType o).symm x).val,
-    fun x => nim ((enumIsoToType o).symm x).val⟩
+    fun x ↦ nim ((enumIsoToType o).symm x).val,
+    fun x ↦ nim ((enumIsoToType o).symm x).val⟩
 termination_by o
 decreasing_by all_goals exact ((enumIsoToType o).symm x).prop
 
@@ -51,10 +50,12 @@ theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by rw [nim
 theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by rw [nim]; rfl
 
 theorem moveLeft_nim_hEq (o : Ordinal) :
-    HEq (nim o).moveLeft fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
+    HEq (nim o).moveLeft fun i : o.toType ↦ nim ((enumIsoToType o).symm i) := by
+  rw [nim]; rfl
 
 theorem moveRight_nim_hEq (o : Ordinal) :
-    HEq (nim o).moveRight fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
+    HEq (nim o).moveRight fun i : o.toType ↦ nim ((enumIsoToType o).symm i) := by
+  rw [nim]; rfl
 
 /-- Turns an ordinal less than `o` into a left move for `nim o` and vice versa. -/
 noncomputable def toLeftMovesNim {o : Ordinal} : Set.Iio o ≃ (nim o).LeftMoves :=
@@ -150,7 +151,7 @@ theorem nim_one_moveRight (x) : (nim 1).moveRight x = nim 0 := by simp
 /-- `nim 1` has exactly the same moves as `star`. -/
 def nimOneRelabelling : nim 1 ≡r star := by
   rw [nim]
-  refine ⟨?_, ?_, fun i => ?_, fun j => ?_⟩
+  refine ⟨?_, ?_, fun i ↦ ?_, fun j ↦ ?_⟩
   any_goals dsimp; apply Equiv.ofUnique
   all_goals simpa [enumIsoToType] using nimZeroRelabelling
 
@@ -174,7 +175,7 @@ theorem neg_nim (o : Ordinal) : -nim o = nim o := by
 instance impartial_nim (o : Ordinal) : Impartial (nim o) := by
   induction' o using Ordinal.induction with o IH
   rw [impartial_def, neg_nim]
-  refine ⟨.rfl, fun i => ?_, fun i => ?_⟩ <;> simpa using IH _ (typein_lt_self _)
+  refine ⟨.rfl, fun i ↦ ?_, fun i ↦ ?_⟩ <;> simpa using IH _ (typein_lt_self _)
 
 theorem nim_fuzzy_zero_of_ne_zero {o : Ordinal} (ho : o ≠ 0) : nim o ‖ 0 := by
   rw [Impartial.fuzzy_zero_iff_exists_leftMoves_equiv]
@@ -211,7 +212,7 @@ This function takes a value in `Nimber`. This is a type synonym for the ordinals
 ordering, but addition in `Nimber` is such that it corresponds to the grundy value of the addition
 of games. See that file for more information on nimbers and their arithmetic. -/
 noncomputable def grundyValue (G : PGame.{u}) : Nimber.{u} :=
-  sInf (Set.range fun i => grundyValue (G.moveLeft i))ᶜ
+  sInf (Set.range fun i ↦ grundyValue (G.moveLeft i))ᶜ
 termination_by G
 
 theorem grundyValue_eq_sInf_moveLeft (G : PGame) :
@@ -222,7 +223,7 @@ theorem grundyValue_ne_moveLeft {G : PGame} (i : G.LeftMoves) :
     grundyValue (G.moveLeft i) ≠ grundyValue G := by
   conv_rhs => rw [grundyValue_eq_sInf_moveLeft]
   have := csInf_mem (nonempty_of_not_bddAbove <|
-    Nimber.not_bddAbove_compl_of_small (Set.range fun i => grundyValue (G.moveLeft i)))
+    Nimber.not_bddAbove_compl_of_small (Set.range fun i ↦ grundyValue (G.moveLeft i)))
   rw [Set.mem_compl_iff, Set.mem_range, not_exists] at this
   exact this _
 

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -33,7 +33,7 @@ namespace Ordinal
 
 /-- Converts an ordinal into the corresponding pre-game. -/
 noncomputable def toPGame (o : Ordinal.{u}) : PGame.{u} :=
-  ⟨o.toType, PEmpty, fun x => ((enumIsoToType o).symm x).val.toPGame, PEmpty.elim⟩
+  ⟨o.toType, PEmpty, fun x ↦ ((enumIsoToType o).symm x).val.toPGame, PEmpty.elim⟩
 termination_by o
 decreasing_by exact ((enumIsoToType o).symm x).prop
 
@@ -63,7 +63,7 @@ theorem toLeftMovesToPGame_symm_lt {o : Ordinal} (i : o.toPGame.LeftMoves) :
 
 @[nolint unusedHavesSuffices]
 theorem toPGame_moveLeft_hEq {o : Ordinal} :
-    HEq o.toPGame.moveLeft fun x : o.toType => ((enumIsoToType o).symm x).val.toPGame := by
+    HEq o.toPGame.moveLeft fun x : o.toType ↦ ((enumIsoToType o).symm x).val.toPGame := by
   rw [toPGame]
   rfl
 
@@ -99,7 +99,7 @@ theorem one_toPGame_moveLeft (x) : (toPGame 1).moveLeft x = toPGame 0 := by simp
 
 /-- `1.toPGame` has the same moves as `1`. -/
 noncomputable def oneToPGameRelabelling : toPGame 1 ≡r 1 :=
-  ⟨Equiv.ofUnique _ _, Equiv.equivOfIsEmpty _ _, fun i => by
+  ⟨Equiv.ofUnique _ _, Equiv.equivOfIsEmpty _ _, fun i ↦ by
     simpa using zeroToPGameRelabelling, isEmptyElim⟩
 
 theorem toPGame_one : toPGame 1 ≈ 1 :=
@@ -109,7 +109,7 @@ theorem toPGame_lf {a b : Ordinal} (h : a < b) : a.toPGame ⧏ b.toPGame := by
   convert moveLeft_lf (toLeftMovesToPGame ⟨a, h⟩); rw [toPGame_moveLeft]
 
 theorem toPGame_le {a b : Ordinal} (h : a ≤ b) : a.toPGame ≤ b.toPGame := by
-  refine le_iff_forall_lf.2 ⟨fun i => ?_, isEmptyElim⟩
+  refine le_iff_forall_lf.2 ⟨fun i ↦ ?_, isEmptyElim⟩
   rw [toPGame_moveLeft']
   exact toPGame_lf ((toLeftMovesToPGame_symm_lt i).trans_le h)
 
@@ -129,7 +129,7 @@ theorem toPGame_le_iff {a b : Ordinal} : a.toPGame ≤ b.toPGame ↔ a ≤ b :=
 
 @[simp]
 theorem toPGame_lt_iff {a b : Ordinal} : a.toPGame < b.toPGame ↔ a < b :=
-  ⟨by contrapose; rw [not_lt]; exact fun h => not_lt_of_le (toPGame_le h), toPGame_lt⟩
+  ⟨by contrapose; rw [not_lt]; exact fun h ↦ not_lt_of_le (toPGame_le h), toPGame_lt⟩
 
 @[simp]
 theorem toPGame_equiv_iff {a b : Ordinal} : (a.toPGame ≈ b.toPGame) ↔ a = b := by
@@ -187,7 +187,7 @@ theorem toGame_inj {a b : Ordinal} : a.toGame = b.toGame ↔ a = b :=
 
 /-- The natural addition of ordinals corresponds to their sum as games. -/
 theorem toPGame_nadd (a b : Ordinal) : (a ♯ b).toPGame ≈ a.toPGame + b.toPGame := by
-  refine ⟨le_of_forall_lf (fun i => ?_) isEmptyElim, le_of_forall_lf (fun i => ?_) isEmptyElim⟩
+  refine ⟨le_of_forall_lf (fun i ↦ ?_) isEmptyElim, le_of_forall_lf (fun i ↦ ?_) isEmptyElim⟩
   · rw [toPGame_moveLeft']
     rcases lt_nadd_iff.1 (toLeftMovesToPGame_symm_lt i) with (⟨c, hc, hc'⟩ | ⟨c, hc, hc'⟩) <;>
     rw [← toPGame_le_iff, (toPGame_nadd _ _).le_congr_right] at hc' <;>
@@ -211,7 +211,7 @@ theorem toGame_nadd (a b : Ordinal) : (a ♯ b).toGame = a.toGame + b.toGame :=
 
 /-- The natural multiplication of ordinals corresponds to their product as pre-games. -/
 theorem toPGame_nmul (a b : Ordinal) : (a ⨳ b).toPGame ≈ a.toPGame * b.toPGame := by
-  refine ⟨le_of_forall_lf (fun i => ?_) isEmptyElim, le_of_forall_lf (fun i => ?_) isEmptyElim⟩
+  refine ⟨le_of_forall_lf (fun i ↦ ?_) isEmptyElim, le_of_forall_lf (fun i ↦ ?_) isEmptyElim⟩
   · rw [toPGame_moveLeft']
     rcases lt_nmul_iff.1 (toLeftMovesToPGame_symm_lt i) with ⟨c, hc, d, hd, h⟩
     rw [← toPGame_le_iff, le_iff_game_le, mk_toPGame, mk_toPGame, toGame_nadd _ _, toGame_nadd _ _,

--- a/CombinatorialGames/Game/Short.lean
+++ b/CombinatorialGames/Game/Short.lean
@@ -48,7 +48,7 @@ instance subsingleton_short (x : PGame) : Subsingleton (Short x) := by
 attribute [-instance] subsingleton_short in
 theorem subsingleton_short_example : ∀ x : PGame, Subsingleton (Short x)
   | mk xl xr xL xR =>
-    ⟨fun a b => by
+    ⟨fun a b ↦ by
       cases a; cases b
       congr!
       · funext x
@@ -136,7 +136,7 @@ theorem short_birthday (x : PGame.{u}) : [Short x] → x.birthday < Ordinal.omeg
       rw [← Cardinal.ord_aleph0]
       refine
         Cardinal.lsub_lt_ord_of_isRegular.{u, u} Cardinal.isRegular_aleph0
-          (Cardinal.lt_aleph0_of_finite _) fun i => ?_
+          (Cardinal.lt_aleph0_of_finite _) fun i ↦ ?_
       rw [Cardinal.ord_aleph0]
     · apply ihl
     · apply ihr
@@ -151,7 +151,7 @@ instance short0 : Short 0 :=
   Short.ofIsEmpty
 
 instance short1 : Short 1 :=
-  Short.mk (fun i => by cases i; infer_instance) fun j => by cases j
+  Short.mk (fun i ↦ by cases i; infer_instance) fun j ↦ by cases j
 
 /-- Evidence that every `PGame` in a list is `Short`. -/
 class inductive ListShort : List PGame.{u} → Type (u + 1)
@@ -185,12 +185,12 @@ def shortOfRelabelling : ∀ {x y : PGame.{u}}, Relabelling x y → Short x → 
     haveI := Fintype.ofEquiv _ R
     exact
       Short.mk'
-        (fun i => by rw [← L.right_inv i]; apply shortOfRelabelling (rL (L.symm i)) inferInstance)
-        fun j => by simpa using shortOfRelabelling (rR (R.symm j)) inferInstance
+        (fun i ↦ by rw [← L.right_inv i]; apply shortOfRelabelling (rL (L.symm i)) inferInstance)
+        fun j ↦ by simpa using shortOfRelabelling (rR (R.symm j)) inferInstance
 
 instance shortNeg : ∀ (x : PGame.{u}) [Short x], Short (-x)
   | mk xl xr xL xR, _ => by
-    exact Short.mk (fun i => shortNeg _) fun i => shortNeg _
+    exact Short.mk (fun i ↦ shortNeg _) fun i ↦ shortNeg _
 
 instance shortAdd : ∀ (x y : PGame.{u}) [Short x] [Short y], Short (x + y)
   | mk xl xr xL xR, mk yl yr yL yR, _, _ => by

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -23,7 +23,7 @@ namespace PGame
 
 /-- The pre-game `star`, which is fuzzy with zero. -/
 def star : PGame.{u} :=
-  ⟨PUnit, PUnit, fun _ => 0, fun _ => 0⟩
+  ⟨PUnit, PUnit, fun _ ↦ 0, fun _ ↦ 0⟩
 
 @[simp]
 theorem star_leftMoves : star.LeftMoves = PUnit :=
@@ -67,7 +67,7 @@ theorem neg_star : -star = star := by simp [star]
 
 /-- The pre-game `up` -/
 def up : PGame.{u} :=
-  ⟨PUnit, PUnit, fun _ => 0, fun _ => star⟩
+  ⟨PUnit, PUnit, fun _ ↦ 0, fun _ ↦ star⟩
 
 @[simp]
 theorem up_leftMoves : up.LeftMoves = PUnit :=
@@ -97,7 +97,7 @@ theorem star_fuzzy_up : star ‖ up := by
 
 /-- The pre-game `down` -/
 def down : PGame.{u} :=
-  ⟨PUnit, PUnit, fun _ => star, fun _ => 0⟩
+  ⟨PUnit, PUnit, fun _ ↦ star, fun _ ↦ 0⟩
 
 @[simp]
 theorem down_leftMoves : down.LeftMoves = PUnit :=

--- a/CombinatorialGames/Game/State.lean
+++ b/CombinatorialGames/Game/State.lean
@@ -68,11 +68,11 @@ turns remaining.
 def ofStateAux : ∀ (n : ℕ) (s : S), turnBound s ≤ n → PGame
   | 0, s, h =>
     PGame.mk { t // t ∈ l s } { t // t ∈ r s }
-      (fun t => by exfalso; exact turnBound_ne_zero_of_left_move t.2 (nonpos_iff_eq_zero.mp h))
-      fun t => by exfalso; exact turnBound_ne_zero_of_right_move t.2 (nonpos_iff_eq_zero.mp h)
+      (fun t ↦ by exfalso; exact turnBound_ne_zero_of_left_move t.2 (nonpos_iff_eq_zero.mp h))
+      fun t ↦ by exfalso; exact turnBound_ne_zero_of_right_move t.2 (nonpos_iff_eq_zero.mp h)
   | n + 1, s, h =>
     PGame.mk { t // t ∈ l s } { t // t ∈ r s }
-      (fun t => ofStateAux n t (turnBound_of_left t.2 n h)) fun t =>
+      (fun t ↦ ofStateAux n t (turnBound_of_left t.2 n h)) fun t ↦
       ofStateAux n t (turnBound_of_right t.2 n h)
 
 /-- Two different (valid) turn bounds give equivalent games. -/
@@ -196,19 +196,19 @@ instance fintypeRightMovesOfStateAux (n : ℕ) (s : S) (h : turnBound s ≤ n) :
 instance shortOfStateAux : ∀ (n : ℕ) {s : S} (h : turnBound s ≤ n), Short (ofStateAux n s h)
   | 0, s, h =>
     Short.mk'
-      (fun i => by
+      (fun i ↦ by
         have i := (leftMovesOfStateAux _ _).toFun i
         exfalso
         exact turnBound_ne_zero_of_left_move i.2 (nonpos_iff_eq_zero.mp h))
-      fun j => by
+      fun j ↦ by
       have j := (rightMovesOfStateAux _ _).toFun j
       exfalso
       exact turnBound_ne_zero_of_right_move j.2 (nonpos_iff_eq_zero.mp h)
   | n + 1, _, h =>
     Short.mk'
-      (fun i =>
+      (fun i ↦
         shortOfRelabelling (relabellingMoveLeftAux (n + 1) h i).symm (shortOfStateAux n _))
-      fun j =>
+      fun j ↦
       shortOfRelabelling (relabellingMoveRightAux (n + 1) h j).symm (shortOfStateAux n _)
 
 instance shortOfState (s : S) : Short (ofState s) := by

--- a/CombinatorialGames/Nimber/Basic.lean
+++ b/CombinatorialGames/Nimber/Basic.lean
@@ -122,7 +122,7 @@ theorem succ_def (a : Nimber) : succ a = ∗(toOrdinal a + 1) :=
 
 /-- A recursor for `Nimber`. Use as `induction x`. -/
 @[elab_as_elim, cases_eliminator, induction_eliminator]
-protected def rec {β : Nimber → Sort*} (h : ∀ a, β (∗a)) : ∀ a, β a := fun a =>
+protected def rec {β : Nimber → Sort*} (h : ∀ a, β (∗a)) : ∀ a, β a := fun a ↦
   h (toOrdinal a)
 
 /-- `Ordinal.induction` but for `Nimber`. -/
@@ -255,16 +255,16 @@ instance : IsLeftCancelAdd Nimber := by
   intro a b c h
   apply le_antisymm <;>
   apply le_of_not_lt
-  · exact fun hc => (add_ne_of_lt a b).2 c hc h.symm
-  · exact fun hb => (add_ne_of_lt a c).2 b hb h
+  · exact fun hc ↦ (add_ne_of_lt a b).2 c hc h.symm
+  · exact fun hb ↦ (add_ne_of_lt a c).2 b hb h
 
 instance : IsRightCancelAdd Nimber := by
   constructor
   intro a b c h
   apply le_antisymm <;>
   apply le_of_not_lt
-  · exact fun hc => (add_ne_of_lt a b).1 c hc h.symm
-  · exact fun ha => (add_ne_of_lt c b).1 a ha h
+  · exact fun hc ↦ (add_ne_of_lt a b).1 c hc h.symm
+  · exact fun ha ↦ (add_ne_of_lt c b).1 a ha h
 
 protected theorem add_comm (a b : Nimber) : a + b = b + a := by
   rw [add_def, add_def]

--- a/CombinatorialGames/Nimber/Field.lean
+++ b/CombinatorialGames/Nimber/Field.lean
@@ -245,13 +245,13 @@ end
 
 theorem zero_mem_invSet (a : Nimber) : 0 ∈ invSet a := by
   rw [invSet]
-  exact Set.mem_sInter.2 fun _ hs => hs.1
+  exact Set.mem_sInter.2 fun _ hs ↦ hs.1
 
 /-- "cons" is our operation `(1 + (a + a') * b) / a'` in the definition of the inverse. -/
 theorem cons_mem_invSet {a' : Nimber} (ha₀ : a' ≠ 0) (ha : a' < a) (hb : b ∈ invSet a) :
     invAux a' * (1 + (a + a') * b) ∈ invSet a := by
   rw [invSet] at hb ⊢
-  exact Set.mem_sInter.2 fun _ hs => hs.2 _ ha ha₀ _ (Set.mem_sInter.1 hb _ hs)
+  exact Set.mem_sInter.2 fun _ hs ↦ hs.2 _ ha ha₀ _ (Set.mem_sInter.1 hb _ hs)
 
 /-- A recursion principle for `invSet`. -/
 @[elab_as_elim]
@@ -313,7 +313,7 @@ private theorem mul_inv_cancel_aux (a : Nimber) :
         add_self, mul_assoc, mul_comm b, add_assoc, add_comm _ a', ← add_assoc, ← mul_one_add,
         ← ne_eq, mul_ne_zero_iff, add_ne_zero_iff, add_ne_zero_iff]
       exact ⟨ha.ne', hb.symm⟩
-  refine ⟨H₁, fun ha₀ => le_antisymm ?_ ?_⟩
+  refine ⟨H₁, fun ha₀ ↦ le_antisymm ?_ ?_⟩
   · apply mul_le_of_forall_ne fun a' ha b hb H ↦ ?_
     replace hb := mem_invSet_of_lt_invAux hb
     rw [add_assoc, ← add_mul, ← CharTwo.eq_add_iff_add_eq] at H

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -43,9 +43,7 @@ One can also map all the ordinals into the surreals!
 
 * [Conway, *On numbers and games*][Conway2001]
 * [Schleicher, Stoll, *An introduction to Conway's games and numbers*][SchleicherStoll]
-
 -/
-
 
 universe u
 
@@ -93,11 +91,11 @@ theorem numeric_rec {C : PGame → Prop}
       C ⟨l, r, L, R⟩) :
     ∀ x, Numeric x → C x
   | ⟨_, _, _, _⟩, ⟨h, hl, hr⟩ =>
-    H _ _ _ _ h hl hr (fun i => numeric_rec H _ (hl i)) fun i => numeric_rec H _ (hr i)
+    H _ _ _ _ h hl hr (fun i ↦ numeric_rec H _ (hl i)) (fun i ↦ numeric_rec H _ (hr i))
 
 theorem Relabelling.numeric_imp {x y : PGame} (r : x ≡r y) (ox : Numeric x) : Numeric y := by
   induction' x using PGame.moveRecOn with x IHl IHr generalizing y
-  apply Numeric.mk (fun i j => ?_) (fun i => ?_) fun j => ?_
+  apply Numeric.mk (fun i j ↦ ?_) (fun i ↦ ?_) fun j ↦ ?_
   · rw [← (r.moveLeftSymm i).equiv.lt_congr (r.moveRightSymm j).equiv]
     apply ox.left_lt_right
   · exact IHl _ (r.moveLeftSymm i) (ox.moveLeft _)
@@ -108,9 +106,9 @@ theorem Relabelling.numeric_congr {x y : PGame} (r : x ≡r y) : Numeric x ↔ N
   ⟨r.numeric_imp, r.symm.numeric_imp⟩
 
 theorem lf_asymm {x y : PGame} (ox : Numeric x) (oy : Numeric y) : x ⧏ y → ¬y ⧏ x := by
-  refine numeric_rec (C := fun x => ∀ z (_oz : Numeric z), x ⧏ z → ¬z ⧏ x)
-    (fun xl xr xL xR hx _oxl _oxr IHxl IHxr => ?_) x ox y oy
-  refine numeric_rec fun yl yr yL yR hy oyl oyr _IHyl _IHyr => ?_
+  refine numeric_rec (C := fun x ↦ ∀ z (_oz : Numeric z), x ⧏ z → ¬z ⧏ x)
+    (fun xl xr xL xR hx _oxl _oxr IHxl IHxr ↦ ?_) x ox y oy
+  refine numeric_rec fun yl yr yL yR hy oyl oyr _IHyl _IHyr ↦ ?_
   rw [mk_lf_mk, mk_lf_mk]; rintro (⟨i, h₁⟩ | ⟨j, h₁⟩) (⟨i, h₂⟩ | ⟨j, h₂⟩)
   · exact IHxl _ _ (oyl _) (h₁.moveLeft_lf _) (h₂.moveLeft_lf _)
   · exact (le_trans h₂ h₁).not_gf (lf_of_lt (hy _ _))
@@ -128,13 +126,13 @@ theorem lt_of_lf {x y : PGame} (h : x ⧏ y) (ox : Numeric x) (oy : Numeric y) :
 alias LF.lt := lt_of_lf
 
 theorem lf_iff_lt {x y : PGame} (ox : Numeric x) (oy : Numeric y) : x ⧏ y ↔ x < y :=
-  ⟨fun h => h.lt ox oy, lf_of_lt⟩
+  ⟨fun h ↦ h.lt ox oy, lf_of_lt⟩
 
 /-- Definition of `x ≤ y` on numeric pre-games, in terms of `<` -/
 theorem le_iff_forall_lt {x y : PGame} (ox : x.Numeric) (oy : y.Numeric) :
     x ≤ y ↔ (∀ i, x.moveLeft i < y) ∧ ∀ j, x < y.moveRight j := by
   refine le_iff_forall_lf.trans (and_congr ?_ ?_) <;>
-      refine forall_congr' fun i => lf_iff_lt ?_ ?_ <;>
+      refine forall_congr' fun i ↦ lf_iff_lt ?_ ?_ <;>
     apply_rules [Numeric.moveLeft, Numeric.moveRight]
 
 /-- Definition of `x < y` on numeric pre-games, in terms of `≤` -/
@@ -152,16 +150,16 @@ theorem lt_def {x y : PGame} (ox : x.Numeric) (oy : y.Numeric) :
       (∃ i, (∀ i', x.moveLeft i' < y.moveLeft i) ∧ ∀ j, x < (y.moveLeft i).moveRight j) ∨
         ∃ j, (∀ i, (x.moveRight j).moveLeft i < y) ∧ ∀ j', x.moveRight j < y.moveRight j' := by
   rw [← lf_iff_lt ox oy, lf_def]
-  refine or_congr ?_ ?_ <;> refine exists_congr fun x_1 => ?_ <;> refine and_congr ?_ ?_ <;>
-      refine forall_congr' fun i => lf_iff_lt ?_ ?_ <;>
+  refine or_congr ?_ ?_ <;> refine exists_congr fun x_1 ↦ ?_ <;> refine and_congr ?_ ?_ <;>
+      refine forall_congr' fun i ↦ lf_iff_lt ?_ ?_ <;>
     apply_rules [Numeric.moveLeft, Numeric.moveRight]
 
 theorem not_fuzzy {x y : PGame} (ox : Numeric x) (oy : Numeric y) : ¬Fuzzy x y :=
-  fun h => not_lf.2 ((lf_of_fuzzy h).le ox oy) h.2
+  fun h ↦ not_lf.2 ((lf_of_fuzzy h).le ox oy) h.2
 
 theorem lt_or_equiv_or_gt {x y : PGame} (ox : Numeric x) (oy : Numeric y) :
     x < y ∨ (x ≈ y) ∨ y < x :=
-  ((lf_or_equiv_or_gf x y).imp fun h => h.lt ox oy) <| Or.imp_right fun h => h.lt oy ox
+  ((lf_or_equiv_or_gf x y).imp fun h ↦ h.lt ox oy) <| Or.imp_right fun h ↦ h.lt oy ox
 
 theorem numeric_of_isEmpty (x : PGame) [IsEmpty x.LeftMoves] [IsEmpty x.RightMoves] : Numeric x :=
   Numeric.mk isEmptyElim isEmptyElim isEmptyElim
@@ -172,17 +170,17 @@ theorem numeric_of_isEmpty_leftMoves (x : PGame) [IsEmpty x.LeftMoves] :
 
 theorem numeric_of_isEmpty_rightMoves (x : PGame) [IsEmpty x.RightMoves]
     (H : ∀ i, Numeric (x.moveLeft i)) : Numeric x :=
-  Numeric.mk (fun _ => isEmptyElim) H isEmptyElim
+  Numeric.mk (fun _ ↦ isEmptyElim) H isEmptyElim
 
 theorem numeric_zero : Numeric 0 :=
   numeric_of_isEmpty 0
 
 theorem numeric_one : Numeric 1 :=
-  numeric_of_isEmpty_rightMoves 1 fun _ => numeric_zero
+  numeric_of_isEmpty_rightMoves 1 fun _ ↦ numeric_zero
 
 theorem Numeric.neg : ∀ {x : PGame} (_ : Numeric x), Numeric (-x)
   | ⟨_, _, _, _⟩, o =>
-    ⟨fun j i => neg_lt_neg_iff.2 (o.1 i j), fun j => (o.2.2 j).neg, fun i => (o.2.1 i).neg⟩
+    ⟨fun j i ↦ neg_lt_neg_iff.2 (o.1 i j), fun j ↦ (o.2.2 j).neg, fun i ↦ (o.2.1 i).neg⟩
 
 /-- Inserting a smaller numeric left option into a numeric game results in a numeric game. -/
 theorem insertLeft_numeric {x x' : PGame} (x_num : x.Numeric) (x'_num : x'.Numeric)
@@ -279,7 +277,7 @@ lemma mk_eq_zero {x : PGame.{u}} {hx} : mk x hx = 0 ↔ x ≈ 0 := Quotient.eq
 /-- Lift an equivalence-respecting function on pre-games to surreals. -/
 def lift {α} (f : ∀ x, Numeric x → α)
     (H : ∀ {x y} (hx : Numeric x) (hy : Numeric y), x ≈ y → f x hx = f y hy) : Surreal → α :=
-  Quotient.lift (fun x : { x // Numeric x } => f x.1 x.2) fun x y => H x.2 y.2
+  Quotient.lift (fun x : { x // Numeric x } ↦ f x.1 x.2) fun x y ↦ H x.2 y.2
 
 /-- Lift a binary equivalence-respecting function on pre-games to surreals. -/
 def lift₂ {α} (f : ∀ x y, Numeric x → Numeric y → α)
@@ -287,11 +285,11 @@ def lift₂ {α} (f : ∀ x y, Numeric x → Numeric y → α)
       ∀ {x₁ y₁ x₂ y₂} (ox₁ : Numeric x₁) (oy₁ : Numeric y₁) (ox₂ : Numeric x₂) (oy₂ : Numeric y₂),
         x₁ ≈ x₂ → y₁ ≈ y₂ → f x₁ y₁ ox₁ oy₁ = f x₂ y₂ ox₂ oy₂) :
     Surreal → Surreal → α :=
-  lift (fun x ox => lift (fun y oy => f x y ox oy) fun _ _ => H _ _ _ _ .rfl)
-    fun _ _ h => funext <| Quotient.ind fun _ => H _ _ _ _ h .rfl
+  lift (fun x ox ↦ lift (fun y oy ↦ f x y ox oy) fun _ _ ↦ H _ _ _ _ .rfl)
+    fun _ _ h ↦ funext <| Quotient.ind fun _ ↦ H _ _ _ _ h .rfl
 
 instance instLE : LE Surreal :=
-  ⟨lift₂ (fun x y _ _ => x ≤ y) fun _ _ _ _ hx hy => propext (hx.le_congr hy)⟩
+  ⟨lift₂ (fun x y _ _ ↦ x ≤ y) fun _ _ _ _ hx hy ↦ propext (hx.le_congr hy)⟩
 
 @[simp]
 lemma mk_le_mk {x y : PGame.{u}} {hx hy} : mk x hx ≤ mk y hy ↔ x ≤ y := Iff.rfl
@@ -299,7 +297,7 @@ lemma mk_le_mk {x y : PGame.{u}} {hx hy} : mk x hx ≤ mk y hy ↔ x ≤ y := If
 lemma zero_le_mk {x : PGame.{u}} {hx} : 0 ≤ mk x hx ↔ 0 ≤ x := Iff.rfl
 
 instance instLT : LT Surreal :=
-  ⟨lift₂ (fun x y _ _ => x < y) fun _ _ _ _ hx hy => propext (hx.lt_congr hy)⟩
+  ⟨lift₂ (fun x y _ _ ↦ x < y) fun _ _ _ _ hx hy ↦ propext (hx.lt_congr hy)⟩
 
 lemma mk_lt_mk {x y : PGame.{u}} {hx hy} : mk x hx < mk y hy ↔ x < y := Iff.rfl
 
@@ -316,13 +314,13 @@ theorem mk_lt_mk_moveRight {x : PGame} (o : Numeric x) (j) :
 /-- Addition on surreals is inherited from pre-game addition:
 the sum of `x = {xL | xR}` and `y = {yL | yR}` is `{xL + y, x + yL | xR + y, x + yR}`. -/
 instance : Add Surreal :=
-  ⟨Surreal.lift₂ (fun (x y : PGame) ox oy => ⟦⟨x + y, ox.add oy⟩⟧) fun _ _ _ _ hx hy =>
+  ⟨Surreal.lift₂ (fun (x y : PGame) ox oy ↦ ⟦⟨x + y, ox.add oy⟩⟧) fun _ _ _ _ hx hy ↦
       Quotient.sound (add_congr hx hy)⟩
 
 /-- Negation for surreal numbers is inherited from pre-game negation:
 the negation of `{L | R}` is `{-R | -L}`. -/
 instance : Neg Surreal :=
-  ⟨Surreal.lift (fun x ox => ⟦⟨-x, ox.neg⟩⟧) fun _ _ a => Quotient.sound (neg_equiv_neg_iff.2 a)⟩
+  ⟨Surreal.lift (fun x ox ↦ ⟦⟨-x, ox.neg⟩⟧) fun _ _ a ↦ Quotient.sound (neg_equiv_neg_iff.2 a)⟩
 
 instance orderedAddCommGroup : OrderedAddCommGroup Surreal where
   add := (· + ·)
@@ -355,7 +353,7 @@ noncomputable instance : LinearOrderedAddCommGroup Surreal :=
   { Surreal.orderedAddCommGroup with
     le_total := by
       rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩
-      exact or_iff_not_imp_left.2 fun h => (PGame.not_le.1 h).le oy ox
+      exact or_iff_not_imp_left.2 fun h ↦ (PGame.not_le.1 h).le oy ox
     decidableLE := Classical.decRel _ }
 
 instance : AddMonoidWithOne Surreal :=
@@ -363,7 +361,7 @@ instance : AddMonoidWithOne Surreal :=
 
 /-- Casts a `Surreal` number into a `Game`. -/
 def toGame : Surreal →+o Game where
-  toFun := lift (fun x _ => ⟦x⟧) fun _ _ => Quot.sound
+  toFun := lift (fun x _ ↦ ⟦x⟧) fun _ _ ↦ Quot.sound
   map_zero' := rfl
   map_add' := by rintro ⟨_, _⟩ ⟨_, _⟩; rfl
   monotone' := by rintro ⟨_, _⟩ ⟨_, _⟩; exact id

--- a/CombinatorialGames/Surreal/Dyadic.lean
+++ b/CombinatorialGames/Surreal/Dyadic.lean
@@ -14,20 +14,22 @@ import Mathlib.Tactic.Linarith
 
 /-!
 # Dyadic numbers
+
 Dyadic numbers are obtained by localizing ℤ away from 2. They are the initial object in the category
 of rings with no 2-torsion.
 
 ## Dyadic surreal numbers
+
 We construct dyadic surreal numbers using the canonical map from ℤ[2 ^ {-1}] to surreals.
 As we currently do not have a ring structure on `Surreal` we construct this map explicitly. Once we
 have the ring structure, this map can be constructed directly by sending `2 ^ {-1}` to `half`.
 
 ## Embeddings
+
 The above construction gives us an abelian group embedding of ℤ into `Surreal`. The goal is to
 extend this to an embedding of dyadic rationals into `Surreal` and use Cauchy sequences of dyadic
 rational numbers to construct an ordered field embedding of ℝ into `Surreal`.
 -/
-
 
 universe u
 
@@ -39,7 +41,7 @@ namespace PGame
 `powHalf (n + 1) + powHalf (n + 1) ≈ powHalf n`. -/
 def powHalf : ℕ → PGame
   | 0 => 1
-  | n + 1 => ⟨PUnit, PUnit, 0, fun _ => powHalf n⟩
+  | n + 1 => ⟨PUnit, PUnit, 0, fun _ ↦ powHalf n⟩
 
 @[simp]
 theorem powHalf_zero : powHalf 0 = 1 :=
@@ -80,7 +82,7 @@ theorem numeric_powHalf (n) : (powHalf n).Numeric := by
   | succ n hn =>
     constructor
     · simpa using hn.moveLeft_lt default
-    · exact ⟨fun _ => numeric_zero, fun _ => hn⟩
+    · exact ⟨fun _ ↦ numeric_zero, fun _ ↦ hn⟩
 
 theorem powHalf_succ_lt_powHalf (n : ℕ) : powHalf (n + 1) < powHalf n :=
   (numeric_powHalf (n + 1)).lt_moveRight default
@@ -197,7 +199,7 @@ theorem dyadic_aux {m₁ m₂ : ℤ} {y₁ y₂ : ℕ} (h₂ : m₁ * 2 ^ y₁ =
 /-- The additive monoid morphism `dyadicMap` sends ⟦⟨m, 2^n⟩⟧ to m • half ^ n. -/
 noncomputable def dyadicMap : Localization.Away (2 : ℤ) →+ Surreal where
   toFun x :=
-    (Localization.liftOn x fun x y => x * powHalf (Submonoid.log y)) <| by
+    (Localization.liftOn x fun x y ↦ x * powHalf (Submonoid.log y)) <| by
       intro m₁ m₂ n₁ n₂ h₁
       obtain ⟨⟨n₃, y₃, hn₃⟩, h₂⟩ := Localization.r_iff_exists.mp h₁
       simp only [Subtype.coe_mk, mul_eq_mul_left_iff] at h₂

--- a/CombinatorialGames/Surreal/Multiplication.lean
+++ b/CombinatorialGames/Surreal/Multiplication.lean
@@ -244,7 +244,7 @@ lemma mulOption_lt_of_lt (hy : y.Numeric) (ihxy : IH1 x y) (ihyx : IH1 y x) (i j
 
 lemma mulOption_lt (hx : x.Numeric) (hy : y.Numeric) (ihxy : IH1 x y) (ihyx : IH1 y x) (i j k l) :
     (⟦mulOption x y i k⟧ : Game) < -⟦mulOption x (-y) j l⟧ := by
-  obtain (h|h|h) := lt_or_equiv_or_gt (hx.moveLeft i) (hx.moveLeft j)
+  obtain (h | h | h) := lt_or_equiv_or_gt (hx.moveLeft i) (hx.moveLeft j)
   · exact mulOption_lt_of_lt hy ihxy ihyx i j k l h
   · have ml := @IsOption.moveLeft
     exact mulOption_lt_iff_P1.2 (P1_of_eq h (P24_of_ih ihxy i j).1

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -24,7 +24,7 @@ namespace Ordinal
 theorem numeric_toPGame (o : Ordinal) : o.toPGame.Numeric := by
   induction' o using Ordinal.induction with o IH
   apply numeric_of_isEmpty_rightMoves
-  simpa using fun i => IH _ (Ordinal.toLeftMovesToPGame_symm_lt i)
+  simpa using fun i ↦ IH _ (Ordinal.toLeftMovesToPGame_symm_lt i)
 
 /-- Converts an ordinal into the corresponding surreal. -/
 noncomputable def toSurreal : Ordinal ↪o Surreal where


### PR DESCRIPTION
This would be seen as complete bikeshedding over at Mathlib... but since the codebase is so much smaller now I think we can afford some stylistic regularity.

Did a few other minor golfs where I was able to find them.