### PR TITLE
doc: document type equalities

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -217,7 +217,6 @@ theorem quot_eq_of_mk'_quot_eq {x y : PGame} (L : x.LeftMoves ≃ y.LeftMoves)
 but to prove their properties we need to use the abelian group structure of games.
 Hence we define them here. -/
 
-
 /-- The product of `x = {xL | xR}` and `y = {yL | yR}` is
 `{xL*y + x*yL - xL*yL, xR*y + x*yR - xR*yR | xL*y + x*yR - xL*yR, xR*y + x*yL - xR*yL}`. -/
 instance : Mul PGame.{u} :=
@@ -231,14 +230,16 @@ instance : Mul PGame.{u} :=
     · exact IHxl i y + IHyr j - IHxl i (yR j)
     · exact IHxr i y + IHyl j - IHxr i (yL j)⟩
 
+/-- Use `toLeftMovesMul` to cast between these two types. -/
+@[simp]
 theorem leftMoves_mul :
-    ∀ x y : PGame.{u},
-      (x * y).LeftMoves = (x.LeftMoves × y.LeftMoves ⊕ x.RightMoves × y.RightMoves)
+    ∀ x y : PGame, (x * y).LeftMoves = (x.LeftMoves × y.LeftMoves ⊕ x.RightMoves × y.RightMoves)
   | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩ => rfl
 
+/-- Use `toRightMovesMul` to cast between these two types. -/
+@[simp]
 theorem rightMoves_mul :
-    ∀ x y : PGame.{u},
-      (x * y).RightMoves = (x.LeftMoves × y.RightMoves ⊕ x.RightMoves × y.LeftMoves)
+    ∀ x y : PGame, (x * y).RightMoves = (x.LeftMoves × y.RightMoves ⊕ x.RightMoves × y.LeftMoves)
   | ⟨_, _, _, _⟩, ⟨_, _, _, _⟩ => rfl
 
 /-- Turns two left or right moves for `x` and `y` into a left move for `x * y` and vice versa.

--- a/CombinatorialGames/Game/Concrete.lean
+++ b/CombinatorialGames/Game/Concrete.lean
@@ -59,10 +59,12 @@ def toPGame (a : α) : PGame :=
 termination_by isWellFounded_subsequent.wf.wrap a
 
 /-- Use `toLeftMovesPGame` to cast between these two types. -/
+@[simp]
 theorem leftMoves_toPGame (a : α) : (toPGame a).LeftMoves = {b // b ≺ₗ a} := by
   rw [toPGame]; rfl
 
 /-- Use `toRightMovesPGame` to cast between these two types. -/
+@[simp]
 theorem rightMoves_toPGame (a : α) : (toPGame a).RightMoves = {b // b ≺ᵣ a} := by
   rw [toPGame]; rfl
 

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -37,10 +37,12 @@ noncomputable def toPGame (o : Ordinal.{u}) : PGame.{u} :=
 termination_by o
 decreasing_by exact ((enumIsoToType o).symm x).prop
 
+/-- Use `toLeftMovesToPGame` to cast between these two types. -/
 @[simp]
 theorem toPGame_leftMoves (o : Ordinal) : o.toPGame.LeftMoves = o.toType := by
   rw [toPGame, LeftMoves]
 
+/-- Use `toRightMovesToPGame` to cast between these two types. -/
 @[simp]
 theorem toPGame_rightMoves (o : Ordinal) : o.toPGame.RightMoves = PEmpty := by
   rw [toPGame, RightMoves]

--- a/CombinatorialGames/Game/PGame.lean
+++ b/CombinatorialGames/Game/PGame.lean
@@ -132,21 +132,10 @@ def moveLeft : ∀ g : PGame, LeftMoves g → PGame
 def moveRight : ∀ g : PGame, RightMoves g → PGame
   | mk _ _r _ R => R
 
-@[simp]
-theorem leftMoves_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).LeftMoves = xl :=
-  rfl
-
-@[simp]
-theorem moveLeft_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).moveLeft = xL :=
-  rfl
-
-@[simp]
-theorem rightMoves_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).RightMoves = xr :=
-  rfl
-
-@[simp]
-theorem moveRight_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).moveRight = xR :=
-  rfl
+@[simp] theorem leftMoves_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).LeftMoves = xl := rfl
+@[simp] theorem moveLeft_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).moveLeft = xL := rfl
+@[simp] theorem rightMoves_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).RightMoves = xr := rfl
+@[simp] theorem moveRight_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).moveRight = xR := rfl
 
 lemma ext {x y : PGame} (hl : x.LeftMoves = y.LeftMoves) (hr : x.RightMoves = y.RightMoves)
     (hL : ∀ i j, HEq i j → x.moveLeft i = y.moveLeft j)
