### PR TITLE
feat: add various recursors

### DIFF
--- a/CombinatorialGames/Counterexamples/Multiplication.lean
+++ b/CombinatorialGames/Counterexamples/Multiplication.lean
@@ -48,11 +48,11 @@ theorem star_sq : star * star ≈ star := by
     rw [le_iff_forall_lf]
     constructor <;>
     intro i
-    · apply leftMoves_mul_cases i <;>
-      intro _ _
-      case' hl => rw [mul_moveLeft_inl]
-      case' hr => rw [mul_moveLeft_inr]
-      all_goals rw [lf_iff_game_lf]; simpa using zero_lf_star
+    · induction i using leftMovesMulRecOn <;>
+      all_goals
+        simp only [mul_moveLeft_inl, mul_moveLeft_inr]
+        rw [lf_iff_game_lf]
+        simpa using zero_lf_star
     · refine lf_zero.2 ⟨toRightMovesMul (Sum.inl default), ?_⟩
       rintro (j | j) <;> -- Instance can't be inferred otherwise.
       exact isEmptyElim j

--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -337,21 +337,49 @@ theorem neg_mk_mul_moveRight_inr {xl xr yl yr} {xL xR yL yR} {i j} :
       -(xR i * mk yl yr yL yR + mk xl xr xL xR * yR j - xR i * yR j) :=
   rfl
 
-theorem leftMoves_mul_cases {x y : PGame} (k) {P : (x * y).LeftMoves → Prop}
-    (hl : ∀ ix iy, P <| toLeftMovesMul (Sum.inl ⟨ix, iy⟩))
-    (hr : ∀ jx jy, P <| toLeftMovesMul (Sum.inr ⟨jx, jy⟩)) : P k := by
-  rw [← toLeftMovesMul.apply_symm_apply k]
-  rcases toLeftMovesMul.symm k with (⟨ix, iy⟩ | ⟨jx, jy⟩)
-  · apply hl
-  · apply hr
+/-- A recursor for `(x * y).LeftMoves`. -/
+@[elab_as_elim]
+def leftMovesMulRecOn {x y : PGame} (i) {P : (x * y).LeftMoves → Sort*}
+    (inl : Π ix iy, P (toLeftMovesMul (Sum.inl (ix, iy))))
+    (inr : Π jx jy, P (toLeftMovesMul (Sum.inr (jx, jy)))) : P i :=
+  cast (by simp) <| (toLeftMovesMul.symm i).casesOn (motive := fun x ↦ P (toLeftMovesMul x))
+    (fun x ↦ inl x.1 x.2) (fun x ↦ inr x.1 x.2)
 
