### PR TITLE
feat: `IGame` part 1

### DIFF
--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -2,7 +2,6 @@ import CombinatorialGames.Counterexamples.Multiplication
 import CombinatorialGames.Game.Basic
 import CombinatorialGames.Game.Birthday
 import CombinatorialGames.Game.Concrete
-import CombinatorialGames.Game.IGame
 import CombinatorialGames.Game.Impartial
 import CombinatorialGames.Game.Ordinal
 import CombinatorialGames.Game.PGame
@@ -13,6 +12,7 @@ import CombinatorialGames.Game.Specific.Domineering
 import CombinatorialGames.Game.Specific.Nim
 import CombinatorialGames.Game.Specific.Poset
 import CombinatorialGames.Game.State
+import CombinatorialGames.IGame.IGame
 import CombinatorialGames.Mathlib.AntisymmRel
 import CombinatorialGames.Nimber.Basic
 import CombinatorialGames.Nimber.Field

--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -2,6 +2,7 @@ import CombinatorialGames.Counterexamples.Multiplication
 import CombinatorialGames.Game.Basic
 import CombinatorialGames.Game.Birthday
 import CombinatorialGames.Game.Concrete
+import CombinatorialGames.Game.IGame
 import CombinatorialGames.Game.Impartial
 import CombinatorialGames.Game.Ordinal
 import CombinatorialGames.Game.PGame

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -8,7 +8,7 @@ import Mathlib.Logic.Small.Set
 
 universe u
 
-open PGame
+open PGame Set
 
 /-- Games up to identity.
 
@@ -22,39 +22,49 @@ namespace IGame
 def mk (x : PGame) : IGame := Quotient.mk _ x
 theorem mk_eq_mk {x y : PGame} : mk x = mk y ↔ x ≡ y := Quotient.eq
 
+alias ⟨_, mk_eq⟩ := mk_eq_mk
+alias _root_.PGame.Identical.mk_eq := mk_eq
+
 @[cases_eliminator]
 theorem ind {P : IGame → Prop} (H : ∀ y, P (mk y)) (x : IGame) : P x :=
   Quotient.ind H x
 
-alias ⟨_, mk_eq⟩ := mk_eq_mk
-alias _root_.PGame.Identical.mk_eq := mk_eq
+-- TODO: docstring
+noncomputable def out (x : IGame) : PGame :=
+  Quotient.out x
+
+@[simp]
+theorem out_eq (x : IGame) : mk x.out = x :=
+  Quotient.out_eq x
 
 -- TODO: docstring
 def lift {α : Sort*} (f : PGame → α) (hf : ∀ x y, x ≡ y → f x = f y) : IGame → α :=
   Quotient.lift f hf
 
+/-- The set of left moves of the game. -/
 def leftMoves : IGame → Set IGame := by
-  refine lift (fun x ↦ mk '' Set.range x.moveLeft) fun x y h ↦ ?_
+  refine lift (fun x ↦ mk '' range x.moveLeft) fun x y h ↦ ?_
   ext z
-  simp_rw [Set.mem_image, Set.mem_range, exists_exists_eq_and]
+  simp_rw [mem_image, mem_range, exists_exists_eq_and]
   constructor <;> rintro ⟨i, rfl⟩
   · obtain ⟨j, hj⟩ := h.moveLeft i
     exact ⟨j, hj.mk_eq.symm⟩
   · obtain ⟨j, hj⟩ := h.moveLeft_symm i
     exact ⟨j, hj.mk_eq⟩
 
+/-- The set of right moves of the game. -/
 def rightMoves : IGame → Set IGame := by
-  refine lift (fun x ↦ mk '' Set.range x.moveRight) fun x y h ↦ ?_
+  refine lift (fun x ↦ mk '' range x.moveRight) fun x y h ↦ ?_
   ext z
-  simp_rw [Set.mem_image, Set.mem_range, exists_exists_eq_and]
+  simp_rw [mem_image, mem_range, exists_exists_eq_and]
   constructor <;> rintro ⟨i, rfl⟩
   · obtain ⟨j, hj⟩ := h.moveRight i
     exact ⟨j, hj.mk_eq.symm⟩
   · obtain ⟨j, hj⟩ := h.moveRight_symm i
     exact ⟨j, hj.mk_eq⟩
 
-@[simp] theorem leftMoves_mk (x : PGame) : leftMoves (mk x) = mk '' Set.range x.moveLeft := rfl
-@[simp] theorem rightMoves_mk (x : PGame) : rightMoves (mk x) = mk '' Set.range x.moveRight := rfl
+@[simp] theorem leftMoves_mk (x : PGame) : leftMoves (mk x) = mk '' range x.moveLeft := rfl
+@[simp] theorem rightMoves_mk (x : PGame) : rightMoves (mk x) = mk '' range x.moveRight := rfl
 
 instance (x : IGame.{u}) : Small.{u} x.leftMoves := by
   cases x
