### PR TITLE
feat: `game_cmp` tactic

### DIFF
--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -72,11 +72,10 @@ The order structures interact in the expected way with arithmetic. In particular
 
 universe u
 
-
 -- TODO: upstream
 @[simp]
-theorem forall_eq_or_eq {α} {P : α → Prop} {y z : α} :
-    (∀ x, (y = x ∨ z = x) → P x) ↔ P y ∧ P z := by
+theorem forall_or_eq {α} {P Q : α → Prop} {y : α} :
+    (∀ x, (P x ∨ y = x) → Q x) ↔ (∀ x, P x → Q x) ∧ Q y := by
   aesop
 
 -- TODO: This is a false positive due to the provisional duplicated IGame/IGame file path.

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -72,6 +72,13 @@ The order structures interact in the expected way with arithmetic. In particular
 
 universe u
 
+
+-- TODO: upstream
+@[simp]
+theorem forall_eq_or_eq {α} {P : α → Prop} {y z : α} :
+    (∀ x, (y = x ∨ z = x) → P x) ↔ P y ∧ P z := by
+  aesop
+
 -- TODO: This is a false positive due to the provisional duplicated IGame/IGame file path.
 set_option linter.dupNamespace false
 -- Computations can be performed through the `game_cmp` tactic.
@@ -983,6 +990,16 @@ theorem rightMoves_mul (x y : IGame) :
       (x.leftMoves ×ˢ y.rightMoves ∪ x.rightMoves ×ˢ y.leftMoves) := by
   rw [mul_eq, rightMoves_ofSets]
 
+@[simp]
+theorem leftMoves_mulOption (x y a b : IGame) :
+    (mulOption x y a b).leftMoves = leftMoves (a * y + x * b - a * b) :=
+  rfl
+
+@[simp]
+theorem rightMoves_mulOption (x y a b : IGame) :
+    (mulOption x y a b).rightMoves = rightMoves (a * y + x * b - a * b) :=
+  rfl
+
 theorem mulOption_left_left_mem_leftMoves_mul {x y a b : IGame}
     (h₁ : a ∈ x.leftMoves) (h₂ : b ∈ y.leftMoves) : mulOption x y a b ∈ (x * y).leftMoves := by
   rw [leftMoves_mul]; use (a, b); simp_all
@@ -1093,4 +1110,18 @@ theorem mulOption_neg (x y a b : IGame) : mulOption (-x) (-y) a b = mulOption x 
 `CombinatorialGames.Game.Basic`. -/
 
 end IGame
+
+/-! ### Tactic tests -/
+
+section Test
+
+example : (0 : IGame) < 1 := by game_cmp
+example : (2 : IGame) + 2 ≈ 4 := by game_cmp
+example : (3 : IGame) - 2 ≈ 1 := by game_cmp
+example : {{1} | {2}}ᴵ ≈ {{0, 1} | {2, 3}}ᴵ := by game_cmp
+
+set_option maxHeartbeats 500000 in
+example : (2 : IGame) * 2 ≈ 4 := by game_cmp
+
+end Test
 end

