### PR TITLE
feat: embed `PGame` construction in `IGame` file

### DIFF
--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -16,7 +16,7 @@ set_option linter.dupNamespace false
 -- All computation should be done through `IGame.Short`.
 noncomputable section
 
--- This avoids name clashes with the existing `PGame`.
+-- TODO: This avoids name clashes with the existing `PGame`.
 -- Remove it when we finish porting!
 namespace Temp
 

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -61,10 +61,10 @@ def moveLeft : ∀ g : PGame, LeftMoves g → PGame
 def moveRight : ∀ g : PGame, RightMoves g → PGame
   | mk _ _r _ R => R
 
-@[simp] theorem leftMoves_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).LeftMoves = xl := rfl
-@[simp] theorem moveLeft_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).moveLeft = xL := rfl
-@[simp] theorem rightMoves_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).RightMoves = xr := rfl
-@[simp] theorem moveRight_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).moveRight = xR := rfl
+@[simp] theorem leftMoves_mk {xl xr xL xR} : (mk xl xr xL xR).LeftMoves = xl := rfl
+@[simp] theorem moveLeft_mk {xl xr xL xR} : (mk xl xr xL xR).moveLeft = xL := rfl
+@[simp] theorem rightMoves_mk {xl xr xL xR} : (mk xl xr xL xR).RightMoves = xr := rfl
+@[simp] theorem moveRight_mk {xl xr xL xR} : (mk xl xr xL xR).moveRight = xR := rfl
 
 /-- Two pre-games are identical if their left and right sets are identical. That is, `Identical x y`
 if every left move of `x` is identical to some left move of `y`, every right move of `x` is

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -86,8 +86,6 @@ theorem identical_iff : ∀ {x y : PGame}, x ≡ y ↔
 protected theorem Identical.refl (x) : x ≡ x :=
   x.recOn fun _ _ _ _ IHL IHR ↦ ⟨Relator.BiTotal.refl IHL, Relator.BiTotal.refl IHR⟩
 
-protected theorem Identical.rfl {x} : x ≡ x := Identical.refl x
-
 @[symm]
 protected theorem Identical.symm : ∀ {x y}, x ≡ y → y ≡ x
   | mk .., mk .., ⟨hL, hR⟩ => ⟨hL.symm fun _ _ h ↦ h.symm, hR.symm fun _ _ h ↦ h.symm⟩
@@ -99,7 +97,7 @@ protected theorem Identical.trans : ∀ {x y z}, x ≡ y → y ≡ z → x ≡ z
 
 /-- `Identical` as a `Setoid`. -/
 def identicalSetoid : Setoid PGame :=
-  ⟨Identical, Identical.refl, Identical.symm, Identical.trans⟩
+  ⟨Identical, .refl, .symm, .trans⟩
 
 /-- If `x ≡ y`, then a left move of `x` is identical to some left move of `y`. -/
 theorem Identical.moveLeft : ∀ {x y}, x ≡ y → ∀ i, ∃ j, x.moveLeft i ≡ y.moveLeft j

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -16,6 +16,10 @@ set_option linter.dupNamespace false
 -- All computation should be done through `IGame.Short`.
 noncomputable section
 
+-- This avoids name clashes with the existing `PGame`.
+-- Remove it when we finish porting!
+namespace Temp
+
 open Set Pointwise
 
 /-! ### Pre-games -/
@@ -139,7 +143,7 @@ def mk (x : PGame) : IGame := Quotient.mk _ x
 theorem mk_eq_mk {x y : PGame} : mk x = mk y ↔ x ≡ y := Quotient.eq
 
 alias ⟨_, mk_eq⟩ := mk_eq_mk
-alias _root_.PGame.Identical.mk_eq := mk_eq
+alias _root_.Temp.PGame.Identical.mk_eq := mk_eq
 
 @[cases_eliminator]
 theorem ind {P : IGame → Prop} (H : ∀ y, P (mk y)) (x : IGame) : P x :=
@@ -767,4 +771,5 @@ theorem sub_congr {a b c d : IGame} (h₁ : a ≈ b) (h₂ : c ≈ d) : a - c �
   add_congr h₁ (neg_congr h₂)
 
 end IGame
+end Temp
 end

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -286,12 +286,12 @@ theorem rightMoves_ofSets (s t : Set _) [Small.{u} s] [Small.{u} t] : {s | t}ᴵ
   ext; simp [ofSets, range_comp, Equiv.range_eq_univ]
 
 @[simp]
-theorem ofSets_leftMoves_rightMoves (x : IGame) : ofSets x.leftMoves x.rightMoves = x := by
+theorem ofSets_leftMoves_rightMoves (x : IGame) : {x.leftMoves | x.rightMoves}ᴵ = x := by
   ext <;> simp
 
 @[simp]
 theorem ofSets_inj {s₁ s₂ t₁ t₂ : Set _} [Small s₁] [Small s₂] [Small t₁] [Small t₂] :
-    ofSets s₁ t₁ = ofSets s₂ t₂ ↔ s₁ = s₂ ∧ t₁ = t₂ := by
+    {s₁ | t₁}ᴵ = {s₂ | t₂}ᴵ ↔ s₁ = s₂ ∧ t₁ = t₂ := by
   simp [IGame.ext_iff]
 
 /-- **Conway recursion**: build data for a game by recursively building it on its

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Violeta Hernández Palacios
+Authors: Violeta Hernández Palacios, Reid Barton, Mario Carneiro, Isabel Longbottom, Kim Morrison, Yuyang Zhao
 -/
 import Mathlib.Algebra.Group.Pointwise.Set.Basic
 import Mathlib.Logic.Hydra


### PR DESCRIPTION
We minimize the `PGame` file to the bare minimum needed to set up `IGame`, and embed it as the first section of the file.