@@ -162,41 +151,33 @@ lemma ext {x y : PGame} (hl : x.LeftMoves = y.LeftMoves) (hr : x.RightMoves = y.
 /-- Construct a pre-game from list of pre-games describing the available moves for Left and Right.
 -/
 def ofLists (L R : List PGame.{u}) : PGame.{u} :=
-  mk (ULift (Fin L.length)) (ULift (Fin R.length)) (fun i ↦ L[i.down.1]) fun j ↦ R[j.down.1]
+  mk (ULift (Fin L.length)) (ULift (Fin R.length)) (fun i ↦ L[i.down.1]) (fun j ↦ R[j.down.1])
 
+/-- Use `toOfListsLeftMoves` to cast between these two types. -/
+@[simp]
 theorem leftMoves_ofLists (L R : List PGame) : (ofLists L R).LeftMoves = ULift (Fin L.length) :=
   rfl
 
+/-- Use `toOfListsRightMoves` to cast between these two types. -/
+@[simp]
 theorem rightMoves_ofLists (L R : List PGame) : (ofLists L R).RightMoves = ULift (Fin R.length) :=
   rfl
 
-/-- Converts a number into a left move for `ofLists`.
-
-This is just an abbreviation for `Equiv.ulift.symm` -/
-abbrev toOfListsLeftMoves {L R : List PGame} : Fin L.length ≃ (ofLists L R).LeftMoves :=
-  Equiv.ulift.symm
-
-/-- Converts a number into a right move for `ofLists`.
-
-This is just an abbreviation for `Equiv.ulift.symm` -/
-abbrev toOfListsRightMoves {L R : List PGame} : Fin R.length ≃ (ofLists L R).RightMoves :=
-  Equiv.ulift.symm
-
 @[simp]
-theorem ofLists_moveLeft' {L R : List PGame} (i : (ofLists L R).LeftMoves) :
+theorem ofLists_moveLeft {L R : List PGame} (i : (ofLists L R).LeftMoves) :
     (ofLists L R).moveLeft i = L[i.down.val] :=
   rfl
 
-theorem ofLists_moveLeft {L R : List PGame} (i : Fin L.length) :
+theorem ofLists_moveLeft_up {L R : List PGame} (i : Fin L.length) :
     (ofLists L R).moveLeft (ULift.up i) = L[i] :=
   rfl
 
 @[simp]
-theorem ofLists_moveRight' {L R : List PGame} (i : (ofLists L R).RightMoves) :
+theorem ofLists_moveRight {L R : List PGame} (i : (ofLists L R).RightMoves) :
     (ofLists L R).moveRight i = R[i.down.val] :=
   rfl
 
-theorem ofLists_moveRight {L R : List PGame} (i : Fin R.length) :
+theorem ofLists_moveRight_up {L R : List PGame} (i : Fin R.length) :
     (ofLists L R).moveRight (ULift.up i) = R[i] :=
   rfl
 
@@ -1058,10 +1039,12 @@ theorem isOption_neg_neg {x y : PGame} : IsOption (-x) (-y) ↔ IsOption x y := 
   rw [isOption_neg, neg_neg]
 
 /-- Use `toLeftMovesNeg` to cast between these two types. -/
+@[simp]
 theorem leftMoves_neg : ∀ x : PGame, (-x).LeftMoves = x.RightMoves
   | ⟨_, _, _, _⟩ => rfl
 
 /-- Use `toRightMovesNeg` to cast between these two types. -/
+@[simp]
 theorem rightMoves_neg : ∀ x : PGame, (-x).RightMoves = x.LeftMoves
   | ⟨_, _, _, _⟩ => rfl
 

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -25,21 +25,11 @@ namespace PGame
 def star : PGame.{u} :=
   ⟨PUnit, PUnit, fun _ ↦ 0, fun _ ↦ 0⟩
 
-@[simp]
-theorem star_leftMoves : star.LeftMoves = PUnit :=
-  rfl
+@[simp] theorem star_leftMoves : star.LeftMoves = PUnit := rfl
+@[simp] theorem star_rightMoves : star.RightMoves = PUnit := rfl
 
-@[simp]
-theorem star_rightMoves : star.RightMoves = PUnit :=
-  rfl
-
-@[simp]
-theorem star_moveLeft (x) : star.moveLeft x = 0 :=
-  rfl
-
-@[simp]
-theorem star_moveRight (x) : star.moveRight x = 0 :=
-  rfl
+@[simp] theorem star_moveLeft (x) : star.moveLeft x = 0 := rfl
+@[simp] theorem star_moveRight (x) : star.moveRight x = 0 := rfl
 
 instance uniqueStarLeftMoves : Unique star.LeftMoves :=
   PUnit.instUnique
@@ -69,21 +59,11 @@ theorem neg_star : -star = star := by simp [star]
 def up : PGame.{u} :=
   ⟨PUnit, PUnit, fun _ ↦ 0, fun _ ↦ star⟩
 
-@[simp]
-theorem up_leftMoves : up.LeftMoves = PUnit :=
-  rfl
+@[simp] theorem up_leftMoves : up.LeftMoves = PUnit := rfl
+@[simp] theorem up_rightMoves : up.RightMoves = PUnit := rfl
 
-@[simp]
-theorem up_rightMoves : up.RightMoves = PUnit :=
-  rfl
-
-@[simp]
-theorem up_moveLeft (x) : up.moveLeft x = 0 :=
-  rfl
-
-@[simp]
-theorem up_moveRight (x) : up.moveRight x = star :=
-  rfl
+@[simp] theorem up_moveLeft (x) : up.moveLeft x = 0 := rfl
+@[simp] theorem up_moveRight (x) : up.moveRight x = star := rfl
 
 @[simp]
 theorem up_neg : 0 < up := by
@@ -99,21 +79,11 @@ theorem star_fuzzy_up : star ‖ up := by
 def down : PGame.{u} :=
   ⟨PUnit, PUnit, fun _ ↦ star, fun _ ↦ 0⟩
 
-@[simp]
-theorem down_leftMoves : down.LeftMoves = PUnit :=
-  rfl
+@[simp] theorem down_leftMoves : down.LeftMoves = PUnit := rfl
+@[simp] theorem down_rightMoves : down.RightMoves = PUnit := rfl
 
-@[simp]
-theorem down_rightMoves : down.RightMoves = PUnit :=
-  rfl
-
-@[simp]
-theorem down_moveLeft (x) : down.moveLeft x = star :=
-  rfl
-
-@[simp]
-theorem down_moveRight (x) : down.moveRight x = 0 :=
-  rfl
+@[simp] theorem down_moveLeft (x) : down.moveLeft x = star := rfl
+@[simp] theorem down_moveRight (x) : down.moveRight x = 0 := rfl
 
 @[simp]
 theorem down_neg : down < 0 := by

--- a/CombinatorialGames/Game/Specific/Nim.lean
+++ b/CombinatorialGames/Game/Specific/Nim.lean
@@ -46,8 +46,15 @@ noncomputable def nim (o : Ordinal.{u}) : PGame.{u} :=
 termination_by o
 decreasing_by all_goals exact ((enumIsoToType o).symm x).prop
 
-theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by rw [nim]; rfl
-theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by rw [nim]; rfl
+/-- Use `toLeftMovesNim` to cast between these two types. -/
+@[simp]
+theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by
+  rw [nim]; rfl
+
+/-- Use `toRightMovesNim` to cast between these two types. -/
+@[simp]
+theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by
+  rw [nim]; rfl
 
 theorem moveLeft_nim_hEq (o : Ordinal) :
     HEq (nim o).moveLeft fun i : o.toType ↦ nim ((enumIsoToType o).symm i) := by


### PR DESCRIPTION
There's a bunch of theorems stating equalities between types that you're *usually* not supposed to use directly. We add comments explaining what casting operation to use instead.

For those rare cases where you *do* want to use these equalities directly (e.g. proving a `Nonempty` instance), we tag some `simp` lemmas to facilitate this. (These `simp` lemmas will never fire when the types are used dependently, which should hopefully mean this won't break things later down the line).

Also, some drive-by compression.