### PR TITLE
fix(IGame/Basic): index in CombinatorialGames & fix namespace

### DIFF
--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -12,7 +12,10 @@ import CombinatorialGames.Game.Specific.Domineering
 import CombinatorialGames.Game.Specific.Nim
 import CombinatorialGames.Game.Specific.Poset
 import CombinatorialGames.Game.State
+import CombinatorialGames.IGame.Basic
 import CombinatorialGames.IGame.IGame
+import CombinatorialGames.IGame.Impartial
+import CombinatorialGames.IGame.Special
 import CombinatorialGames.Mathlib.AntisymmRel
 import CombinatorialGames.Mathlib.CompRel
 import CombinatorialGames.Nimber.Basic

--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -14,7 +14,6 @@ import CombinatorialGames.Game.Specific.Poset
 import CombinatorialGames.Game.State
 import CombinatorialGames.IGame.Basic
 import CombinatorialGames.IGame.IGame
-import CombinatorialGames.IGame.Impartial
 import CombinatorialGames.IGame.Special
 import CombinatorialGames.Mathlib.AntisymmRel
 import CombinatorialGames.Mathlib.CompRel

--- a/CombinatorialGames/IGame/Basic.lean
+++ b/CombinatorialGames/IGame/Basic.lean
@@ -9,6 +9,9 @@ universe u
 
 noncomputable section
 
+-- TODO: remove Temp namespace
+namespace Temp
+
 open IGame Set Pointwise
 
 /-- Games up to equivalence.
@@ -114,4 +117,4 @@ theorem zero_def : 0 = {∅ | ∅}ᴳ := by apply (mk_ofSets _ _).trans; simp
 theorem one_def : 1 = {{0} | ∅}ᴳ := by apply (mk_ofSets _ _).trans; simp
 
 end Game
-end
+end Temp


### PR DESCRIPTION
wasn't caught in CI because `CombinatorialGames` didn't index every file in `IGame`.