-theorem rightMoves_mul_cases {x y : PGame} (k) {P : (x * y).RightMoves → Prop}
-    (hl : ∀ ix jy, P <| toRightMovesMul (Sum.inl ⟨ix, jy⟩))
-    (hr : ∀ jx iy, P <| toRightMovesMul (Sum.inr ⟨jx, iy⟩)) : P k := by
-  rw [← toRightMovesMul.apply_symm_apply k]
-  rcases toRightMovesMul.symm k with (⟨ix, iy⟩ | ⟨jx, jy⟩)
-  · apply hl
-  · apply hr
+/-- A recursor for `(x * y).RightMoves`. -/
+@[elab_as_elim]
+def rightMovesMulRecOn {x y : PGame} (i) {P : (x * y).RightMoves → Sort*}
+    (inl : Π ix jy, P (toRightMovesMul (Sum.inl (ix, jy))))
+    (inr : Π jx iy, P (toRightMovesMul (Sum.inr (jx, iy)))) : P i :=
+  cast (by simp) <| (toRightMovesMul.symm i).casesOn (motive := fun x ↦ P (toRightMovesMul x))
+    (fun x ↦ inl x.1 x.2) (fun x ↦ inr x.1 x.2)
+
+@[simp]
+theorem leftMovesMulRecOn_toLeftMovesMul_inl {x y : PGame} (i j) {P : (x * y).LeftMoves → Sort*}
+    (inl : Π ix jy, P (toLeftMovesMul (Sum.inl (ix, jy))))
+    (inr : Π jx iy, P (toLeftMovesMul (Sum.inr (jx, iy)))) :
+    leftMovesMulRecOn (toLeftMovesMul (Sum.inl (i, j))) inl inr = inl i j := by
+  rw [leftMovesMulRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
+
+@[simp]
+theorem leftMovesMulRecOn_toLeftMovesMul_inr {x y : PGame} (i j) {P : (x * y).LeftMoves → Sort*}
+    (inl : Π ix jy, P (toLeftMovesMul (Sum.inl (ix, jy))))
+    (inr : Π jx iy, P (toLeftMovesMul (Sum.inr (jx, iy)))) :
+    leftMovesMulRecOn (toLeftMovesMul (Sum.inr (i, j))) inl inr = inr i j := by
+  rw [leftMovesMulRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
+
+@[simp]
+theorem rightMovesMulRecOn_toLeftMovesMul_inl {x y : PGame} (i j) {P : (x * y).RightMoves → Sort*}
+    (inl : Π ix jy, P (toRightMovesMul (Sum.inl (ix, jy))))
+    (inr : Π jx iy, P (toRightMovesMul (Sum.inr (jx, iy)))) :
+    rightMovesMulRecOn (toRightMovesMul (Sum.inl (i, j))) inl inr = inl i j := by
+  rw [rightMovesMulRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
+
+@[simp]
+theorem rightMovesMulRecOn_toLeftMovesMul_inr {x y : PGame} (i j) {P : (x * y).RightMoves → Sort*}
+    (inl : Π ix jy, P (toRightMovesMul (Sum.inl (ix, jy))))
+    (inr : Π jx iy, P (toRightMovesMul (Sum.inr (jx, iy)))) :
+    rightMovesMulRecOn (toRightMovesMul (Sum.inr (i, j))) inl inr = inr i j := by
+  rw [rightMovesMulRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
 
 /-- `x * y` and `y * x` have the same moves. -/
 protected lemma mul_comm (x y : PGame) : x * y ≡ y * x :=

--- a/CombinatorialGames/Game/Concrete.lean
+++ b/CombinatorialGames/Game/Concrete.lean
@@ -89,6 +89,16 @@ def toRightMovesPGame {a : α} : {b // b ≺ᵣ a} ≃ (toPGame a).RightMoves :=
   Equiv.cast (rightMoves_toPGame a).symm
 
 @[simp]
+theorem toLeftMovesPGame_symm_prop {a : α} (i : (toPGame a).LeftMoves) :
+    (toLeftMovesPGame.symm i).1 ≺ₗ a :=
+  (toLeftMovesPGame.symm i).prop
+
+@[simp]
+theorem toRightMovesPGame_symm_prop {a : α} (i : (toPGame a).RightMoves) :
+    (toRightMovesPGame.symm i).1 ≺ᵣ a :=
+  (toRightMovesPGame.symm i).prop
+
+@[simp]
 theorem moveLeft_toPGame {a : α} (i) :
     (toPGame a).moveLeft i = toPGame (toLeftMovesPGame.symm i).1 :=
   (congr_heq (moveLeft_toPGame_hEq a).symm (cast_heq _ i)).symm
@@ -106,15 +116,31 @@ theorem moveRight_toPGame_toRightMovesPGame {a : α} (i) :
     (toPGame a).moveRight (toRightMovesPGame i) = toPGame i.1 :=
   by simp
 
-@[simp]
-theorem toLeftMovesPGame_symm_prop {a : α} (i : (toPGame a).LeftMoves) :
-    (toLeftMovesPGame.symm i).1 ≺ₗ a :=
-  (toLeftMovesPGame.symm i).prop
+-- A recursion principle for `(toPGame a).LeftMoves`. -/
+@[elab_as_elim]
+def leftMovesPGameRecOn {a : α} {P : (toPGame a).LeftMoves → Sort*} (i)
+    (H : Π i, P (toLeftMovesPGame i)) : P i :=
+  cast (by simp) <| H (toLeftMovesPGame.symm i)
+
+-- A recursion principle for `(toPGame a).RightMoves`. -/
+@[elab_as_elim]
+def rightMovesPGameRecOn {a : α} {P : (toPGame a).RightMoves → Sort*} (i)
+    (H : Π i, P (toRightMovesPGame i)) : P i :=
+  cast (by simp) <| H (toRightMovesPGame.symm i)
 
 @[simp]
-theorem toRightMovesPGame_symm_prop {a : α} (i : (toPGame a).RightMoves) :
-    (toRightMovesPGame.symm i).1 ≺ᵣ a :=
-  (toRightMovesPGame.symm i).prop
+theorem leftMovesPGameRecOn_toLeftMovesPGame {a : α} {P : (toPGame a).LeftMoves → Sort*} (i)
+    (H : Π i, P (toLeftMovesPGame i)) : leftMovesPGameRecOn (toLeftMovesPGame i) H = H i := by
+  rw [leftMovesPGameRecOn, cast_eq_iff_heq]
+  congr
+  exact Equiv.apply_symm_apply ..
+
+@[simp]
+theorem rightMovesPGameRecOn_toRightMovesPGame {a : α} {P : (toPGame a).RightMoves → Sort*} (i)
+    (H : Π i, P (toRightMovesPGame i)) : rightMovesPGameRecOn (toRightMovesPGame i) H = H i := by
+  rw [rightMovesPGameRecOn, cast_eq_iff_heq]
+  congr
+  exact Equiv.apply_symm_apply ..
 
 theorem neg_toPGame (h : subsequentL (α := α) = subsequentR) (a : α) : -toPGame a = toPGame a := by
   rw [toPGame, neg_def]

--- a/CombinatorialGames/Game/Impartial.lean
+++ b/CombinatorialGames/Game/Impartial.lean
@@ -82,13 +82,13 @@ instance impartial_add (G H : PGame) [G.Impartial] [H.Impartial] : (G + H).Impar
   rw [impartial_def]
   refine ⟨(add_congr (neg_equiv_self G) (neg_equiv_self _)).trans
       (of_eq (G.neg_add H).symm), fun k ↦ ?_, fun k ↦ ?_⟩
-  · apply leftMoves_add_cases k
+  · induction k using leftMovesAddRecOn
     all_goals
-      intro i; simp only [add_moveLeft_inl, add_moveLeft_inr]
+      simp only [add_moveLeft_inl, add_moveLeft_inr]
       apply impartial_add
-  · apply rightMoves_add_cases k
+  · induction k using rightMovesAddRecOn
     all_goals
-      intro i; simp only [add_moveRight_inl, add_moveRight_inr]
+      simp only [add_moveRight_inl, add_moveRight_inr]
       apply impartial_add
 termination_by (G, H)
 

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -197,12 +197,12 @@ theorem toPGame_nadd (a b : Ordinal) : (a ♯ b).toPGame ≈ a.toPGame + b.toPGa
       rwa [toPGame_lf_iff]
     · apply add_lf_add_left
       rwa [toPGame_lf_iff]
-  · apply leftMoves_add_cases i <;>
-    intro i <;>
-    let wf := toLeftMovesToPGame_symm_lt i <;>
-    (try rw [add_moveLeft_inl]) <;>
-    (try rw [add_moveLeft_inr]) <;>
-    rw [toPGame_moveLeft', ← lf_congr_left (toPGame_nadd _ _), toPGame_lf_iff]
+  · induction i using leftMovesAddRecOn
+    all_goals
+      rename_i i
+      let wf := toLeftMovesToPGame_symm_lt i
+      simp only [add_moveLeft_inl, add_moveLeft_inr]
+      rw [toPGame_moveLeft', ← lf_congr_left (toPGame_nadd _ _), toPGame_lf_iff]
     · exact nadd_lt_nadd_right wf _
     · exact nadd_lt_nadd_left wf _
 termination_by (a, b)
@@ -223,8 +223,7 @@ theorem toPGame_nmul (a b : Ordinal) : (a ⨳ b).toPGame ≈ a.toPGame * b.toPGa
       quot_sub, quot_add]
     repeat rw [← game_eq (toPGame_nmul _ _)]
     rfl
-  · apply leftMoves_mul_cases i _ isEmptyElim
-    intro i j
+  · refine leftMovesMulRecOn i (fun i j ↦ ?_) isEmptyElim
     rw [mul_moveLeft_inl, toPGame_moveLeft', toPGame_moveLeft', lf_iff_game_lf,
       quot_sub, quot_add, ← Game.not_le, le_sub_iff_add_le]
     repeat rw [← game_eq (toPGame_nmul _ _)]

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -200,7 +200,7 @@ theorem toPGame_nadd (a b : Ordinal) : (a ♯ b).toPGame ≈ a.toPGame + b.toPGa
   · induction i using leftMovesAddRecOn
     all_goals
       rename_i i
-      let wf := toLeftMovesToPGame_symm_lt i
+      have wf := toLeftMovesToPGame_symm_lt i
       simp only [add_moveLeft_inl, add_moveLeft_inr]
       rw [toPGame_moveLeft', ← lf_congr_left (toPGame_nadd _ _), toPGame_lf_iff]
     · exact nadd_lt_nadd_right wf _

--- a/CombinatorialGames/Game/PGame.lean
+++ b/CombinatorialGames/Game/PGame.lean
@@ -1086,7 +1086,8 @@ theorem moveLeft_neg {x : PGame} (i) :
   rfl
 
 theorem moveLeft_neg_toLeftMovesNeg {x : PGame} (i) :
-    (-x).moveLeft (toLeftMovesNeg i) = -x.moveRight i := by simp
+    (-x).moveLeft (toLeftMovesNeg i) = -x.moveRight i := by
+  simp
 
 @[simp]
 theorem moveRight_neg {x : PGame} (i) :
@@ -1095,7 +1096,8 @@ theorem moveRight_neg {x : PGame} (i) :
   rfl
 
 theorem moveRight_neg_toRightMovesNeg {x : PGame} (i) :
-    (-x).moveRight (toRightMovesNeg i) = -x.moveLeft i := by simp
+    (-x).moveRight (toRightMovesNeg i) = -x.moveLeft i := by
+  simp
 
 @[simp]
 theorem forall_leftMoves_neg {x : PGame} {p : (-x).LeftMoves → Prop} :
@@ -1117,17 +1119,27 @@ theorem exists_rightMoves_neg {x : PGame} {p : (-x).RightMoves → Prop} :
     (∃ i : (-x).RightMoves, p i) ↔ (∃ i : x.LeftMoves, p (toRightMovesNeg i)) :=
   toRightMovesNeg.exists_congr_right.symm
 
-theorem leftMoves_neg_cases {x : PGame} (k) {P : (-x).LeftMoves → Prop}
-    (h : ∀ i, P <| toLeftMovesNeg i) :
-    P k := by
-  rw [← toLeftMovesNeg.apply_symm_apply k]
-  exact h _
+/-- A recursor for `(-x).LeftMoves`. -/
+@[elab_as_elim]
+def leftMovesNegRecOn {x : PGame} (i) {P : (-x).LeftMoves → Sort*}
+    (H : Π i, P (toLeftMovesNeg i)) : P i :=
+  cast (by simp) <| H (toLeftMovesNeg.symm i)
 
-theorem rightMoves_neg_cases {x : PGame} (k) {P : (-x).RightMoves → Prop}
-    (h : ∀ i, P <| toRightMovesNeg i) :
-    P k := by
-  rw [← toRightMovesNeg.apply_symm_apply k]
-  exact h _
+/-- A recursor for `(-x).RightMoves`. -/
+@[elab_as_elim]
+def rightMovesNegRecOn {x : PGame} (i) {P : (-x).RightMoves → Sort*}
+    (H : Π i, P (toRightMovesNeg i)) : P i :=
+  cast (by simp) <| H (toRightMovesNeg.symm i)
+
+@[simp]
+theorem leftMovesNegRecOn_toLeftMovesNeg {x : PGame} (i) {P : (-x).LeftMoves → Sort*}
+    (H : Π i, P (toLeftMovesNeg i)) : leftMovesNegRecOn (toLeftMovesNeg i) H = H i := by
+  rw [leftMovesNegRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
+
+@[simp]
+theorem rightMovesNegRecOn_toRightMovesNeg {x : PGame} (i) {P : (-x).RightMoves → Sort*}
+    (H : Π i, P (toRightMovesNeg i)) : rightMovesNegRecOn (toRightMovesNeg i) H = H i := by
+  rw [rightMovesNegRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
 
 /-- If `x` has the same moves as `y`, then `-x` has the sames moves as `-y`. -/
 lemma Identical.neg : ∀ {x₁ x₂ : PGame}, x₁ ≡ x₂ → -x₁ ≡ -x₂
@@ -1368,23 +1380,45 @@ theorem add_moveRight_inr (x : PGame) {y : PGame} (i) :
   cases y
   rfl
 
-/-- Case on possible left moves of `x + y`. -/
-theorem leftMoves_add_cases {x y : PGame} (k) {P : (x + y).LeftMoves → Prop}
-    (hl : ∀ i, P <| toLeftMovesAdd (Sum.inl i)) (hr : ∀ i, P <| toLeftMovesAdd (Sum.inr i)) :
-    P k := by
-  rw [← toLeftMovesAdd.apply_symm_apply k]
-  rcases toLeftMovesAdd.symm k with i | i
-  · exact hl i
-  · exact hr i
+/-- A recursor for `(x + y).LeftMoves`. -/
+@[elab_as_elim]
+def leftMovesAddRecOn {x y : PGame} (i) {P : (x + y).LeftMoves → Sort*}
+    (inl : Π i, P (toLeftMovesAdd (Sum.inl i))) (inr : Π i, P (toLeftMovesAdd (Sum.inr i))) :
+    P i :=
+  cast (by simp) <|
+    (toLeftMovesAdd.symm i).casesOn (motive := fun x ↦ P (toLeftMovesAdd x)) inl inr
 
-/-- Case on possible right moves of `x + y`. -/
-theorem rightMoves_add_cases {x y : PGame} (k) {P : (x + y).RightMoves → Prop}
-    (hl : ∀ j, P <| toRightMovesAdd (Sum.inl j)) (hr : ∀ j, P <| toRightMovesAdd (Sum.inr j)) :
-    P k := by
-  rw [← toRightMovesAdd.apply_symm_apply k]
-  rcases toRightMovesAdd.symm k with i | i
-  · exact hl i
-  · exact hr i
+/-- A recursor for `(x + y).RightMoves`. -/
+@[elab_as_elim]
+def rightMovesAddRecOn {x y : PGame} (i) {P : (x + y).RightMoves → Sort*}
+    (inl : Π j, P (toRightMovesAdd (Sum.inl j))) (inr : Π j, P (toRightMovesAdd (Sum.inr j))) :
+    P i :=
+  cast (by simp) <|
+    (toRightMovesAdd.symm i).casesOn (motive := fun x ↦ P (toRightMovesAdd x)) inl inr
+
+@[simp]
+theorem leftMovesAddRecOn_toLeftMovesAdd_inl {x y : PGame} (i) {P : (x + y).LeftMoves → Sort*}
+    (inl : Π j, P (toLeftMovesAdd (Sum.inl j))) (inr : Π j, P (toLeftMovesAdd (Sum.inr j))) :
+    leftMovesAddRecOn (toLeftMovesAdd (Sum.inl i)) inl inr = inl i := by
+  rw [leftMovesAddRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
+
+@[simp]
+theorem leftMovesAddRecOn_toLeftMovesAdd_inr {x y : PGame} (i) {P : (x + y).LeftMoves → Sort*}
+    (inl : Π j, P (toLeftMovesAdd (Sum.inl j))) (inr : Π j, P (toLeftMovesAdd (Sum.inr j))) :
+    leftMovesAddRecOn (toLeftMovesAdd (Sum.inr i)) inl inr = inr i := by
+  rw [leftMovesAddRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
+
+@[simp]
+theorem rightMovesAddRecOn_toRightMovesAdd_inl {x y : PGame} (i) {P : (x + y).RightMoves → Sort*}
+    (inl : Π j, P (toRightMovesAdd (Sum.inl j))) (inr : Π j, P (toRightMovesAdd (Sum.inr j))) :
+    rightMovesAddRecOn (toRightMovesAdd (Sum.inl i)) inl inr = inl i := by
+  rw [rightMovesAddRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
+
+@[simp]
+theorem rightMovesAddRecOn_toRightMovesAdd_inr {x y : PGame} (i) {P : (x + y).RightMoves → Sort*}
+    (inl : Π j, P (toRightMovesAdd (Sum.inl j))) (inr : Π j, P (toRightMovesAdd (Sum.inr j))) :
+    rightMovesAddRecOn (toRightMovesAdd (Sum.inr i)) inl inr = inr i := by
+  rw [rightMovesAddRecOn, cast_eq_iff_heq, Equiv.symm_apply_apply]
 
 instance isEmpty_nat_rightMoves : ∀ n : ℕ, IsEmpty (RightMoves n)
   | 0 => inferInstanceAs (IsEmpty PEmpty)

--- a/CombinatorialGames/Game/Specific/Nim.lean
+++ b/CombinatorialGames/Game/Specific/Nim.lean
@@ -19,7 +19,7 @@ individual grundy values.
 
 ## Implementation details
 
-The pen-and-paper definition of nim defines the possible moves of `nim o` to be `Set.Iio o`.
+The pen-and-paper definition of nim defines the possible moves of `nim o` to be `Iio o`.
 However, this definition does not work for us because it would make the type of nim
 `Ordinal.{u} → PGame.{u + 1}`, which would make it impossible for us to state the
 Sprague-Grundy theorem, since that requires the type of `nim` to be
@@ -33,7 +33,7 @@ noncomputable section
 universe u
 
 open scoped PGame
-open Ordinal Nimber
+open Nimber Ordinal Set
 
 namespace PGame
 
@@ -58,11 +58,11 @@ theorem moveRight_nim_hEq (o : Ordinal) :
   rw [nim]; rfl
 
 /-- Turns an ordinal less than `o` into a left move for `nim o` and vice versa. -/
-noncomputable def toLeftMovesNim {o : Ordinal} : Set.Iio o ≃ (nim o).LeftMoves :=
+noncomputable def toLeftMovesNim {o : Ordinal} : Iio o ≃ (nim o).LeftMoves :=
   (enumIsoToType o).toEquiv.trans (Equiv.cast (leftMoves_nim o).symm)
 
 /-- Turns an ordinal less than `o` into a right move for `nim o` and vice versa. -/
-noncomputable def toRightMovesNim {o : Ordinal} : Set.Iio o ≃ (nim o).RightMoves :=
+noncomputable def toRightMovesNim {o : Ordinal} : Iio o ≃ (nim o).RightMoves :=
   (enumIsoToType o).toEquiv.trans (Equiv.cast (rightMoves_nim o).symm)
 
 @[simp]
@@ -91,17 +91,31 @@ theorem moveRight_toRightMovesNim {o : Ordinal} (i) :
     (nim o).moveRight (toRightMovesNim i) = nim i := by
   simp
 
-/-- A recursion principle for left moves of a nim game. -/
+/-- A recursion principle for `(nim o).LeftMoves`. -/
 @[elab_as_elim]
-def leftMovesNimRecOn {o : Ordinal} {P : (nim o).LeftMoves → Sort*} (i : (nim o).LeftMoves)
-    (H : ∀ a (H : a < o), P <| toLeftMovesNim ⟨a, H⟩) : P i := by
-  rw [← toLeftMovesNim.apply_symm_apply i]; apply H
+def leftMovesNimRecOn {o : Ordinal} {P : (nim o).LeftMoves → Sort*} (i)
+    (H : Π a (H : a < o), P (toLeftMovesNim ⟨a, H⟩)) : P i :=
+  cast (by simp) <| H _ (toLeftMovesNim_symm_lt i)
 
-/-- A recursion principle for right moves of a nim game. -/
+/-- A recursion principle for `(nim o).RightMoves`. -/
 @[elab_as_elim]
-def rightMovesNimRecOn {o : Ordinal} {P : (nim o).RightMoves → Sort*} (i : (nim o).RightMoves)
-    (H : ∀ a (H : a < o), P <| toRightMovesNim ⟨a, H⟩) : P i := by
-  rw [← toRightMovesNim.apply_symm_apply i]; apply H
+def rightMovesNimRecOn {o : Ordinal} {P : (nim o).RightMoves → Sort*} (i)
+    (H : Π a (h : a < o), P (toRightMovesNim ⟨a, h⟩)) : P i :=
+  cast (by simp) <| H _ (toRightMovesNim_symm_lt i)
+
+@[simp]
+theorem leftMovesNimRecOn_toLeftMovesNim {o : Ordinal} {P : (nim o).LeftMoves → Sort*}
+    (i : Iio o) (H : Π a (h : a < o), P (toLeftMovesNim ⟨a, h⟩)) :
+    leftMovesNimRecOn (toLeftMovesNim i) H = H i.1 i.2 := by
+  rw [leftMovesNimRecOn, cast_eq_iff_heq]
+  congr <;> simp
+
+@[simp]
+theorem rightMovesNimRecOn_toRightMovesNim {o : Ordinal} {P : (nim o).RightMoves → Sort*}
+    (i : Iio o) (H : Π a (h : a < o), P (toRightMovesNim ⟨a, h⟩)) :
+    rightMovesNimRecOn (toRightMovesNim i) H = H i.1 i.2 := by
+  rw [rightMovesNimRecOn, cast_eq_iff_heq]
+  congr <;> simp
 
 instance isEmpty_nim_zero_leftMoves : IsEmpty (nim 0).LeftMoves := by
   rw [nim]
@@ -126,22 +140,22 @@ noncomputable instance uniqueNimOneRightMoves : Unique (nim 1).RightMoves :=
 
 @[simp]
 theorem default_nim_one_leftMoves_eq :
-    (default : (nim 1).LeftMoves) = @toLeftMovesNim 1 ⟨0, Set.mem_Iio.mpr zero_lt_one⟩ :=
+    (default : (nim 1).LeftMoves) = @toLeftMovesNim 1 ⟨0, mem_Iio.mpr zero_lt_one⟩ :=
   rfl
 
 @[simp]
 theorem default_nim_one_rightMoves_eq :
-    (default : (nim 1).RightMoves) = @toRightMovesNim 1 ⟨0, Set.mem_Iio.mpr zero_lt_one⟩ :=
+    (default : (nim 1).RightMoves) = @toRightMovesNim 1 ⟨0, mem_Iio.mpr zero_lt_one⟩ :=
   rfl
 
 @[simp]
 theorem toLeftMovesNim_one_symm (i) :
-    (@toLeftMovesNim 1).symm i = ⟨0, Set.mem_Iio.mpr zero_lt_one⟩ := by
+    (@toLeftMovesNim 1).symm i = ⟨0, mem_Iio.mpr zero_lt_one⟩ := by
   simp [eq_iff_true_of_subsingleton]
 
 @[simp]
 theorem toRightMovesNim_one_symm (i) :
-    (@toRightMovesNim 1).symm i = ⟨0, Set.mem_Iio.mpr zero_lt_one⟩ := by
+    (@toRightMovesNim 1).symm i = ⟨0, mem_Iio.mpr zero_lt_one⟩ := by
   simp [eq_iff_true_of_subsingleton]
 
 theorem nim_one_moveLeft (x) : (nim 1).moveLeft x = nim 0 := by simp
@@ -211,23 +225,23 @@ This function takes a value in `Nimber`. This is a type synonym for the ordinals
 ordering, but addition in `Nimber` is such that it corresponds to the grundy value of the addition
 of games. See that file for more information on nimbers and their arithmetic. -/
 noncomputable def grundyValue (G : PGame.{u}) : Nimber.{u} :=
-  sInf (Set.range fun i ↦ grundyValue (G.moveLeft i))ᶜ
+  sInf (range fun i ↦ grundyValue (G.moveLeft i))ᶜ
 termination_by G
 
 theorem grundyValue_eq_sInf_moveLeft (G : PGame) :
-    grundyValue G = sInf (Set.range (grundyValue ∘ G.moveLeft))ᶜ := by
+    grundyValue G = sInf (range (grundyValue ∘ G.moveLeft))ᶜ := by
   rw [grundyValue]; rfl
 
 theorem grundyValue_ne_moveLeft {G : PGame} (i : G.LeftMoves) :
     grundyValue (G.moveLeft i) ≠ grundyValue G := by
   conv_rhs => rw [grundyValue_eq_sInf_moveLeft]
   have := csInf_mem (nonempty_of_not_bddAbove <|
-    Nimber.not_bddAbove_compl_of_small (Set.range fun i ↦ grundyValue (G.moveLeft i)))
-  rw [Set.mem_compl_iff, Set.mem_range, not_exists] at this
+    Nimber.not_bddAbove_compl_of_small (range fun i ↦ grundyValue (G.moveLeft i)))
+  rw [mem_compl_iff, mem_range, not_exists] at this
   exact this _
 
 theorem le_grundyValue_of_Iio_subset_moveLeft {G : PGame} {o : Nimber}
-    (h : Set.Iio o ⊆ Set.range (grundyValue ∘ G.moveLeft)) : o ≤ grundyValue G := by
+    (h : Iio o ⊆ range (grundyValue ∘ G.moveLeft)) : o ≤ grundyValue G := by
   by_contra! ho
   obtain ⟨i, hi⟩ := h ho
   exact grundyValue_ne_moveLeft i hi
@@ -249,8 +263,7 @@ theorem equiv_nim_grundyValue (G : PGame.{u}) [G.Impartial] :
     G ≈ nim (toOrdinal (grundyValue G)) := by
   rw [Impartial.equiv_iff_add_equiv_zero, Impartial.equiv_zero_iff_forall_leftMoves_fuzzy]
   intro x
-  apply leftMoves_add_cases x <;>
-  intro i
+  induction x using leftMovesAddRecOn <;> rename_i i
   · rw [add_moveLeft_inl, ← fuzzy_congr_left (add_congr_left (equiv_nim_grundyValue _).symm),
       nim_add_fuzzy_zero_iff]
     exact grundyValue_ne_moveLeft i
@@ -290,7 +303,7 @@ theorem grundyValue_neg (G : PGame) [G.Impartial] : grundyValue (-G) = grundyVal
   rw [grundyValue_eq_iff_equiv_nim, neg_equiv_iff, neg_nim, ← grundyValue_eq_iff_equiv_nim]
 
 theorem grundyValue_eq_sInf_moveRight (G : PGame) [G.Impartial] :
-    grundyValue G = sInf (Set.range (grundyValue ∘ G.moveRight))ᶜ := by
+    grundyValue G = sInf (range (grundyValue ∘ G.moveRight))ᶜ := by
   obtain ⟨l, r, L, R⟩ := G
   rw [← grundyValue_neg, grundyValue_eq_sInf_moveLeft]
   iterate 3 apply congr_arg
@@ -302,7 +315,7 @@ theorem grundyValue_ne_moveRight {G : PGame} [G.Impartial] (i : G.RightMoves) :
   convert grundyValue_ne_moveLeft (toLeftMovesNeg i) using 1 <;> simp
 
 theorem le_grundyValue_of_Iio_subset_moveRight {G : PGame} [G.Impartial] {o : Nimber}
-    (h : Set.Iio o ⊆ Set.range (grundyValue ∘ G.moveRight)) : o ≤ grundyValue G := by
+    (h : Iio o ⊆ range (grundyValue ∘ G.moveRight)) : o ≤ grundyValue G := by
   by_contra! ho
   obtain ⟨i, hi⟩ := h ho
   exact grundyValue_ne_moveRight i hi
@@ -322,10 +335,9 @@ theorem grundyValue_le_of_forall_moveRight {G : PGame} [G.Impartial] {o : Nimber
 /-- The Grundy value of the sum of two nim games equals their nimber addition. -/
 theorem grundyValue_nim_add_nim (x y : Ordinal) : grundyValue (nim x + nim y) = ∗x + ∗y := by
   apply (grundyValue_le_of_forall_moveLeft _).antisymm (le_grundyValue_of_Iio_subset_moveLeft _)
-  · intro i
-    apply leftMoves_add_cases i <;> intro j <;> have := (toLeftMovesNim_symm_lt j).ne
-    · simpa [grundyValue_nim_add_nim (toLeftMovesNim.symm j) y]
-    · simpa [grundyValue_nim_add_nim x (toLeftMovesNim.symm j)]
+  · refine (leftMovesAddRecOn · ?_ ?_) <;> intro i <;> have := (toLeftMovesNim_symm_lt i).ne
+    · simpa [grundyValue_nim_add_nim (toLeftMovesNim.symm i) y]
+    · simpa [grundyValue_nim_add_nim x (toLeftMovesNim.symm i)]
   · intro k hk
     obtain h | h := Nimber.lt_add_cases hk
     · let a := toOrdinal (k + ∗y)


### PR DESCRIPTION
We previously had a few theorems for casing on moves of more complicated operations. We promote these to `Sort*`-valued recursors, and prove that they behave as they should.