@@ -66,7 +76,37 @@ instance (x : IGame.{u}) : Small.{u} x.rightMoves := by
   rw [rightMoves_mk]
   infer_instance
 
---noncomputable def ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] : IGame.{u} :=
+@[ext]
+theorem ext {x y : IGame} (hl : x.leftMoves = y.leftMoves) (hr : x.rightMoves = y.rightMoves) :
+    x = y := by
+  cases x with | H x =>
+  cases y with | H y =>
+  dsimp at hl hr
+  refine (identical_iff.2 ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩).mk_eq <;> intro i
+  · obtain ⟨_, ⟨j, rfl⟩, hj⟩ := hl ▸ mem_image_of_mem mk (mem_range_self (f := x.moveLeft) i)
+    exact ⟨j, mk_eq_mk.1 hj.symm⟩
+  · obtain ⟨_, ⟨j, rfl⟩, hj⟩ := hl ▸ mem_image_of_mem mk (mem_range_self (f := y.moveLeft) i)
+    exact ⟨j, mk_eq_mk.1 hj⟩
+  · obtain ⟨_, ⟨j, rfl⟩, hj⟩ := hr ▸ mem_image_of_mem mk (mem_range_self (f := x.moveRight) i)
+    exact ⟨j, mk_eq_mk.1 hj.symm⟩
+  · obtain ⟨_, ⟨j, rfl⟩, hj⟩ := hr ▸ mem_image_of_mem mk (mem_range_self (f := y.moveRight) i)
+    exact ⟨j, mk_eq_mk.1 hj⟩
 
+/-- Construct an `IGame` from its left and right sets. -/
+noncomputable def ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] : IGame.{u} :=
+  mk <| .mk (Shrink s) (Shrink t)
+    (out ∘ Subtype.val ∘ (equivShrink s).symm) (out ∘ Subtype.val ∘ (equivShrink t).symm)
+
+@[simp]
+theorem leftMoves_ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] :
+    (ofSets s t).leftMoves = s := by
+  ext y
+  simp [ofSets, range_comp, Equiv.range_eq_univ]
+
+@[simp]
+theorem rightMoves_ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] :
+    (ofSets s t).rightMoves = t := by
+  ext y
+  simp [ofSets, range_comp, Equiv.range_eq_univ]
 
 end IGame

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -400,7 +400,7 @@ theorem isOption_neg_neg {x y : IGame} : IsOption (-x) (-y) ↔ IsOption x y := 
   rw [isOption_neg, neg_neg]
 
 @[simp]
-theorem neg_le_iff {x y : IGame} : -x ≤ -y ↔ y ≤ x := by
+protected theorem neg_le_neg_iff {x y : IGame} : -x ≤ -y ↔ y ≤ x := by
   -- TODO: may have to add an `elab_as_elim` attr. in Mathlib
   refine Sym2.GameAdd.induction (C := fun x y ↦ -x ≤ -y ↔ y ≤ x) isOption_wf (fun x y IH ↦ ?_) x y
   dsimp at *
@@ -410,6 +410,34 @@ theorem neg_le_iff {x y : IGame} : -x ≤ -y ↔ y ≤ x := by
   congr! 3 with z hz z hz
   · rw [IH _ _ (Sym2.GameAdd.fst_snd (.of_mem_leftMoves hz))]
   · rw [IH _ _ (Sym2.GameAdd.snd_fst (.of_mem_rightMoves hz))]