--- a/CombinatorialGames/IGame/IGame.lean
+++ b/CombinatorialGames/IGame/IGame.lean
@@ -543,7 +543,7 @@ macro "game_cmp" : tactic =>
   `(tactic| {
     try simp only [lt_iff_le_not_le, AntisymmRel, CompRel, IncompRel]
     repeat
-      try rw [le_iff_forall_lf]
+      rw [le_iff_forall_lf]
       simp })
 
 @[simp]
@@ -1119,8 +1119,6 @@ example : (0 : IGame) < 1 := by game_cmp
 example : (2 : IGame) + 2 ≈ 4 := by game_cmp
 example : (3 : IGame) - 2 ≈ 1 := by game_cmp
 example : {{1} | {2}}ᴵ ≈ {{0, 1} | {2, 3}}ᴵ := by game_cmp
-
-set_option maxHeartbeats 500000 in
 example : (2 : IGame) * 2 ≈ 4 := by game_cmp
 
 end Test

--- a/CombinatorialGames/IGame/Ordinal.lean
+++ b/CombinatorialGames/IGame/Ordinal.lean
@@ -225,4 +225,20 @@ theorem toGame_natCast : ∀ n : ℕ, toGame n = n
 theorem toIGame_natCast_equiv (n : ℕ) : toIGame n ≈ n :=
   Game.mk_eq_mk.1 (by simp)
 
+@[simp]
+theorem forall_lt_natCast {P : NatOrdinal → Prop} (n : ℕ) :
+    (∀ a < (n : NatOrdinal), P a) ↔ ∀ a < n, P a := by
+  constructor
+  · 
+
 end NatOrdinal
+
+#exit
+
+attribute [simp] Nat.forall_lt_succ Nat.exists_lt_succ
+
+example : NatOrdinal.toIGame 3 ≈ 3 := by
+  rw [AntisymmRel]
+  rw [le_iff_forall_lf]
+
+  simp

--- a/CombinatorialGames/IGame/Ordinal.lean
+++ b/CombinatorialGames/IGame/Ordinal.lean
@@ -27,7 +27,8 @@ open Set IGame
 
 noncomputable section
 
--- TODO: upstream
+/-! ### Lemmas to upstream -/
+
 @[simp]
 theorem OrderEmbedding.antisymmRel_iff_antisymmRel {α β : Type*} [Preorder α] [Preorder β]
     {a b : α} (f : α ↪o β) : f a ≈ f b ↔ a ≈ b := by
@@ -45,7 +46,44 @@ theorem not_le_of_not_le_of_le {α : Type*} [Preorder α] {a b c : α} (h₁ : �
     ¬ c ≤ a :=
   fun h ↦ h₁ (h₂.trans h)
 
+theorem Ordinal.Iio_natCast (n : ℕ) : Iio (n : Ordinal) = Nat.cast '' Iio n := by
+  ext o
+  constructor
+  · intro ho
+    obtain ⟨n, rfl⟩ := Ordinal.lt_omega0.1 (ho.trans (nat_lt_omega0 _))
+    simp_all
+  · rintro ⟨o, ho, rfl⟩
+    simp_all
+
+theorem NatOrdinal.Iio_natCast (n : ℕ) : Iio (n : NatOrdinal) = Nat.cast '' Iio n := by
+  rw [← Ordinal.toNatOrdinal_cast_nat]
+  apply (Ordinal.Iio_natCast _).trans
+  congr! 1
+  exact Ordinal.toNatOrdinal_cast_nat _
+
 namespace NatOrdinal
+
+@[simp]
+theorem forall_lt_natCast {P : NatOrdinal → Prop} {n : ℕ} :
+    (∀ a < (n : NatOrdinal), P a) ↔ ∀ a < n, P a := by
+  change (∀ a ∈ Iio _, _) ↔ ∀ a ∈ Iio _, _
+  simp [NatOrdinal.Iio_natCast]
+
+@[simp]
+theorem exists_lt_natCast {P : NatOrdinal → Prop} {n : ℕ} :
+    (∃ a < (n : NatOrdinal), P a) ↔ ∃ a < n, P a := by
+  change (∃ a ∈ Iio _, _) ↔ ∃ a ∈ Iio _, _
+  simp [NatOrdinal.Iio_natCast]
+
+@[simp]
+theorem forall_lt_ofNat {P : NatOrdinal → Prop} {n : ℕ} [n.AtLeastTwo] :
+    (∀ a < ofNat(n), P a) ↔ ∀ a < n, P a :=
+  forall_lt_natCast
+
+@[simp]
+theorem exists_lt_ofNat {P : NatOrdinal → Prop} {n : ℕ} [n.AtLeastTwo] :
+    (∃ a < ofNat(n), P a) ↔ ∃ a < n, P a :=
+  exists_lt_natCast
 
 instance (o : NatOrdinal.{u}) : Small.{u} (Iio o) := inferInstanceAs (Small (Iio o.toOrdinal))
 
@@ -225,20 +263,7 @@ theorem toGame_natCast : ∀ n : ℕ, toGame n = n
 theorem toIGame_natCast_equiv (n : ℕ) : toIGame n ≈ n :=
   Game.mk_eq_mk.1 (by simp)
 
-@[simp]
-theorem forall_lt_natCast {P : NatOrdinal → Prop} (n : ℕ) :
-    (∀ a < (n : NatOrdinal), P a) ↔ ∀ a < n, P a := by
-  constructor
-  · 
-
 end NatOrdinal
 
-#exit
-
 attribute [simp] Nat.forall_lt_succ Nat.exists_lt_succ
-
-example : NatOrdinal.toIGame 3 ≈ 3 := by
-  rw [AntisymmRel]
-  rw [le_iff_forall_lf]
-
-  simp
+example : NatOrdinal.toIGame 3 ≈ 3 := by game_cmp

--- a/CombinatorialGames/IGame/Special.lean
+++ b/CombinatorialGames/IGame/Special.lean
@@ -93,17 +93,10 @@ def up : IGame :=
 @[simp] theorem leftMoves_up : leftMoves ↑ = {0} := leftMoves_ofSets ..
 @[simp] theorem rightMoves_up : rightMoves ↑ = {⋆} := rightMoves_ofSets ..
 
-@[simp]
-theorem up_pos : 0 < ↑ := by
-  rw [lt_iff_le_not_le, zero_lf, zero_le]
-  simp
+@[simp] theorem up_pos : 0 < ↑ := by game_cmp
 
-theorem up_fuzzy_star : ↑ ‖ ⋆ := by
-  rw [IncompRel, le_iff_forall_lf, le_iff_forall_lf]
-  simpa using up_pos.le
-
-theorem star_fuzzy_up : ⋆ ‖ ↑ :=
-  up_fuzzy_star.symm
+theorem up_fuzzy_star : ↑ ‖ ⋆ := by game_cmp
+theorem star_fuzzy_up : ⋆ ‖ ↑ := up_fuzzy_star.symm
 
 /-- See `IGame.up`. -/
 def _root_.SGame.up : SGame :=
@@ -127,17 +120,10 @@ def down : IGame :=
 @[simp] theorem neg_down : -↓ = ↑ := by simp [up, down]
 @[simp] theorem neg_up : -↑ = ↓ := by simp [up, down]
 
-@[simp]
-theorem down_neg : ↓ < 0 := by
-  rw [← zero_lt_neg, neg_down]
-  exact up_pos
+@[simp] theorem down_neg : ↓ < 0 := by game_cmp
 
-theorem down_fuzzy_star : ↓ ‖ ⋆ := by
-  rw [← neg_fuzzy_neg_iff, neg_down, neg_star]
-  exact up_fuzzy_star
-
-theorem star_fuzzy_down : ⋆ ‖ ↓ :=
-  down_fuzzy_star.symm
+theorem down_fuzzy_star : ↓ ‖ ⋆ := by game_cmp
+theorem star_fuzzy_down : ⋆ ‖ ↓ := down_fuzzy_star.symm
 
 /-- See `IGame.down`. -/
 def _root_.SGame.down : SGame :=

--- a/CombinatorialGames/IGame/Special.lean
+++ b/CombinatorialGames/IGame/Special.lean
@@ -62,15 +62,9 @@ def half : IGame :=
 @[simp] theorem leftMoves_half : leftMoves ½ = {0} := leftMoves_ofSets ..
 @[simp] theorem rightMoves_half : rightMoves ½ = {1} := rightMoves_ofSets ..
 
-theorem zero_lt_half : 0 < ½ := by
-  rw [lt_iff_le_not_le, zero_le, le_zero]; simpa using zero_lt_one.not_le
-
-theorem half_lt_one : ½ < 1 := by
-  rw [lt_iff_le_not_le, le_iff_forall_lf, le_iff_forall_lf]; simpa using zero_lt_one.not_le
-
-theorem half_add_half_equiv_one : ½ + ½ ≈ 1 := by
-  rw [AntisymmRel, le_iff_forall_lf, le_iff_forall_lf]
-  simp [zero_lt_half.not_le, half_lt_one.not_le, (add_pos zero_lt_half zero_lt_half).not_le]
+theorem zero_lt_half : 0 < ½ := by game_cmp
+theorem half_lt_one : ½ < 1 := by game_cmp
+theorem half_add_half_equiv_one : ½ + ½ ≈ 1 := by game_cmp
 
 /-- See `IGame.half`. -/
 def _root_.SGame.half : SGame :=
@@ -94,7 +88,6 @@ def up : IGame :=
 @[simp] theorem rightMoves_up : rightMoves ↑ = {⋆} := rightMoves_ofSets ..
 
 @[simp] theorem up_pos : 0 < ↑ := by game_cmp
-
 theorem up_fuzzy_star : ↑ ‖ ⋆ := by game_cmp
 theorem star_fuzzy_up : ⋆ ‖ ↑ := up_fuzzy_star.symm
 
@@ -121,7 +114,6 @@ def down : IGame :=
 @[simp] theorem neg_up : -↑ = ↓ := by simp [up, down]
 
 @[simp] theorem down_neg : ↓ < 0 := by game_cmp
-
 theorem down_fuzzy_star : ↓ ‖ ⋆ := by game_cmp
 theorem star_fuzzy_down : ⋆ ‖ ↓ := down_fuzzy_star.symm
 


### PR DESCRIPTION
We implement a simple tactic capable of proving simple inequalities on games. The idea is to use this for computation, instead of trying to square the circle through barely functional decidability tactics.