+
+protected theorem neg_le {x y : IGame} : -x ≤ y ↔ -y ≤ x := by
+  simpa using @IGame.neg_le_neg_iff x (-y)
+protected theorem le_neg {x y : IGame} : x ≤ -y ↔ y ≤ -x := by
+  simpa using @IGame.neg_le_neg_iff (-x) y
+
+@[simp]
+protected theorem neg_lt_neg_iff {x y : IGame} : -x < -y ↔ y < x := by
+  rw [lt_iff_le_not_le, IGame.neg_le_neg_iff, IGame.neg_le_neg_iff, lt_iff_le_not_le]
+
+protected theorem neg_lt {x y : IGame} : -x < y ↔ -y < x := by
+  simpa using @IGame.neg_lt_neg_iff x (-y)
+protected theorem lt_neg {x y : IGame} : x < -y ↔ y < -x := by
+  simpa using @IGame.neg_lt_neg_iff (-x) y
+
+@[simp]
+protected theorem neg_equiv_neg_iff {x y : IGame} : -x ≈ -y ↔ x ≈ y := by
+  simp [AntisymmRel, and_comm]
+
+@[simp] theorem neg_le_zero {x : IGame} : -x ≤ 0 ↔ 0 ≤ x := by simpa using @IGame.neg_le x 0
+@[simp] theorem zero_le_neg {x : IGame} : 0 ≤ -x ↔ x ≤ 0 := by simpa using @IGame.le_neg 0 x
+@[simp] theorem neg_lt_zero {x : IGame} : -x < 0 ↔ 0 < x := by simpa using @IGame.neg_lt x 0
+@[simp] theorem zero_lt_neg {x : IGame} : 0 < -x ↔ x < 0 := by simpa using @IGame.lt_neg 0 x
+
+@[simp] theorem neg_equiv_zero {x : IGame} : -x ≈ 0 ↔ x ≈ 0 := by
+  simpa using @IGame.neg_equiv_neg_iff x 0
+@[simp] theorem zero_equiv_neg {x : IGame} : 0 ≈ -x ↔ 0 ≈ x := by
+  simpa using @IGame.neg_equiv_neg_iff 0 x
 
 end IGame
 end

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Violeta Hernández Palacios
+-/
+import CombinatorialGames.Game.PGame
+import Mathlib.Logic.Small.Set
+
+universe u
+
+open PGame
+
+/-- Games up to identity.
+
+TODO: write proper docstring. -/
+def IGame : Type (u + 1) :=
+  Quotient identicalSetoid
+
+namespace IGame
+
+-- TODO: docstring
+def mk (x : PGame) : IGame := Quotient.mk _ x
+theorem mk_eq_mk {x y : PGame} : mk x = mk y ↔ x ≡ y := Quotient.eq
+
+@[cases_eliminator]
+theorem ind {P : IGame → Prop} (H : ∀ y, P (mk y)) (x : IGame) : P x :=
+  Quotient.ind H x
+
+alias ⟨_, mk_eq⟩ := mk_eq_mk
+alias _root_.PGame.Identical.mk_eq := mk_eq
+
+-- TODO: docstring
+def lift {α : Sort*} (f : PGame → α) (hf : ∀ x y, x ≡ y → f x = f y) : IGame → α :=
+  Quotient.lift f hf
+
+def leftMoves : IGame → Set IGame := by
+  refine lift (fun x ↦ mk '' Set.range x.moveLeft) fun x y h ↦ ?_
+  ext z
+  simp_rw [Set.mem_image, Set.mem_range, exists_exists_eq_and]
+  constructor <;> rintro ⟨i, rfl⟩
+  · obtain ⟨j, hj⟩ := h.moveLeft i
+    exact ⟨j, hj.mk_eq.symm⟩
+  · obtain ⟨j, hj⟩ := h.moveLeft_symm i
+    exact ⟨j, hj.mk_eq⟩
+
+def rightMoves : IGame → Set IGame := by
+  refine lift (fun x ↦ mk '' Set.range x.moveRight) fun x y h ↦ ?_
+  ext z
+  simp_rw [Set.mem_image, Set.mem_range, exists_exists_eq_and]
+  constructor <;> rintro ⟨i, rfl⟩
+  · obtain ⟨j, hj⟩ := h.moveRight i
+    exact ⟨j, hj.mk_eq.symm⟩
+  · obtain ⟨j, hj⟩ := h.moveRight_symm i
+    exact ⟨j, hj.mk_eq⟩
+
+@[simp] theorem leftMoves_mk (x : PGame) : leftMoves (mk x) = mk '' Set.range x.moveLeft := rfl
+@[simp] theorem rightMoves_mk (x : PGame) : rightMoves (mk x) = mk '' Set.range x.moveRight := rfl
+
+instance (x : IGame.{u}) : Small.{u} x.leftMoves := by
+  cases x
+  rw [leftMoves_mk]
+  infer_instance
+
+instance (x : IGame.{u}) : Small.{u} x.rightMoves := by
+  cases x
+  rw [rightMoves_mk]
+  infer_instance
+
+--noncomputable def ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] : IGame.{u} :=
+
+
+end IGame

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -127,7 +127,7 @@ noncomputable def moveRecOn {P : IGame → Sort*} (x)
 theorem moveRecOn_eq {P : IGame → Sort*} (x)
     (H : Π x, (Π y ∈ x.leftMoves, P y) → (Π y ∈ x.rightMoves, P y) → P x) :
     moveRecOn x H = H x (fun y _ ↦ moveRecOn y H) (fun y _ ↦ moveRecOn y H) :=
-  isOption_wf.fix_eq _ _
+  isOption_wf.fix_eq ..
 
 -- TODO: docstring
 def Subsequent : IGame → IGame → Prop :=
@@ -138,6 +138,10 @@ theorem Subsequent.of_mem_leftMoves {x y : IGame} (h : x ∈ y.leftMoves) : Subs
 
 theorem Subsequent.of_mem_rightMoves {x y : IGame} (h : x ∈ y.rightMoves) : Subsequent x y :=
   Relation.TransGen.single (.of_mem_rightMoves h)
+
+theorem Subsequent.trans {x y z : IGame} (h₁ : Subsequent x y) (h₂ : Subsequent y z) :
+    Subsequent x z :=
+  Relation.TransGen.trans h₁ h₂
 
 instance : IsTrans _ Subsequent := inferInstanceAs (IsTrans _ (Relation.TransGen _))
 instance : IsWellFounded _ Subsequent := inferInstanceAs (IsWellFounded _ (Relation.TransGen _))
@@ -151,14 +155,12 @@ noncomputable def ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] : IGa
 @[simp]
 theorem leftMoves_ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] :
     (ofSets s t).leftMoves = s := by
-  ext y
-  simp [ofSets, range_comp, Equiv.range_eq_univ]
+  ext; simp [ofSets, range_comp, Equiv.range_eq_univ]
 
 @[simp]
 theorem rightMoves_ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] :
     (ofSets s t).rightMoves = t := by
-  ext y
-  simp [ofSets, range_comp, Equiv.range_eq_univ]
+  ext; simp [ofSets, range_comp, Equiv.range_eq_univ]
 
 @[simp]
 theorem ofSets_leftMoves_rightMoves (x : IGame) : ofSets x.leftMoves x.rightMoves = x := by

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -19,17 +19,15 @@ open PGame Set Pointwise
 
 /-- Games up to identity.
 
-`IGame` uses the set-theoretic notion of equality on Games,
-compared to `PGame`'s 'type-theoretic' notion of equality.
+`IGame` uses the set-theoretic notion of equality on games, compared to `PGame`'s 'type-theoretic'
+notion of equality.
 
-This is not the same equivalence as used broadly in combinatorial game theory literature,
-as a game like {0,1|0} is not _identical_ to {1|0}, despite being equivalent.
-However, many theorems can be proven over the 'identical' equivalence relation,
-and the literature may occasionally specifically use the 'identical' equivalence
-relation for this reason. 
+This is not the same equivalence as used broadly in combinatorial game theory literature, as a game
+like {0, 1 | 0} is not *identical* to {1 | 0}, despite being equivalent. However, many theorems can
+be proven over the 'identical' equivalence relation, and the literature may occasionally
+specifically use the 'identical' equivalence relation for this reason.
 
-For game equivalence from literature, see `Game.Basic`.
--/
+For the more common game equivalence from literature, see `Game.Basic`. -/
 def IGame : Type (u + 1) :=
   Quotient identicalSetoid
 
@@ -52,16 +50,9 @@ theorem ind {P : IGame → Prop} (H : ∀ y, P (mk y)) (x : IGame) : P x :=
 def out (x : IGame) : PGame := Quotient.out x
 @[simp] theorem out_eq (x : IGame) : mk x.out = x := Quotient.out_eq x
 
-/--
-`Quotient.lift` for `IGame`: if f : PGame → α respects the identical equivalence relation ≡, then f
-lifts IGame to α
--/
-def lift {α : Sort*} (f : PGame → α) (hf : ∀ x y, x ≡ y → f x = f y) : IGame → α :=
-  Quotient.lift f hf
-
 /-- The set of left moves of the game. -/
 def leftMoves : IGame → Set IGame := by
-  refine lift (fun x ↦ mk '' range x.moveLeft) fun x y h ↦ ?_
+  refine Quotient.lift (fun x ↦ mk '' range x.moveLeft) fun x y h ↦ ?_
   ext z
   simp_rw [mem_image, mem_range, exists_exists_eq_and]
   constructor <;> rintro ⟨i, rfl⟩
@@ -72,7 +63,7 @@ def leftMoves : IGame → Set IGame := by
 
 /-- The set of right moves of the game. -/
 def rightMoves : IGame → Set IGame := by
-  refine lift (fun x ↦ mk '' range x.moveRight) fun x y h ↦ ?_
+  refine Quotient.lift (fun x ↦ mk '' range x.moveRight) fun x y h ↦ ?_
   ext z
   simp_rw [mem_image, mem_range, exists_exists_eq_and]
   constructor <;> rintro ⟨i, rfl⟩
@@ -147,30 +138,30 @@ theorem moveRecOn_eq {P : IGame → Sort*} (x)
     moveRecOn x H = H x (fun y _ ↦ moveRecOn y H) (fun y _ ↦ moveRecOn y H) :=
   isOption_wf.fix_eq ..
 
--- TODO: docstring
-def Subsequent : IGame → IGame → Prop :=
+/-- A (proper) subposition is any game in the transitive closure of `IsOption`. -/
+def Subposition : IGame → IGame → Prop :=
   Relation.TransGen IsOption
 
-theorem Subsequent.of_mem_leftMoves {x y : IGame} (h : x ∈ y.leftMoves) : Subsequent x y :=
+theorem Subposition.of_mem_leftMoves {x y : IGame} (h : x ∈ y.leftMoves) : Subposition x y :=
   Relation.TransGen.single (.of_mem_leftMoves h)
 
-theorem Subsequent.of_mem_rightMoves {x y : IGame} (h : x ∈ y.rightMoves) : Subsequent x y :=
+theorem Subposition.of_mem_rightMoves {x y : IGame} (h : x ∈ y.rightMoves) : Subposition x y :=
   Relation.TransGen.single (.of_mem_rightMoves h)
 
-theorem Subsequent.trans {x y z : IGame} (h₁ : Subsequent x y) (h₂ : Subsequent y z) :
-    Subsequent x z :=
+theorem Subposition.trans {x y z : IGame} (h₁ : Subposition x y) (h₂ : Subposition y z) :
+    Subposition x z :=
   Relation.TransGen.trans h₁ h₂
 
-instance : IsTrans _ Subsequent := inferInstanceAs (IsTrans _ (Relation.TransGen _))
-instance : IsWellFounded _ Subsequent := inferInstanceAs (IsWellFounded _ (Relation.TransGen _))
-instance : WellFoundedRelation IGame := ⟨Subsequent, instIsWellFoundedSubsequent.wf⟩
+instance : IsTrans _ Subposition := inferInstanceAs (IsTrans _ (Relation.TransGen _))
+instance : IsWellFounded _ Subposition := inferInstanceAs (IsWellFounded _ (Relation.TransGen _))
+instance : WellFoundedRelation IGame := ⟨Subposition, instIsWellFoundedSubposition.wf⟩
 
-/-- Discharges proof obligations of the form `⊢ Subsequent ..` arising in termination proofs
+/-- Discharges proof obligations of the form `⊢ Subposition ..` arising in termination proofs
 of definitions using well-founded recursion on `IGame`. -/
 macro "igame_wf" : tactic =>
   `(tactic| all_goals solve_by_elim
     [Prod.Lex.left, Prod.Lex.right, PSigma.Lex.left, PSigma.Lex.right,
-    Subsequent.of_mem_leftMoves, Subsequent.of_mem_rightMoves, Subsequent.trans, Subtype.prop] )
+    Subposition.of_mem_leftMoves, Subposition.of_mem_rightMoves, Subposition.trans, Subtype.prop] )
 
 /-- Construct an `IGame` from its left and right sets.
 

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -52,7 +52,10 @@ theorem ind {P : IGame → Prop} (H : ∀ y, P (mk y)) (x : IGame) : P x :=
 def out (x : IGame) : PGame := Quotient.out x
 @[simp] theorem out_eq (x : IGame) : mk x.out = x := Quotient.out_eq x
 
--- TODO: docstring
+/--
+`Quotient.lift` for `IGame`: if f : PGame → α respects the identical equivalence relation ≡, then f
+lifts IGame to α
+-/
 def lift {α : Sort*} (f : PGame → α) (hf : ∀ x y, x ≡ y → f x = f y) : IGame → α :=
   Quotient.lift f hf
 

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -10,6 +10,8 @@ import Mathlib.Logic.Small.Set
 
 universe u
 
+-- This is a false positive due to the provisional duplicated IGame/IGame file path.
+set_option linter.dupNamespace false
 -- All computation should be done through `IGame.Short`.
 noncomputable section
 
@@ -37,12 +39,8 @@ theorem ind {P : IGame → Prop} (H : ∀ y, P (mk y)) (x : IGame) : P x :=
   Quotient.ind H x
 
 /-- Choose an element of the equivalence class using the axiom of choice. -/
-def out (x : IGame) : PGame :=
-  Quotient.out x
-
-@[simp]
-theorem out_eq (x : IGame) : mk x.out = x :=
-  Quotient.out_eq x
+def out (x : IGame) : PGame := Quotient.out x
+@[simp] theorem out_eq (x : IGame) : mk x.out = x := Quotient.out_eq x
 
 -- TODO: docstring
 def lift {α : Sort*} (f : PGame → α) (hf : ∀ x y, x ≡ y → f x = f y) : IGame → α :=

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -233,8 +233,7 @@ instance : One IGame := ⟨{{0} | ∅}ᴵ⟩
 
 /-- The less or equal relation on games.
 
-If `0 ≤ x`, then Left can win `x` as the second player. `x ≤ y` means that `0 ≤ y - x`.
-See `PGame.le_iff_sub_nonneg`. -/
+If `0 ≤ x`, then Left can win `x` as the second player. `x ≤ y` means that `0 ≤ y - x`. -/
 instance : LE IGame where
   le := Sym2.GameAdd.fix isOption_wf fun x y le ↦
     (∀ z (h : z ∈ x.leftMoves),  ¬le y z (Sym2.GameAdd.snd_fst (IsOption.of_mem_leftMoves h))) ∧
@@ -243,8 +242,7 @@ instance : LE IGame where
 -- TODO: can a macro expert verify this makes sense?
 /-- The less or fuzzy relation on pre-games. `x ⧏ y` is notation for `¬ y ≤ x`.
 
-If `0 ⧏ x`, then Left can win `x` as the first player. `x ⧏ y` means that `0 ⧏ y - x`.
-See `PGame.lf_iff_sub_zero_lf`. -/
+If `0 ⧏ x`, then Left can win `x` as the first player. `x ⧏ y` means that `0 ⧏ y - x`. -/
 macro_rules | `($x ⧏ $y) => `(¬$y ≤ $x)
 
 /-- Definition of `x ≤ y` on pre-games, in terms of `⧏`. -/

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -19,7 +19,17 @@ open PGame Set Pointwise
 
 /-- Games up to identity.
 
-TODO: write proper docstring. -/
+`IGame` uses the set-theoretic notion of equality on Games,
+compared to `PGame`'s 'type-theoretic' notion of equality.
+
+This is not the same equivalence as used broadly in combinatorial game theory literature,
+as a game like {0,1|0} is not _identical_ to {1|0}, despite being equivalent.
+However, many theorems can be proven over the 'identical' equivalence relation,
+and the literature may occasionally specifically use the 'identical' equivalence
+relation for this reason. 
+
+For game equivalence from literature, see `Game.Basic`.
+-/
 def IGame : Type (u + 1) :=
   Quotient identicalSetoid
 

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -226,6 +226,8 @@ instance : Inhabited IGame := ⟨0⟩
 /-- The game `1 = {{0} | ∅}ᴵ`. -/
 instance : One IGame := ⟨{{0} | ∅}ᴵ⟩
 
+theorem one_def : 1 = {{0} | ∅}ᴵ := rfl
+
 @[simp] theorem leftMoves_one : leftMoves 1 = {0} := leftMoves_ofSets ..
 @[simp] theorem rightMoves_one : rightMoves 1 = ∅ := rightMoves_ofSets ..
 

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -165,8 +165,12 @@ macro "igame_wf" : tactic =>
 
 /-- Construct an `IGame` from its left and right sets.
 
-This is given notation `{s | t}ᴵ`, where the superscript `I` is to disambiguate
-from set builder notation, and from the analogous constructor on `Game`. -/
+This is given notation `{s | t}ᴵ`, where the superscript `I` is to disambiguate from set builder
+notation, and from the analogous constructor on `Game`.
+
+This function is regretably noncomputable. Among other issues, sets simply do not carry data in
+Lean. To perform computations on `IGame` we instead depend on another auxiliary type, see
+`IGame.Short` for more information. -/
 def ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] : IGame.{u} :=
   mk <| .mk (Shrink s) (Shrink t)
     (out ∘ Subtype.val ∘ (equivShrink s).symm) (out ∘ Subtype.val ∘ (equivShrink t).symm)

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -161,21 +161,21 @@ macro "igame_wf" : tactic =>
 
 /-- Construct an `IGame` from its left and right sets.
 
-This is given notation `{s | t}ᴳ`, where the superscript G is to disambiguate
-from set builder notation. -/
+This is given notation `{s | t}ᴵ`, where the superscript `I` is to disambiguate
+from set builder notation, and from the analogous constructor on `Game`. -/
 def ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] : IGame.{u} :=
   mk <| .mk (Shrink s) (Shrink t)
     (out ∘ Subtype.val ∘ (equivShrink s).symm) (out ∘ Subtype.val ∘ (equivShrink t).symm)
 
 -- TODO: can a macro expert verify this makes sense?
-@[inherit_doc ofSets] macro "{" s:term " | " t:term "}ᴳ" : term => `(ofSets $s $t)
+@[inherit_doc ofSets] macro "{" s:term " | " t:term "}ᴵ" : term => `(ofSets $s $t)
 
 @[simp]
-theorem leftMoves_ofSets (s t : Set _) [Small.{u} s] [Small.{u} t] : {s | t}ᴳ.leftMoves = s := by
+theorem leftMoves_ofSets (s t : Set _) [Small.{u} s] [Small.{u} t] : {s | t}ᴵ.leftMoves = s := by
   ext; simp [ofSets, range_comp, Equiv.range_eq_univ]
 
 @[simp]
-theorem rightMoves_ofSets (s t : Set _) [Small.{u} s] [Small.{u} t] : {s | t}ᴳ.rightMoves = t := by
+theorem rightMoves_ofSets (s t : Set _) [Small.{u} s] [Small.{u} t] : {s | t}ᴵ.rightMoves = t := by
   ext; simp [ofSets, range_comp, Equiv.range_eq_univ]
 
 @[simp]
@@ -193,14 +193,14 @@ left and right sets.
 See `moveRecOn` for an alternate form. -/
 @[elab_as_elim]
 def ofSetsRecOn {P : IGame.{u} → Sort*} (x)
-    (H : Π (s t : Set _) [Small s] [Small t], (Π x ∈ s, P x) → (Π x ∈ t, P x) → P {s | t}ᴳ) : P x :=
-  cast (by simp) <| moveRecOn (P := fun x ↦ P {x.leftMoves | x.rightMoves}ᴳ) x fun x IHl IHr ↦
+    (H : Π (s t : Set _) [Small s] [Small t], (Π x ∈ s, P x) → (Π x ∈ t, P x) → P {s | t}ᴵ) : P x :=
+  cast (by simp) <| moveRecOn (P := fun x ↦ P {x.leftMoves | x.rightMoves}ᴵ) x fun x IHl IHr ↦
     H _ _ (fun y hy ↦ cast (by simp) (IHl y hy)) (fun y hy ↦ cast (by simp) (IHr y hy))
 
 @[simp]
 theorem ofSetsRecOn_ofSets {P : IGame.{u} → Sort*} (s t : Set IGame) [Small.{u} s] [Small.{u} t]
-    (H : Π (s t : Set _) [Small s] [Small t], (Π x ∈ s, P x) → (Π x ∈ t, P x) → P {s | t}ᴳ) :
-    ofSetsRecOn {s | t}ᴳ H = H _ _ (fun y _ ↦ ofSetsRecOn y H) (fun y _ ↦ ofSetsRecOn y H) := by
+    (H : Π (s t : Set _) [Small s] [Small t], (Π x ∈ s, P x) → (Π x ∈ t, P x) → P {s | t}ᴵ) :
+    ofSetsRecOn {s | t}ᴵ H = H _ _ (fun y _ ↦ ofSetsRecOn y H) (fun y _ ↦ ofSetsRecOn y H) := by
   rw [ofSetsRecOn, cast_eq_iff_heq, moveRecOn_eq]
   congr
   any_goals simp
@@ -213,18 +213,18 @@ theorem ofSetsRecOn_ofSets {P : IGame.{u} → Sort*} (s t : Set IGame) [Small.{u
 
 /-! ### Basic games -/
 
-/-- The game `0 = {∅ | ∅}ᴳ`. -/
-instance : Zero IGame := ⟨{∅ | ∅}ᴳ⟩
+/-- The game `0 = {∅ | ∅}ᴵ`. -/
+instance : Zero IGame := ⟨{∅ | ∅}ᴵ⟩
 
-theorem zero_def : 0 = {∅ | ∅}ᴳ := rfl
+theorem zero_def : 0 = {∅ | ∅}ᴵ := rfl
 
 @[simp] theorem leftMoves_zero : leftMoves 0 = ∅ := leftMoves_ofSets ..
 @[simp] theorem rightMoves_zero : rightMoves 0 = ∅ := rightMoves_ofSets ..
 
 instance : Inhabited IGame := ⟨0⟩
 
-/-- The game `1 = {{0} | ∅}ᴳ`. -/
-instance : One IGame := ⟨{{0} | ∅}ᴳ⟩
+/-- The game `1 = {{0} | ∅}ᴵ`. -/
+instance : One IGame := ⟨{{0} | ∅}ᴵ⟩
 
 @[simp] theorem leftMoves_one : leftMoves 1 = {0} := leftMoves_ofSets ..
 @[simp] theorem rightMoves_one : rightMoves 1 = ∅ := rightMoves_ofSets ..
@@ -373,16 +373,16 @@ instance {α : Type*} [InvolutiveNeg α] (s : Set α) [Small.{u} s] : Small.{u} 
   infer_instance
 
 private def neg' (x : IGame) : IGame :=
-  {range fun y : x.rightMoves ↦ neg' y.1 | range fun y : x.leftMoves ↦ neg' y.1}ᴳ
+  {range fun y : x.rightMoves ↦ neg' y.1 | range fun y : x.leftMoves ↦ neg' y.1}ᴵ
 termination_by x
 decreasing_by igame_wf
 
-/-- The negative of a game is defined by `-{s | t}ᴳ = {-t | -s}ᴳ`. -/
+/-- The negative of a game is defined by `-{s | t}ᴵ = {-t | -s}ᴵ`. -/
 instance : Neg IGame where
   neg := neg'
 
 private theorem neg_ofSets' (s t : Set _) [Small s] [Small t] :
-    -{s | t}ᴳ = {Neg.neg '' t | Neg.neg '' s}ᴳ := by
+    -{s | t}ᴵ = {Neg.neg '' t | Neg.neg '' s}ᴵ := by
   change neg' _ = _
   rw [neg']
   simp [Neg.neg, Set.ext_iff]
@@ -393,13 +393,13 @@ instance : InvolutiveNeg IGame where
     aesop (add simp [neg_ofSets'])
 
 @[simp]
-theorem neg_ofSets (s t : Set _) [Small s] [Small t] : -{s | t}ᴳ = {-t | -s}ᴳ := by
+theorem neg_ofSets (s t : Set _) [Small s] [Small t] : -{s | t}ᴵ = {-t | -s}ᴵ := by
   simp_rw [neg_ofSets', Set.image_neg_eq_neg]
 
 instance : NegZeroClass IGame where
   neg_zero := by simp [zero_def]
 
-theorem neg_eq (x : IGame) : -x = {-x.rightMoves | -x.leftMoves}ᴳ := by
+theorem neg_eq (x : IGame) : -x = {-x.rightMoves | -x.leftMoves}ᴵ := by
   rw [← neg_ofSets, ofSets_leftMoves_rightMoves]
 
 @[simp]
@@ -461,25 +461,25 @@ protected theorem neg_equiv_neg_iff {x y : IGame} : -x ≈ -y ↔ x ≈ y := by
 
 private def add' (x y : IGame) : IGame :=
   {(range fun z : x.leftMoves ↦ add' z y) ∪ (range fun z : y.leftMoves ↦ add' x z) |
-    (range fun z : x.rightMoves ↦ add' z y) ∪ (range fun z : y.rightMoves ↦ add' x z)}ᴳ
+    (range fun z : x.rightMoves ↦ add' z y) ∪ (range fun z : y.rightMoves ↦ add' x z)}ᴵ
 termination_by (x, y)
 decreasing_by igame_wf
 
-/-- The sum of `x = {s₁ | t₁}ᴳ` and `y = {s₂ | t₂}ᴳ` is `{s₁ + y, x + s₂ | t₁ + y, x + t₂}ᴳ`. -/
+/-- The sum of `x = {s₁ | t₁}ᴵ` and `y = {s₂ | t₂}ᴵ` is `{s₁ + y, x + s₂ | t₁ + y, x + t₂}ᴵ`. -/
 instance : Add IGame where
   add := add'
 
 theorem add_eq (x y : IGame) : x + y =
     {(· + y) '' x.leftMoves ∪ (x + ·) '' y.leftMoves |
-      (· + y) '' x.rightMoves ∪ (x + ·) '' y.rightMoves}ᴳ := by
+      (· + y) '' x.rightMoves ∪ (x + ·) '' y.rightMoves}ᴵ := by
   change add' _ _ = _
   rw [add']
   simp [HAdd.hAdd, Add.add, Set.ext_iff]
 
 theorem ofSets_add_ofSets (s₁ t₁ s₂ t₂ : Set IGame) [Small s₁] [Small t₁] [Small s₂] [Small t₂] :
-    {s₁ | t₁}ᴳ + {s₂ | t₂}ᴳ =
-      {(· + {s₂ | t₂}ᴳ) '' s₁ ∪ ({s₁ | t₁}ᴳ + ·) '' s₂ |
-        (· + {s₂ | t₂}ᴳ) '' t₁ ∪ ({s₁ | t₁}ᴳ + ·) '' t₂}ᴳ := by
+    {s₁ | t₁}ᴵ + {s₂ | t₂}ᴵ =
+      {(· + {s₂ | t₂}ᴵ) '' s₁ ∪ ({s₁ | t₁}ᴵ + ·) '' s₂ |
+        (· + {s₂ | t₂}ᴵ) '' t₁ ∪ ({s₁ | t₁}ᴵ + ·) '' t₂}ᴵ := by
   rw [add_eq]
   simp
 


### PR DESCRIPTION
We define up to the `AddCommMonoid` instance on `IGame`. #29

There's some results I haven't ported yet like `x - x ≈ 0` or `x ≤ y → z + x ≤ z + y`. I think a lot of the results that existed on `PGame` could be simplified by first building the quotient `Game = Antisymmetrization IGame`, proving the `OrderedAddCommGroup` instance on it, and then "porting back" the results via def-eq. So I'd like to do that before proving the more advanced relations between orders and arithemetic on `IGame`.

For now I've put everything in an `IGame` folder - of course, when the refactor is over, the idea is to put everything back in its place, overwriting whatever we had before.