### PR TITLE
feat: surreal division!

### DIFF
--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -17,6 +17,7 @@ import CombinatorialGames.Nimber.Basic
 import CombinatorialGames.Nimber.Field
 import CombinatorialGames.Register
 import CombinatorialGames.Surreal.Basic
+import CombinatorialGames.Surreal.Division
 import CombinatorialGames.Surreal.Multiplication
 import CombinatorialGames.Surreal.Ordinal
 import CombinatorialGames.Test

--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -191,6 +191,24 @@ protected theorem sub_le_iff_le_add {x y z : IGame} : x - z ≤ y ↔ x ≤ y + 
 protected theorem le_sub_iff_add_le {x y z : IGame} : x ≤ z - y ↔ x + y ≤ z :=
   @le_sub_iff_add_le Game _ _ _ (.mk x) (.mk y) (.mk z)
 
+protected theorem sub_lt_iff_lt_add {x y z : IGame} : x - z < y ↔ x < y + z :=
+  @sub_lt_iff_lt_add Game _ _ _ (.mk x) (.mk y) (.mk z)
+
+protected theorem lt_sub_iff_add_lt {x y z : IGame} : x < z - y ↔ x + y < z :=
+  @lt_sub_iff_add_lt Game _ _ _ (.mk x) (.mk y) (.mk z)
+
+protected theorem sub_nonneg {x y : IGame} : 0 ≤ x - y ↔ y ≤ x :=
+  @sub_nonneg Game _ _ _ (.mk x) (.mk y)
+
+protected theorem sub_nonpos {x y : IGame} : x - y ≤ 0 ↔ x ≤ y :=
+  @sub_nonpos Game _ _ _ (.mk x) (.mk y)
+
+protected theorem sub_pos {x y : IGame} : 0 < x - y ↔ y < x :=
+  @sub_pos Game _ _ _ (.mk x) (.mk y)
+
+protected theorem sub_neg {x y : IGame} : x - y < 0 ↔ x < y :=
+  @sub_neg Game _ _ _ (.mk x) (.mk y)
+
 theorem mul_add_equiv (x y z : IGame) : x * (y + z) ≈ x * y + x * z :=
   Game.mk_eq_mk.1 (Game.mk_mul_add x y z)
 

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -1141,6 +1141,137 @@ theorem mulOption_neg (x y a b : IGame) : mulOption (-x) (-y) a b = mulOption x 
 /-! Distributivity and associativity only hold up to equivalence; we prove this in
 `CombinatorialGames.Game.Basic`. -/
 
+/-! ### Division -/
+
+/-
+-- TODO: upstream
+theorem small_preimage {α β : Type*} {f : α → β} (hf : Function.Injective f)
+    (s : Set β) [Small.{u} s] : Small.{u} (f ⁻¹' s) := by
+  let g : (f ⁻¹' s) → s := Subtype.coind (fun x ↦ f x.1) (by simp)
+  exact small_of_injective (f := g) (Subtype.coind_injective _ (hf.comp Subtype.val_injective))
+-/
+
+/-- An auxiliary inductive type to enumerate the options of `IGame.inv`. -/
+private inductive InvTy (l r : Type u) : Bool → Type u
+  | zero : InvTy l r false
+  | left₁ : r → InvTy l r false → InvTy l r false
+  | left₂ : l → InvTy l r true → InvTy l r false
+  | right₁ : l → InvTy l r false → InvTy l r true
+  | right₂ : r → InvTy l r true → InvTy l r true
+
+private def InvTy.val' {x : IGame}
+    (IHl : Shrink x.leftMoves → IGame) (IHr : Shrink x.rightMoves → IGame)
+    (b : Bool) : InvTy (Shrink x.leftMoves) (Shrink x.rightMoves) b → IGame
+  | InvTy.zero => 0
+  | InvTy.left₁ i j => (1 + ((equivShrink _).symm i - x) * val' IHl IHr _ j) * IHr i
+  | InvTy.left₂ i j => (1 + ((equivShrink _).symm i - x) * val' IHl IHr _ j) * IHl i
+  | InvTy.right₁ i j => (1 + ((equivShrink _).symm i - x) * val' IHl IHr _ j) * IHl i
+  | InvTy.right₂ i j => (1 + ((equivShrink _).symm i - x) * val' IHl IHr _ j) * IHr i
+
+private def inv' (x : IGame.{u}) : IGame.{u} :=
+  let IHl : Shrink x.leftMoves → IGame := fun x ↦ inv' (Subtype.val <| (equivShrink _).symm x)
+  let IHr : Shrink x.rightMoves → IGame := fun x ↦ inv' (Subtype.val <| (equivShrink _).symm x)
+  {.range (InvTy.val' IHl IHr false) | .range (InvTy.val' IHl IHr true)}ᴵ
+termination_by x
+decreasing_by igame_wf
+
+private def InvTy.val (x : IGame) (b : Bool)
+    (i : InvTy (Shrink x.leftMoves) (Shrink x.rightMoves) b) : IGame :=
+  i.val' (inv' ∘ Subtype.val ∘ (equivShrink _).symm) (inv' ∘ Subtype.val ∘ (equivShrink _).symm) b
+
+/-- The inverse of `x = {s | t}ᴵ` is `{s' | t'}ᴵ`, where `s'` and `t'` are the smallest sets such
+that `0 ∈ s'`, and such that `(1 + (z - x) * a) / z, (1 + (y - x) * b) / y ∈ s'`,
+`(1 + (y - x) * a) / y, (1 + (z - x) * b) / z ∈ t'` for `y ∈ s`, `z ∈ t`, `a ∈ s'`, `b ∈ t'`.
+
+When `x` is a numeric game with no negative left options, we have `x * x⁻¹ ≈ 1`. -/
+instance : Inv IGame where
+  inv := inv'
+
+instance : Div IGame where
+  div x y := x * y⁻¹
+
+protected theorem div_eq_mul_inv (x y : IGame) : x / y = x * y⁻¹ := rfl
+
+private theorem inv_eq (x : IGame.{u}) :
+    x⁻¹ = {.range (InvTy.val x false) | .range (InvTy.val x true)}ᴵ := by
+  change inv' x = _
+  rw [inv']
+  rfl
+
+/-- The general option of `x⁻¹` looks like `(1 + (y - x) * a) / y`, for `y` an option of `x`, and
+`a` some other "earlier" option of `x⁻¹`. -/
+def invOption (x y a : IGame) : IGame :=
+  (1 + (y - x) * a) / y
+
+theorem zero_mem_leftMoves_inv (x : IGame) : 0 ∈ (x⁻¹).leftMoves := by
+  rw [inv_eq, leftMoves_ofSets]
+  exact ⟨InvTy.zero, rfl⟩
+
+theorem invOption_right_left_mem_leftMoves_inv {x y a : IGame}
+    (hy : y ∈ x.rightMoves) (ha : a ∈ (x⁻¹).leftMoves) : invOption x y a ∈ (x⁻¹).leftMoves := by
+  rw [inv_eq, leftMoves_ofSets] at *
+  obtain ⟨i, rfl⟩ := ha
+  use InvTy.left₁ (equivShrink _ ⟨_, hy⟩) i
+  simp [InvTy.val, InvTy.val']
+  rfl
+
+theorem invOption_left_right_mem_leftMoves_inv {x y a : IGame}
+    (hy : y ∈ x.leftMoves) (ha : a ∈ (x⁻¹).rightMoves) : invOption x y a ∈ (x⁻¹).leftMoves := by
+  rw [inv_eq, leftMoves_ofSets, rightMoves_ofSets] at *
+  obtain ⟨i, rfl⟩ := ha
+  use InvTy.left₂ (equivShrink _ ⟨_, hy⟩) i
+  simp [InvTy.val, InvTy.val']
+  rfl
+
+theorem invOption_left_left_mem_rightMoves_inv {x y a : IGame}
+    (hy : y ∈ x.leftMoves) (ha : a ∈ (x⁻¹).leftMoves) : invOption x y a ∈ (x⁻¹).rightMoves := by
+  rw [inv_eq, leftMoves_ofSets, rightMoves_ofSets] at *
+  obtain ⟨i, rfl⟩ := ha
+  use InvTy.right₁ (equivShrink _ ⟨_, hy⟩) i
+  simp [InvTy.val, InvTy.val']
+  rfl
+
+theorem invOption_right_right_mem_rightMoves_inv {x y a : IGame}
+    (hy : y ∈ x.rightMoves) (ha : a ∈ (x⁻¹).rightMoves) : invOption x y a ∈ (x⁻¹).rightMoves := by
+  rw [inv_eq, rightMoves_ofSets] at *
+  obtain ⟨i, rfl⟩ := ha
+  use InvTy.right₂ (equivShrink _ ⟨_, hy⟩) i
+  simp [InvTy.val, InvTy.val']
+  rfl
+
+set_option linter.unnecessarySimpa false in
+/-- An induction principle on left and right moves of `x⁻¹`. -/
+theorem invRecOn (x : IGame) {P : ∀ y ∈ (x⁻¹).leftMoves, Prop} {Q : ∀ y ∈ (x⁻¹).rightMoves, Prop}
+    {y z : IGame} (hy : y ∈ (x⁻¹).leftMoves) (hz : z ∈ (x⁻¹).rightMoves)
+    (zero : P 0 (zero_mem_leftMoves_inv x))
+    (left₁ : ∀ y (hy : y ∈ x.rightMoves), ∀ a (ha : a ∈ (x⁻¹).leftMoves), P a ha →
+      P _ (invOption_right_left_mem_leftMoves_inv hy ha))
+    (left₂ : ∀ y (hy : y ∈ x.leftMoves), ∀ a (ha : a ∈ (x⁻¹).rightMoves), Q a ha →
+      P _ (invOption_left_right_mem_leftMoves_inv hy ha))
+    (right₁ : ∀ y (hy : y ∈ x.leftMoves), ∀ a (ha : a ∈ (x⁻¹).leftMoves), P a ha →
+      Q _ (invOption_left_left_mem_rightMoves_inv hy ha))
+    (right₂ : ∀ y (hy : y ∈ x.rightMoves), ∀ a (ha : a ∈ (x⁻¹).rightMoves), Q a ha →
+      Q _ (invOption_right_right_mem_rightMoves_inv hy ha)) : P y hy ∧ Q z hz := by
+  suffices ∀ b : Bool, ∀ i, if hb : b then
+      Q (InvTy.val x b i) (by subst hb; simp [inv_eq]) else
+      P (InvTy.val x b i) (by rw [Bool.not_eq_true] at hb; subst hb; simp [inv_eq]) by
+    rw [inv_eq, leftMoves_ofSets] at hy
+    rw [inv_eq, rightMoves_ofSets] at hz
+    obtain ⟨i, rfl⟩ := hy
+    obtain ⟨j, rfl⟩ := hz
+    have hi := this false i
+    have hj := this true j
+    simp_all
+  intro b i
+  induction i
+  · simpa
+  all_goals simp only [Bool.false_eq_true]
+  on_goal 1 => apply left₁
+  on_goal 4 => apply left₂
+  on_goal 7 => apply right₁
+  on_goal 10 => apply right₂
+  all_goals simpa
+
 end IGame
 
 /-! ### Tactic tests -/

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -1201,13 +1201,16 @@ private theorem inv_eq (x : IGame.{u}) :
 def invOption (x y a : IGame) : IGame :=
   (1 + (y - x) * a) / y
 
-theorem zero_mem_leftMoves_inv (x : IGame) : 0 ∈ (x⁻¹).leftMoves := by
+theorem zero_mem_leftMoves_inv (x : IGame) : 0 ∈ x⁻¹.leftMoves := by
   rw [inv_eq, leftMoves_ofSets]
   exact ⟨InvTy.zero, rfl⟩
 
+theorem inv_nonneg (x : IGame) : 0 ⧏ x⁻¹ :=
+  leftMove_lf (zero_mem_leftMoves_inv x)
+
 theorem invOption_right_left_mem_leftMoves_inv {x y a : IGame}
-    (hy : y ∈ x.rightMoves) (ha : a ∈ (x⁻¹).leftMoves) :
-    invOption x y a ∈ (x⁻¹).leftMoves := by
+    (hy : y ∈ x.rightMoves) (ha : a ∈ x⁻¹.leftMoves) :
+    invOption x y a ∈ x⁻¹.leftMoves := by
   rw [inv_eq, leftMoves_ofSets] at *
   obtain ⟨i, rfl⟩ := ha
   use InvTy.left₁ (equivShrink _ ⟨_, hy⟩) i
@@ -1215,8 +1218,8 @@ theorem invOption_right_left_mem_leftMoves_inv {x y a : IGame}
   rfl
 
 theorem invOption_left_right_mem_leftMoves_inv {x y a : IGame}
-    (hy : y ∈ x.leftMoves) (hy' : 0 < y) (ha : a ∈ (x⁻¹).rightMoves) :
-    invOption x y a ∈ (x⁻¹).leftMoves := by
+    (hy : y ∈ x.leftMoves) (hy' : 0 < y) (ha : a ∈ x⁻¹.rightMoves) :
+    invOption x y a ∈ x⁻¹.leftMoves := by
   rw [inv_eq, leftMoves_ofSets, rightMoves_ofSets] at *
   obtain ⟨i, rfl⟩ := ha
   use InvTy.left₂ (equivShrink _ ⟨_, hy, hy'⟩) i
@@ -1224,8 +1227,8 @@ theorem invOption_left_right_mem_leftMoves_inv {x y a : IGame}
   rfl
 
 theorem invOption_left_left_mem_rightMoves_inv {x y a : IGame}
-    (hy : y ∈ x.leftMoves) (hy' : 0 < y) (ha : a ∈ (x⁻¹).leftMoves) :
-    invOption x y a ∈ (x⁻¹).rightMoves := by
+    (hy : y ∈ x.leftMoves) (hy' : 0 < y) (ha : a ∈ x⁻¹.leftMoves) :
+    invOption x y a ∈ x⁻¹.rightMoves := by
   rw [inv_eq, leftMoves_ofSets, rightMoves_ofSets] at *
   obtain ⟨i, rfl⟩ := ha
   use InvTy.right₁ (equivShrink _ ⟨_, hy, hy'⟩) i
@@ -1233,8 +1236,8 @@ theorem invOption_left_left_mem_rightMoves_inv {x y a : IGame}
   rfl
 
 theorem invOption_right_right_mem_rightMoves_inv {x y a : IGame}
-    (hy : y ∈ x.rightMoves) (ha : a ∈ (x⁻¹).rightMoves) :
-    invOption x y a ∈ (x⁻¹).rightMoves := by
+    (hy : y ∈ x.rightMoves) (ha : a ∈ x⁻¹.rightMoves) :
+    invOption x y a ∈ x⁻¹.rightMoves := by
   rw [inv_eq, rightMoves_ofSets] at *
   obtain ⟨i, rfl⟩ := ha
   use InvTy.right₂ (equivShrink _ ⟨_, hy⟩) i
@@ -1243,17 +1246,17 @@ theorem invOption_right_right_mem_rightMoves_inv {x y a : IGame}
 
 set_option linter.unnecessarySimpa false in
 /-- An induction principle on left and right moves of `x⁻¹`. -/
-theorem invRec (x : IGame) {P : ∀ y ∈ (x⁻¹).leftMoves, Prop} {Q : ∀ y ∈ (x⁻¹).rightMoves, Prop}
+theorem invRec (x : IGame) {P : ∀ y ∈ x⁻¹.leftMoves, Prop} {Q : ∀ y ∈ x⁻¹.rightMoves, Prop}
     (zero : P 0 (zero_mem_leftMoves_inv x))
-    (left₁ : ∀ y (hy : y ∈ x.rightMoves), ∀ a (ha : a ∈ (x⁻¹).leftMoves), P a ha →
+    (left₁ : ∀ y (hy : y ∈ x.rightMoves), ∀ a (ha : a ∈ x⁻¹.leftMoves), P a ha →
       P _ (invOption_right_left_mem_leftMoves_inv hy ha))
-    (left₂ : ∀ y (hy : y ∈ x.leftMoves) (hy' : 0 < y), ∀ a (ha : a ∈ (x⁻¹).rightMoves), Q a ha →
+    (left₂ : ∀ y (hy : y ∈ x.leftMoves) (hy' : 0 < y), ∀ a (ha : a ∈ x⁻¹.rightMoves), Q a ha →
       P _ (invOption_left_right_mem_leftMoves_inv hy hy' ha))
-    (right₁ : ∀ y (hy : y ∈ x.leftMoves) (hy' : 0 < y), ∀ a (ha : a ∈ (x⁻¹).leftMoves), P a ha →
+    (right₁ : ∀ y (hy : y ∈ x.leftMoves) (hy' : 0 < y), ∀ a (ha : a ∈ x⁻¹.leftMoves), P a ha →
       Q _ (invOption_left_left_mem_rightMoves_inv hy hy' ha))
-    (right₂ : ∀ y (hy : y ∈ x.rightMoves) , ∀ a (ha : a ∈ (x⁻¹).rightMoves), Q a ha →
+    (right₂ : ∀ y (hy : y ∈ x.rightMoves) , ∀ a (ha : a ∈ x⁻¹.rightMoves), Q a ha →
       Q _ (invOption_right_right_mem_rightMoves_inv hy ha)) :
-    (∀ y (hy : y ∈ (x⁻¹).leftMoves), P y hy) ∧ (∀ y (hy : y ∈ (x⁻¹).rightMoves), Q y hy) := by
+    (∀ y (hy : y ∈ x⁻¹.leftMoves), P y hy) ∧ (∀ y (hy : y ∈ x⁻¹.rightMoves), Q y hy) := by
   suffices ∀ b : Bool, ∀ i, if hb : b then
       Q (InvTy.val x b i) (by subst hb; simp [inv_eq]) else
       P (InvTy.val x b i) (by rw [Bool.not_eq_true] at hb; subst hb; simp [inv_eq]) by

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -1184,8 +1184,8 @@ such that `0 ∈ s'`, and such that `(1 + (z - x) * a) / z, (1 + (y - x) * b) / 
 `(1 + (y - x) * a) / y, (1 + (z - x) * b) / z ∈ t'` for `y ∈ s` positive, `z ∈ t`, `a ∈ s'`, and
 `b ∈ t'`.
 
-When `x` is a positive numeric game, then `x * x⁻¹ ≈ 1`. The value of this function on any other
-game should be treated as a junk value. -/
+If `x` is a positive numeric game, then `x * x⁻¹ ≈ 1`. The value of this function on any other game
+should be treated as a junk value. -/
 instance : Inv IGame where
   inv := inv'
 
@@ -1202,6 +1202,7 @@ private theorem inv_eq (x : IGame.{u}) :
 
 /-- The general option of `x⁻¹` looks like `(1 + (y - x) * a) / y`, for `y` an option of `x`, and
 `a` some other "earlier" option of `x⁻¹`. -/
+@[pp_nodot]
 def invOption (x y a : IGame) : IGame :=
   (1 + (y - x) * a) / y
 

--- a/CombinatorialGames/Mathlib/Order.lean
+++ b/CombinatorialGames/Mathlib/Order.lean
@@ -1,4 +1,4 @@
-import Mathlib.Order.Basic
+import Mathlib.Order.Antisymmetrization
 
 theorem not_le_of_le_of_not_le {α : Type*} [Preorder α] {a b c : α} (h₁ : a ≤ b) (h₂ : ¬ c ≤ b) :
     ¬ c ≤ a :=
@@ -7,3 +7,21 @@ theorem not_le_of_le_of_not_le {α : Type*} [Preorder α] {a b c : α} (h₁ : a
 theorem not_le_of_not_le_of_le {α : Type*} [Preorder α] {a b c : α} (h₁ : ¬ b ≤ a) (h₂ : b ≤ c) :
     ¬ c ≤ a :=
   fun h ↦ h₁ (h₂.trans h)
+
+theorem not_lt_of_antisymmRel {α} [Preorder α] {x y : α} (h : AntisymmRel (· ≤ ·) x y) : ¬ x < y :=
+  h.ge.not_lt
+
+theorem not_gt_of_antisymmRel {α} [Preorder α] {x y : α} (h : AntisymmRel (· ≤ ·) x y) : ¬ y < x :=
+  h.le.not_lt
+
+alias AntisymmRel.not_lt := not_lt_of_antisymmRel
+alias AntisymmRel.not_gt := not_gt_of_antisymmRel
+
+theorem not_antisymmRel_of_lt {α} [Preorder α] {x y : α} : x < y → ¬ AntisymmRel (· ≤ ·) x y :=
+  imp_not_comm.1 not_lt_of_antisymmRel
+
+theorem not_antisymmRel_of_gt {α} [Preorder α] {x y : α} : y < x → ¬ AntisymmRel (· ≤ ·) x y :=
+  imp_not_comm.1 not_gt_of_antisymmRel
+
+alias LT.lt.not_antisymmRel := not_antisymmRel_of_lt
+alias LT.lt.not_antisymmRel_symm := not_antisymmRel_of_gt

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -125,6 +125,14 @@ protected theorem not_le [Numeric x] [Numeric y] : ¬ x ≤ y ↔ y < x :=
 protected theorem not_lt [Numeric x] [Numeric y] : ¬ x < y ↔ y ≤ x :=
   not_iff_comm.1 Numeric.not_le
 
+protected theorem le_or_lt (x y : IGame) [Numeric x] [Numeric y] : x ≤ y ∨ y < x := by
+  rw [← Numeric.not_le]
+  exact em _
+
+protected theorem lt_or_le (x y : IGame) [Numeric x] [Numeric y] : x < y ∨ y ≤ x := by
+  rw [← Numeric.not_lt]
+  exact em _
+
 theorem not_fuzzy (x y : IGame) [Numeric x] [Numeric y] : ¬ x ‖ y := by
   simpa [not_incompRel_iff] using Numeric.le_total x y
 

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -215,8 +215,14 @@ birthday that fits in it -/
 def Fits (x y : IGame) : Prop :=
   (∀ z ∈ y.leftMoves, z ⧏ x) ∧ (∀ z ∈ y.rightMoves, x ⧏ z)
 
+theorem fits_of_equiv {x y : IGame} (h : x ≈ y) : Fits x y :=
+  ⟨fun _ hz ↦ not_le_of_not_le_of_le (leftMove_lf hz) h.ge,
+    fun _ hz ↦ not_le_of_le_of_not_le h.le (lf_rightMove hz) ⟩
+
+alias AntisymmRel.Fits := fits_of_equiv
+
 theorem Fits.refl (x : IGame) : x.Fits x :=
-  ⟨fun _ ↦ leftMove_lf, fun _ ↦ lf_rightMove⟩
+  fits_of_equiv .rfl
 
 @[simp]
 theorem fits_neg_iff {x y : IGame} : Fits (-x) (-y) ↔ Fits x y := by
@@ -257,13 +263,13 @@ theorem Fits.equiv_of_forall_birthday_le {x y : IGame} [Numeric x] (hx : x.Fits 
   · exact fun z hz h ↦ (birthday_lt_of_mem_rightMoves hz).not_le <| H z (.of_mem_rightMoves hz) h
 
 /-- A specialization of the simplicity theorem to `0`. -/
-theorem equiv_zero_of_fits {x : IGame} [Numeric x] (hx : Fits 0 x) : x ≈ 0 := by
-  apply (hx.equiv_of_forall_not_fits _ _).symm <;> simp
+theorem fits_zero_iff_equiv {x : IGame} [Numeric x] : Fits 0 x ↔ x ≈ 0 := by
+  refine ⟨fun hx ↦ (hx.equiv_of_forall_not_fits ?_ ?_).symm, fun h ↦ fits_of_equiv h.symm⟩ <;> simp
 
 /-- A specialization of the simplicity theorem to `1`. -/
-theorem equiv_one_of_fits {x : IGame} [Numeric x] (hx : Fits 1 x) (h : ¬ Fits 0 x) : x ≈ 1 := by
+theorem equiv_one_of_fits {x : IGame} [Numeric x] (hx : Fits 1 x) (h : ¬ x ≈ 0) : x ≈ 1 := by
   apply (hx.equiv_of_forall_not_fits _ _).symm
-  · simpa
+  · simpa [fits_zero_iff_equiv]
   · simp
 
 end IGame

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -32,8 +32,9 @@ form a linear ordered commutative ring.
 
 ## TODO
 
-- Define the field structure on the surreals.
+- Prove that surreals with finite birthday are dyadic rationals.
 - Build the embedding from reals into surreals.
+- Define sign sequences.
 -/
 
 universe u
@@ -197,6 +198,10 @@ protected instance natCast : ∀ n : ℕ, Numeric n
 protected instance ofNat (n : ℕ) [n.AtLeastTwo] : Numeric ofNat(n) :=
   inferInstanceAs (Numeric n)
 
+/-- Note that this assumes `x⁻¹` numeric. -/
+theorem inv_pos (x : IGame) [Numeric x⁻¹] : 0 < x⁻¹ :=
+  Numeric.lt_of_not_le (inv_nonneg x)
+
 end Numeric
 
 /-! ### Simplicity theorem -/
@@ -250,6 +255,16 @@ theorem Fits.equiv_of_forall_birthday_le {x y : IGame} [Numeric x] (hx : x.Fits 
   apply hx.equiv_of_forall_not_fits
   · exact fun z hz h ↦ (birthday_lt_of_mem_leftMoves hz).not_le <| H z (.of_mem_leftMoves hz) h
   · exact fun z hz h ↦ (birthday_lt_of_mem_rightMoves hz).not_le <| H z (.of_mem_rightMoves hz) h
+
+/-- A specialization of the simplicity theorem to `0`. -/
+theorem equiv_zero_of_fits {x : IGame} [Numeric x] (hx : Fits 0 x) : x ≈ 0 := by
+  apply (hx.equiv_of_forall_not_fits _ _).symm <;> simp
+
+/-- A specialization of the simplicity theorem to `1`. -/
+theorem equiv_one_of_fits {x : IGame} [Numeric x] (hx : Fits 1 x) (h : ¬ Fits 0 x) : x ≈ 1 := by
+  apply (hx.equiv_of_forall_not_fits _ _).symm
+  · simpa
+  · simp
 
 end IGame
 

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -46,18 +46,6 @@ protected theorem IGame.Numeric.mul_pos_of_neg_of_neg {x y : IGame} [Numeric x] 
 
 namespace Surreal.Division
 
-theorem numeric_option_inv {x : IGame} [Numeric x]
-    (hl : ∀ y ∈ x.leftMoves, Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹) :
-    (∀ y ∈ x⁻¹.leftMoves, Numeric y) ∧ (∀ y ∈ x⁻¹.rightMoves, Numeric y) := by
-  apply invRec x Numeric.zero
-  all_goals
-    intro y hy
-    intros
-    first |
-      have := Numeric.of_mem_leftMoves hy; have := hl _ hy |
-      have := Numeric.of_mem_rightMoves hy; have := hr _ hy
-    infer_instance
-
 theorem one_neg_mul_invOption (x : IGame) {y : IGame} (hy : y * y⁻¹ ≈ 1) (a : IGame)
     [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] :
     1 - x * invOption x y a ≈ (1 - x * a) * (y - x) / y := by
@@ -66,9 +54,32 @@ theorem one_neg_mul_invOption (x : IGame) {y : IGame} (hy : y * y⁻¹ ≈ 1) (a
   simp only [one_mul, sub_eq_add_neg, add_mul, hy]
   ring
 
+theorem mulOption_self_inv (x : IGame) {y : IGame} (hy : y * y⁻¹ ≈ 1) (a : IGame)
+    [Numeric x] [Numeric x⁻¹] [Numeric y] [Numeric y⁻¹] [Numeric a] :
+    mulOption x x⁻¹ y a ≈ 1 + (x⁻¹ - invOption x y a) * y := by
+  rw [mul_comm] at hy
+  rw [← Surreal.mk_eq_mk] at *
+  dsimp [mulOption, invOption] at *
+  simp only [sub_eq_add_neg, add_mul, neg_mul, mul_assoc, hy]
+  ring
+
+  #exit
+
+theorem numeric_option_inv {x : IGame} [Numeric x]
+    (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹) :
+    (∀ y ∈ x⁻¹.leftMoves, Numeric y) ∧ (∀ y ∈ x⁻¹.rightMoves, Numeric y) := by
+  apply invRec x Numeric.zero
+  all_goals
+    intro y hy hy'
+    intros
+    first |
+      have := Numeric.of_mem_leftMoves hy; have := hl _ hy hy' |
+      have := Numeric.of_mem_rightMoves hy; have := hr _ hy
+    infer_instance
+
 theorem mul_inv_option_mem (x : IGame) [Numeric x]
-    (hl : ∀ y ∈ x.leftMoves, Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
-    (hl' : ∀ y ∈ x.leftMoves, y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
+    (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
+    (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
     (∀ y ∈ x⁻¹.leftMoves, x * y < 1) ∧ (∀ y ∈ x⁻¹.rightMoves, 1 < x * y) := by
   apply invRec x
   · simp
@@ -83,18 +94,18 @@ theorem mul_inv_option_mem (x : IGame) [Numeric x]
       exact Numeric.lt_rightMove hy
   · intro y hy hy' a ha h
     have := Numeric.of_mem_leftMoves hy
-    have := hl y hy
+    have := hl y hy hy'
     have := (numeric_option_inv hl hr).1 a ha
-    rw [← IGame.sub_pos, (one_neg_mul_invOption x (hl' y hy) a).lt_congr_right]
+    rw [← IGame.sub_pos, (one_neg_mul_invOption x (hl' y hy hy') a).lt_congr_right]
     apply Numeric.mul_pos (Numeric.mul_pos_of_neg_of_neg _ _) (IGame.inv_pos y)
     · rwa [IGame.sub_neg]
     · rw [IGame.sub_neg]
       exact Numeric.leftMove_lt hy
   · intro y hy hy' a ha h
     have := Numeric.of_mem_leftMoves hy
-    have := hl y hy
+    have := hl y hy hy'
     have := (numeric_option_inv hl hr).1 a ha
-    rw [← IGame.sub_neg, (one_neg_mul_invOption x (hl' y hy) a).lt_congr_left]
+    rw [← IGame.sub_neg, (one_neg_mul_invOption x (hl' y hy hy') a).lt_congr_left]
     apply Numeric.mul_neg_of_neg_of_pos (Numeric.mul_neg_of_pos_of_neg _ _) (IGame.inv_pos y)
     · rwa [IGame.sub_pos]
     · rw [IGame.sub_neg]
@@ -131,42 +142,6 @@ theorem one_neg_mul_invOption (x : IGame) {y : IGame} (hy : Game.mk (y * y⁻¹)
   Game.mk_mul_assoc, Game.mk_add_mul, Game.mk_mul_add]-/
 -/
 #exit
-
-private theorem numeric_inv' (x : IGame) [Numeric x] :
-    (∀ y ∈ (x⁻¹).leftMoves, Numeric y) ∧ (∀ y ∈ (x⁻¹).rightMoves, Numeric y) := by
-  refine invRec x ?_ ?_ ?_ ?_ ?_
-  · infer_instance
-  · intro y hy a ha _
-    rw [invOption, IGame.div_eq_mul_inv]
-    have := Numeric.of_mem_rightMoves hy
-    have := numeric_inv' y
-    infer_instance
-  · sorry
-  · sorry
-  · sorry
-termination_by x
-decreasing_by igame_wf
-
-#exit
-private theorem mul_move_inv {x : IGame} [Numeric x] (h : 0 < x) :
-    (∀ y ∈ (x⁻¹).leftMoves, x * y < 1) ∧ (∀ y ∈ (x⁻¹).rightMoves, 1 < x * y) := by
-  refine invRec x ?_ ?_ ?_ ?_ ?_
-  · simp
-  · intro y hy a ha hxa
-    rw [invOption, IGame.div_eq_mul_inv]
-    sorry
-  · sorry
-  · sorry
-  · sorry
-
-#exit
-theorem mul_leftMove_inv_lt {x y : IGame} [Numeric x] (h : 0 < x) (hy : y ∈ (x⁻¹).leftMoves) :
-    x * y < 1 :=
-  (mul_move_inv h).1 y hy
-
-theorem lt_mul_rightMove_inv {x y : IGame} [Numeric x] (h : 0 < x) (hy : y ∈ (x⁻¹).rightMoves) :
-    1 < x * y :=
-  (mul_move_inv h).2 y hy
 
 end IGame
 end

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -6,11 +6,67 @@ noncomputable section
 
 namespace IGame
 
+instance (x y a : IGame) [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] :
+    Numeric (invOption x y a) :=
+  inferInstanceAs (Numeric (_ * _))
+
+theorem numeric_option_inv {x : IGame} [Numeric x]
+    (hl : ∀ y ∈ x.leftMoves, Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹) :
+    (∀ y ∈ x⁻¹.leftMoves, Numeric y) ∧ (∀ y ∈ x⁻¹.rightMoves, Numeric y) := by
+  apply invRec x Numeric.zero
+  all_goals
+    intro y hy
+    intros
+    first |
+      have := Numeric.of_mem_leftMoves hy; have := hl _ hy |
+      have := Numeric.of_mem_rightMoves hy; have := hr _ hy
+    infer_instance
+#exit
+/-
+theorem one_neg_mul_invOption (x : IGame) {y : IGame} (hy : Game.mk (y * y⁻¹) = 1) (a : IGame) :
+    Game.mk (1 - x * invOption x y a) = Game.mk ((1 - x * a) * (y - x) / y) := by
+  rw [IGame.div_eq_mul_inv, Game.mk_mul_assoc, Game.mk_sub_mul, one_mul, Game.mk_sub_mul,
+    mul_comm (y - x), ← Game.mk_mul_assoc, Game.mk_mul_sub]
+  rw [invOption, Game.mk_sub, Game.mk_one, IGame.div_eq_mul_inv, mul_comm, Game.mk_mul_assoc,
+    Game.mk_add_mul, Game.mk_mul_assoc, Game.mk_sub_mul, one_mul]
+  simp only [← Game.mk_mul_assoc, ← sub_add, ← sub_sub, hy, mul_comm]
+  congr 2
+  rw [Game.mk_mul_assoc, Game.mk_mul_assoc, mul_comm, Game.mk_mul_assoc]
+
+  -- [mul_comm, Game.mk_mul_assoc]
+  · rw [mul_comm]
+  · sorry
+
+  abel_nf
+  congr 2
+  /-simp [invOption, IGame.div_eq_mul_inv, sub_eq_add_neg,
+  Game.mk_mul_assoc, Game.mk_add_mul, Game.mk_mul_add]-/
+-/
+#exit
+
+private theorem numeric_inv' (x : IGame) [Numeric x] :
+    (∀ y ∈ (x⁻¹).leftMoves, Numeric y) ∧ (∀ y ∈ (x⁻¹).rightMoves, Numeric y) := by
+  refine invRec x ?_ ?_ ?_ ?_ ?_
+  · infer_instance
+  · intro y hy a ha _
+    rw [invOption, IGame.div_eq_mul_inv]
+    have := Numeric.of_mem_rightMoves hy
+    have := numeric_inv' y
+    infer_instance
+  · sorry
+  · sorry
+  · sorry
+termination_by x
+decreasing_by igame_wf
+
+#exit
 private theorem mul_move_inv {x : IGame} [Numeric x] (h : 0 < x) :
     (∀ y ∈ (x⁻¹).leftMoves, x * y < 1) ∧ (∀ y ∈ (x⁻¹).rightMoves, 1 < x * y) := by
   refine invRec x ?_ ?_ ?_ ?_ ?_
   · simp
-  · sorry
+  · intro y hy a ha hxa
+    rw [invOption, IGame.div_eq_mul_inv]
+    sorry
   · sorry
   · sorry
   · sorry

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -232,7 +232,7 @@ private noncomputable def inv' (x : IGame) : IGame := by
 private theorem inv'_zero : inv' 0 = 0 := by
   simp [inv']
 
-protected instance Numeric.inv' {x : IGame} [Numeric x] : Numeric (inv' x) := by
+private instance {x : IGame} [Numeric x] : Numeric (inv' x) := by
   unfold inv'
   obtain h | h | h := Numeric.lt_or_equiv_or_gt x 0
   · simpa [h, h.asymm] using Numeric.inv (IGame.zero_lt_neg.2 h)

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -4,6 +4,24 @@ import Mathlib.Tactic.FieldSimp
 
 open IGame
 
+-- TODO: upstream
+theorem not_antisymmRel_of_lt {α} [Preorder α] {x y : α} (h : x < y) : ¬ AntisymmRel (· ≤ ·) x y :=
+  fun h' ↦ h.not_le h'.ge
+
+theorem not_antisymmRel_of_gt {α} [Preorder α] {x y : α} (h : y < x) : ¬ AntisymmRel (· ≤ ·) x y :=
+  fun h' ↦ h.not_le h'.le
+
+alias LT.lt.not_antisymmRel := not_antisymmRel_of_lt
+alias LT.lt.not_antisymmRel_symm := not_antisymmRel_of_gt
+
+theorem IGame.Numeric.le_or_lt (x y : IGame) [Numeric x] [Numeric y] : x ≤ y ∨ y < x := by
+  rw [← Numeric.not_le]
+  exact em _
+
+theorem IGame.Numeric.lt_or_le (x y : IGame) [Numeric x] [Numeric y] : x < y ∨ y ≤ x := by
+  rw [← Numeric.not_lt]
+  exact em _
+
 namespace Surreal.Division
 
 lemma one_neg_mul_invOption (x : IGame) {y : IGame} (hy : y * y⁻¹ ≈ 1) (a : IGame)
@@ -22,6 +40,17 @@ lemma mulOption_self_inv (x : IGame) {y : IGame} (hy : y * y⁻¹ ≈ 1) (a : IG
   dsimp [mulOption, invOption, mk_div'] at *
   simp only [sub_eq_add_neg, add_mul, neg_mul, mul_assoc, hy]
   ring
+
+lemma mulOption_le (x y : IGame) {a b : IGame} [Numeric x] [Numeric y] [Numeric a] [Numeric b]
+    (ha : a ≤ 0) (hb : b ≤ y) : mulOption x y a b ≤ x * b := by
+  rw [mulOption, ← Game.mk_le_mk]
+  dsimp
+  have : Game.mk (a * y) - Game.mk (a * b) ≤ 0 := by
+    rw [← Game.mk_mul_sub]
+    apply Numeric.mul_nonpos_of_nonpos_of_nonneg ha
+    rwa [IGame.sub_nonneg]
+  rw [← add_le_add_iff_left (Game.mk (x * b))] at this
+  convert this using 1 <;> abel
 
 lemma numeric_option_inv {x : IGame} [Numeric x]
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹) :
@@ -87,16 +116,55 @@ lemma numeric_inv {x : IGame} [Numeric x] (hx : 0 < x)
   refine Numeric.mk' (fun y hy z hz ↦ ?_) Hl' Hr'
   have := Hl' y hy
   have := Hr' z hz
-  have := (Hl y hy).trans (Hr z hz)
-  rwa [Numeric.mul_lt_mul_left hx] at this
+  exact (Numeric.mul_lt_mul_left hx).1 <| (Hl y hy).trans (Hr z hz)
+
+lemma option_mul_inv_lt {x : IGame} [Numeric x] (hx : 0 < x)
+    (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
+    (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
+    (∀ y ∈ (x * x⁻¹).leftMoves, y < 1) ∧ (∀ y ∈ (x * x⁻¹).rightMoves, 1 < y) := by
+  have := numeric_inv hx hl hr hl' hr'
+  obtain ⟨Hl, Hr⟩ := numeric_option_inv hl hr
+  rw [forall_leftMoves_mul, forall_rightMoves_mul]
+  refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
+  · intro y hy a ha
+    have := Numeric.of_mem_leftMoves hy
+    have := Hl a ha
+    obtain hy' | hy' := Numeric.lt_or_le 0 y
+    · have := hl y hy hy'
+      rw [(mulOption_self_inv x (hl' y hy hy') a).lt_congr_left, add_comm, ← IGame.lt_sub_iff_add_lt,
+        (IGame.sub_self_equiv _).lt_congr_right]
+      apply Numeric.mul_neg_of_neg_of_pos _ hy'
+      rw [IGame.sub_neg]
+      exact Numeric.lt_rightMove (invOption_left_left_mem_rightMoves_inv hy hy' ha)
+    · apply (mulOption_le x x⁻¹ hy' (Numeric.leftMove_lt ha).le).trans_lt
+      exact (mul_inv_option_mem hl hr hl' hr').1 a ha
+  · intro y hy a ha
+    sorry
+  · sorry
+  · sorry
 
 #exit
-theorem main {x : IGame} [Numeric x] (hx : 0 < x) : Numeric x⁻¹ ∧ x * x⁻¹ ≈ 1 := by
+lemma mul_inv_self {x : IGame} [Numeric x] (hx : 0 < x)
+    (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
+    (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
+    x * x⁻¹ ≈ 1 := by
+  obtain ⟨Hl, Hr⟩ := option_mul_inv_lt hx hl hr hl' hr'
+  have := numeric_inv hx hl hr hl' hr'
+  apply equiv_one_of_fits ⟨fun z hz ↦ (Hl z hz).not_le, fun z hz ↦ (Hr z hz).not_le⟩
+  rw [Numeric.mul_equiv_zero, not_or]
+  exact ⟨hx.not_antisymmRel_symm, (Numeric.inv_pos x).not_antisymmRel_symm⟩
+
+theorem main {x : IGame} [Numeric x] (hx : 0 < x) (hx' : ∀ y ∈ x.leftMoves, 0 < y) :
+    Numeric x⁻¹ ∧ x * x⁻¹ ≈ 1 := by
   have IHl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹ ∧ y * y⁻¹ ≈ 1 :=
     fun y hy hy' ↦ have := Numeric.of_mem_leftMoves hy; main hy'
   have IHr : ∀ y ∈ x.rightMoves, Numeric y⁻¹ ∧ y * y⁻¹ ≈ 1 :=
     fun y hy ↦ have := Numeric.of_mem_rightMoves hy; main (hx.trans (Numeric.lt_rightMove hy))
-  sorry
+  have hl := fun y hy hy' ↦ (IHl y hy hy').1
+  have hr := fun y hy ↦ (IHr y hy).1
+  have hl' := fun y hy hy' ↦ (IHl y hy hy').2
+  have hr' := fun y hy ↦ (IHr y hy).2
+  exact ⟨numeric_inv hx hl hr hl' hr', mul_inv_self hx hl hr hl' hr'⟩
 termination_by x
 decreasing_by igame_wf
 
@@ -105,11 +173,8 @@ end Surreal.Division
 namespace IGame
 open Surreal.Division
 
-theorem Numeric.inv {x : IGame} [Numeric x] (hx : 0 < x) : Numeric x⁻¹ :=
-  (main hx).1
-
-theorem Numeric.mul_inv_cancel {x : IGame} [Numeric x] (hx : 0 < x) : x * x⁻¹ ≈ 1 :=
-  (main hx).2
+theorem Numeric.inv {x : IGame} [Numeric x] (hx : 0 < x) : Numeric x⁻¹ := (main hx).1
+theorem Numeric.mul_inv_cancel {x : IGame} [Numeric x] (hx : 0 < x) : x * x⁻¹ ≈ 1 := (main hx).2
 
 end IGame
 

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -53,7 +53,7 @@ lemma mul_inv_option_mem {x : IGame} [Numeric x]
   · intro y hy hy' a ha h
     have := Numeric.of_mem_leftMoves hy
     have := hl y hy hy'
-    have := (numeric_option_inv hl hr).1 a ha
+    have := (numeric_option_inv hl hr).2 a ha
     rw [← IGame.sub_pos, (one_neg_mul_invOption x (hl' y hy hy') a).lt_congr_right]
     apply Numeric.mul_pos (Numeric.mul_pos_of_neg_of_neg _ _) (Numeric.inv_pos y)
     · rwa [IGame.sub_neg]
@@ -71,7 +71,7 @@ lemma mul_inv_option_mem {x : IGame} [Numeric x]
   · intro y hy a ha h
     have := Numeric.of_mem_rightMoves hy
     have := hr y hy
-    have := (numeric_option_inv hl hr).1 a ha
+    have := (numeric_option_inv hl hr).2 a ha
     rw [← IGame.sub_neg, (one_neg_mul_invOption x (hr' y hy) a).lt_congr_left]
     apply Numeric.mul_neg_of_neg_of_pos (Numeric.mul_neg_of_neg_of_pos _ _) (Numeric.inv_pos y)
     · rwa [IGame.sub_neg]

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -6,10 +6,16 @@ noncomputable section
 
 namespace IGame
 
-private theorem mul_move_inv {x y z : IGame} [Numeric x] (h : 0 < x) :
-    (∀ y ∈ (x⁻¹).leftMoves, x * y < 1) ∧ (∀ y ∈ (x⁻¹).rightMoves, 1 < x * z) :=
-  refine invRec ?_
+private theorem mul_move_inv {x : IGame} [Numeric x] (h : 0 < x) :
+    (∀ y ∈ (x⁻¹).leftMoves, x * y < 1) ∧ (∀ y ∈ (x⁻¹).rightMoves, 1 < x * y) := by
+  refine invRec x ?_ ?_ ?_ ?_ ?_
+  · simp
+  · sorry
+  · sorry
+  · sorry
+  · sorry
 
+#exit
 theorem mul_leftMove_inv_lt {x y : IGame} [Numeric x] (h : 0 < x) (hy : y ∈ (x⁻¹).leftMoves) :
     x * y < 1 :=
   (mul_move_inv h).1 y hy
@@ -18,4 +24,5 @@ theorem lt_mul_rightMove_inv {x y : IGame} [Numeric x] (h : 0 < x) (hy : y ∈ (
     1 < x * y :=
   (mul_move_inv h).2 y hy
 
+end IGame
 end

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -241,15 +241,11 @@ private instance {x : IGame} [Numeric x] : Numeric (inv' x) := by
 
 private theorem Numeric.mul_inv'_cancel {x : IGame} [Numeric x] (hx : ¬ x ≈ 0) :
     x * (inv' x) ≈ 1 := by
-  rw [inv']
+  unfold inv'
   obtain h | h | h := Numeric.lt_or_equiv_or_gt x 0
-  · rw [if_neg h.asymm, if_pos h]
-    rw [← IGame.zero_lt_neg] at h
-    convert Numeric.mul_inv_cancel h using 1
-    simp
+  · simpa [h, h.asymm] using Numeric.mul_inv_cancel (IGame.zero_lt_neg.2 h)
   · contradiction
-  · rw [if_pos h]
-    exact Numeric.mul_inv_cancel h
+  · simpa [h] using Numeric.mul_inv_cancel h
 
 private theorem Numeric.inv'_congr {x y : IGame} [Numeric x] [Numeric y] (hy : x ≈ y) :
     inv' x ≈ inv' y := by

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -6,9 +6,22 @@ noncomputable section
 
 namespace IGame
 
+instance (x y : IGame) [Numeric x] [Numeric y⁻¹] : Numeric (x / y) :=
+  inferInstanceAs (Numeric (_ * _))
+
+@[simp]
+theorem Surreal.mk_mul (x y : IGame) [Numeric x] [Numeric y] :
+    Surreal.mk (x * y) = Surreal.mk x * Surreal.mk y :=
+  rfl
+
+@[simp]
+theorem Surreal.mk_div (x y : IGame) [Numeric x] [Numeric y⁻¹] :
+    Surreal.mk (x / y) = Surreal.mk x * Surreal.mk y⁻¹ :=
+  rfl
+
 instance (x y a : IGame) [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] :
     Numeric (invOption x y a) :=
-  inferInstanceAs (Numeric (_ * _))
+  inferInstanceAs (Numeric (_ / _))
 
 theorem numeric_option_inv {x : IGame} [Numeric x]
     (hl : ∀ y ∈ x.leftMoves, Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹) :
@@ -21,6 +34,16 @@ theorem numeric_option_inv {x : IGame} [Numeric x]
       have := Numeric.of_mem_leftMoves hy; have := hl _ hy |
       have := Numeric.of_mem_rightMoves hy; have := hr _ hy
     infer_instance
+
+theorem one_neg_mul_invOption (x : IGame) {y : IGame} (hy : y * y⁻¹ ≈ 1) (a : IGame)
+    [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] :
+    1 - x * invOption x y a ≈ (1 - x * a) * (y - x) / y := by
+  rw [← Surreal.mk_eq_mk] at *
+  dsimp [invOption] at *
+  simp only [one_mul, sub_eq_add_neg, add_mul, hy]
+  ring
+
+
 #exit
 /-
 theorem one_neg_mul_invOption (x : IGame) {y : IGame} (hy : Game.mk (y * y⁻¹) = 1) (a : IGame) :

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -1,0 +1,21 @@
+import CombinatorialGames.Surreal.Multiplication
+import Mathlib.Tactic.Ring.RingNF
+import Mathlib.Tactic.FieldSimp
+
+noncomputable section
+
+namespace IGame
+
+private theorem mul_move_inv {x y z : IGame} [Numeric x] (h : 0 < x) :
+    (∀ y ∈ (x⁻¹).leftMoves, x * y < 1) ∧ (∀ y ∈ (x⁻¹).rightMoves, 1 < x * z) :=
+  refine invRec ?_
+
+theorem mul_leftMove_inv_lt {x y : IGame} [Numeric x] (h : 0 < x) (hy : y ∈ (x⁻¹).leftMoves) :
+    x * y < 1 :=
+  (mul_move_inv h).1 y hy
+
+theorem lt_mul_rightMove_inv {x y : IGame} [Numeric x] (h : 0 < x) (hy : y ∈ (x⁻¹).rightMoves) :
+    1 < x * y :=
+  (mul_move_inv h).2 y hy
+
+end

--- a/CombinatorialGames/Surreal/Multiplication.lean
+++ b/CombinatorialGames/Surreal/Multiplication.lean
@@ -592,4 +592,8 @@ protected theorem mul_lt_mul_right {x y z : IGame} [Numeric x] [Numeric y] [Nume
     (hx : 0 < x) : y * x < z * x ↔ y < z :=
   mul_lt_mul_right (a := Surreal.mk x) (b := Surreal.mk y) (c := Surreal.mk z) hx
 
+theorem mul_equiv_zero {x y : IGame} [Numeric x] [Numeric y] : x * y ≈ 0 ↔ x ≈ 0 ∨ y ≈ 0 := by
+  repeat rw [← Surreal.mk_eq_mk]
+  exact @mul_eq_zero Surreal _ _ (.mk x) (.mk y)
+
 end IGame.Numeric

--- a/CombinatorialGames/Surreal/Multiplication.lean
+++ b/CombinatorialGames/Surreal/Multiplication.lean
@@ -469,7 +469,7 @@ decreasing_by all_goals (try rw [leftMoves_neg] at *); igame_wf
 
 end Surreal.Multiplication
 
-/-! ### Instances and lemmas -/
+/-! ### Instances and corollaries -/
 
 namespace IGame.Numeric
 open Surreal.Multiplication
@@ -512,7 +512,7 @@ namespace Surreal
 noncomputable instance : LinearOrderedCommRing Surreal where
   __ := Surreal.instLinearOrderedAddCommGroup
   __ := Surreal.instZeroLEOneClass
-  mul := Quotient.map₂ (fun a b ↦ ⟨a.1 * b.1, inferInstance⟩) fun _ _ h₁ _ _ ↦ Numeric.mul_congr h₁
+  mul := Quotient.map₂ (fun a b ↦ ⟨a.1 * b.1, inferInstance⟩) fun _ _ h _ _ ↦ Numeric.mul_congr h
   zero_mul := by rintro ⟨x⟩; change mk (0 * x) = mk 0; simp_rw [zero_mul]
   mul_zero := by rintro ⟨x⟩; change mk (x * 0) = mk 0; simp_rw [mul_zero]
   one_mul := by rintro ⟨x⟩; change mk (1 * x) = mk x; simp_rw [one_mul]

--- a/CombinatorialGames/Surreal/Multiplication.lean
+++ b/CombinatorialGames/Surreal/Multiplication.lean
@@ -446,59 +446,66 @@ theorem main (a : Args) : a.Numeric → P124 a := by
     · exact (Game.mk_eq <| P2_of_IH ih ·)
     · exact P4_of_IH ih
 
-end Surreal.Multiplication
-
-/-! ### Instances -/
-
-namespace IGame
-open Surreal.Multiplication
-
-variable {x x₁ x₂ y y₁ y₂ a b : IGame}
-
-instance Numeric.mul [hx : Numeric x] [hy : Numeric y] : Numeric (x * y) :=
-  main _ <| Args.numeric_P1.mpr ⟨hx, hy⟩
-
-instance Numeric.mulOption [Numeric x] [Numeric y] [Numeric a] [Numeric b] :
-    Numeric (mulOption x y a b) :=
-  inferInstanceAs (Numeric (_ - _))
-
-private lemma P24 (x₁ x₂ y : IGame) [hx₁ : Numeric x₁] [hx₂ : Numeric x₂] [hy : Numeric y] :
+lemma main_P24 (x₁ x₂ y : IGame) [hx₁ : Numeric x₁] [hx₂ : Numeric x₂] [hy : Numeric y] :
     P24 x₁ x₂ y :=
   main _ <| Args.numeric_P24.mpr ⟨hx₁, hx₂, hy⟩
 
-theorem Numeric.mul_congr_left [Numeric x₁] [Numeric x₂] [Numeric y] (he : x₁ ≈ x₂) :
-    x₁ * y ≈ x₂ * y :=
-  Game.mk_eq_mk.1 ((P24 ..).1 he)
-
-theorem Numeric.mul_congr_right [Numeric x] [Numeric y₁] [Numeric y₂] (he : y₁ ≈ y₂) :
-    x * y₁ ≈ x * y₂ := by
-  rw [mul_comm, mul_comm x]; exact Numeric.mul_congr_left he
-
-theorem Numeric.mul_congr [Numeric x₁] [Numeric x₂] [Numeric y₁] [Numeric y₂]
-    (hx : x₁ ≈ x₂) (hy : y₁ ≈ y₂) : x₁ * y₁ ≈ x₂ * y₂ :=
-  (mul_congr_left hx).trans (mul_congr_right hy)
-
-/-- One additional inductive argument that proves `P3`. -/
-private lemma P3_of_lt_of_lt {x₁ x₂ y₁ y₂} [Numeric x₁] [Numeric x₂] [Numeric y₁] [Numeric y₂]
+/-- One additional inductive argument proves `P3`. -/
+lemma P3_of_lt_of_lt {x₁ x₂ y₁ y₂} [Numeric x₁] [Numeric x₂] [Numeric y₁] [Numeric y₂]
     (hx : x₁ < x₂) (hy : y₁ < y₂) : P3 x₁ x₂ y₁ y₂ := by
   refine P3_of_IH3 ?_ ?_ hx
   all_goals
     intro i hi
     have := Numeric.of_mem_leftMoves hi
-    refine ⟨(P24 ..).1, (P24 ..).1, P3_comm.2 ?_, fun h ↦ ?_⟩
-  · exact ((P24 y₁ y₂ x₂).2 hy).1 _ hi
+    refine ⟨(main_P24 ..).1, (main_P24 ..).1, P3_comm.2 ?_, fun h ↦ ?_⟩
+  · exact ((main_P24 y₁ y₂ x₂).2 hy).1 _ hi
   · exact P3_of_lt_of_lt h hy
-  · exact ((P24 y₁ y₂ x₁).2 hy).2 _ hi
+  · exact ((main_P24 y₁ y₂ x₁).2 hy).2 _ hi
   · rw [IGame.neg_lt] at h
     rw [← P3_neg, neg_neg]
     exact P3_of_lt_of_lt h hy
 termination_by (x₁, x₂)
 decreasing_by all_goals (try rw [leftMoves_neg] at *); igame_wf
 
-theorem Numeric.mul_pos [Numeric x₁] [Numeric x₂] (hp₁ : 0 < x₁) (hp₂ : 0 < x₂) : 0 < x₁ * x₂ := by
+end Surreal.Multiplication
+
+/-! ### Instances and lemmas -/
+
+namespace IGame.Numeric
+open Surreal.Multiplication
+
+variable {x x₁ x₂ y y₁ y₂ a b : IGame}
+
+instance mul [hx : Numeric x] [hy : Numeric y] : Numeric (x * y) :=
+  main _ <| Args.numeric_P1.mpr ⟨hx, hy⟩
+
+instance mulOption [Numeric x] [Numeric y] [Numeric a] [Numeric b] :
+    Numeric (mulOption x y a b) :=
+  inferInstanceAs (Numeric (_ - _))
+
+/-- Note that this assumes `y⁻¹` numeric. -/
+instance div (x y : IGame) [Numeric x] [Numeric y⁻¹] : Numeric (x / y) :=
+  inferInstanceAs (Numeric (_ * _))
+
+/-- Note that this assumes `y⁻¹` numeric. -/
+instance invOption (x y a : IGame) [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] :
+    Numeric (invOption x y a) :=
+  inferInstanceAs (Numeric (_ / _))
+
+theorem mul_congr_left [Numeric x₁] [Numeric x₂] [Numeric y] (he : x₁ ≈ x₂) : x₁ * y ≈ x₂ * y :=
+  Game.mk_eq_mk.1 ((main_P24 ..).1 he)
+
+theorem mul_congr_right [Numeric x] [Numeric y₁] [Numeric y₂] (he : y₁ ≈ y₂) : x * y₁ ≈ x * y₂ := by
+  rw [mul_comm, mul_comm x]; exact Numeric.mul_congr_left he
+
+theorem mul_congr [Numeric x₁] [Numeric x₂] [Numeric y₁] [Numeric y₂]
+    (hx : x₁ ≈ x₂) (hy : y₁ ≈ y₂) : x₁ * y₁ ≈ x₂ * y₂ :=
+  (mul_congr_left hx).trans (mul_congr_right hy)
+
+theorem mul_pos [Numeric x₁] [Numeric x₂] (hp₁ : 0 < x₁) (hp₂ : 0 < x₂) : 0 < x₁ * x₂ := by
   simpa [P3] using P3_of_lt_of_lt hp₁ hp₂
 
-end IGame
+end IGame.Numeric
 
 namespace Surreal
 
@@ -517,4 +524,72 @@ noncomputable instance : LinearOrderedCommRing Surreal where
   mul_pos := by rintro ⟨x⟩ ⟨y⟩; exact Numeric.mul_pos
   le_total := by rintro ⟨x⟩ ⟨y⟩; exact Numeric.le_total x y
 
+@[simp]
+theorem mk_mul (x y : IGame) [Numeric x] [Numeric y] :
+    Surreal.mk (x * y) = Surreal.mk x * Surreal.mk y :=
+  rfl
+
+/-- Note that this assumes `y⁻¹` numeric. -/
+theorem mk_div' (x y : IGame) [Numeric x] [Numeric y⁻¹] :
+    Surreal.mk (x / y) = Surreal.mk x * Surreal.mk y⁻¹ :=
+  rfl
+
 end Surreal
+
+namespace IGame.Numeric
+
+protected theorem mul_neg_of_pos_of_neg {x y : IGame} [Numeric x] [Numeric y]
+    (hx : 0 < x) (hy : y < 0) : x * y < 0 :=
+  @mul_neg_of_pos_of_neg Surreal (.mk x) (.mk y) _ _ _ hx hy
+
+protected theorem mul_neg_of_neg_of_pos {x y : IGame} [Numeric x] [Numeric y]
+    (hx : x < 0) (hy : 0 < y) : x * y < 0 :=
+  @mul_neg_of_neg_of_pos Surreal (.mk x) (.mk y) _ _ _ hx hy
+
+protected theorem mul_pos_of_neg_of_neg {x y : IGame} [Numeric x] [Numeric y]
+    (hx : x < 0) (hy : y < 0) : 0 < x * y :=
+  @mul_pos_of_neg_of_neg Surreal _ _ _ _ _ _ (.mk x) (.mk y) hx hy
+
+protected theorem mul_nonneg {x y : IGame} [Numeric x] [Numeric y]
+    (hx : 0 ≤ x) (hy : 0 ≤ y) : 0 ≤ x * y :=
+  @mul_nonneg Surreal (.mk x) (.mk y) _ _ _ hx hy
+
+protected theorem mul_nonpos_of_nonneg_of_nonpos {x y : IGame} [Numeric x] [Numeric y]
+    (hx : 0 ≤ x) (hy : y ≤ 0) : x * y ≤ 0 :=
+  @mul_nonpos_of_nonneg_of_nonpos Surreal (.mk x) (.mk y) _ _ _ hx hy
+
+protected theorem mul_nonpos_of_nonpos_of_nonneg {x y : IGame} [Numeric x] [Numeric y]
+    (hx : x ≤ 0) (hy : 0 ≤ y) : x * y ≤ 0 :=
+  @mul_nonpos_of_nonpos_of_nonneg Surreal (.mk x) (.mk y) _ _ _ hx hy
+
+protected theorem mul_nonneg_of_nonpos_of_nonpos {x y : IGame} [Numeric x] [Numeric y]
+    (hx : x ≤ 0) (hy : y ≤ 0) : 0 ≤ x * y :=
+  @mul_nonneg_of_nonpos_of_nonpos Surreal _ _ (.mk x) (.mk y) _ _ _ _ hx hy
+
+protected theorem mul_left_cancel {x y z : IGame} [Numeric x] [Numeric y] [Numeric z]
+    (hx : ¬ x ≈ 0) (h : x * y ≈ x * z) : y ≈ z := by
+  rw [← Surreal.mk_eq_mk] at *
+  exact mul_left_cancel₀ hx h
+
+protected theorem mul_right_cancel {x y z : IGame} [Numeric x] [Numeric y] [Numeric z]
+    (hx : ¬ x ≈ 0) (h : y * x ≈ z * x) : y ≈ z := by
+  rw [← Surreal.mk_eq_mk] at *
+  exact mul_right_cancel₀ hx h
+
+protected theorem mul_le_mul_left {x y z : IGame} [Numeric x] [Numeric y] [Numeric z]
+    (hx : 0 < x) : x * y ≤ x * z ↔ y ≤ z :=
+  mul_le_mul_left (a := Surreal.mk x) (b := Surreal.mk y) (c := Surreal.mk z) hx
+
+protected theorem mul_le_mul_right {x y z : IGame} [Numeric x] [Numeric y] [Numeric z]
+    (hx : 0 < x) : y * x ≤ z * x ↔ y ≤ z :=
+  mul_le_mul_right (a := Surreal.mk x) (b := Surreal.mk y) (c := Surreal.mk z) hx
+
+protected theorem mul_lt_mul_left {x y z : IGame} [Numeric x] [Numeric y] [Numeric z]
+    (hx : 0 < x) : x * y < x * z ↔ y < z :=
+  mul_lt_mul_left (a := Surreal.mk x) (b := Surreal.mk y) (c := Surreal.mk z) hx
+
+protected theorem mul_lt_mul_right {x y z : IGame} [Numeric x] [Numeric y] [Numeric z]
+    (hx : 0 < x) : y * x < z * x ↔ y < z :=
+  mul_lt_mul_right (a := Surreal.mk x) (b := Surreal.mk y) (c := Surreal.mk z) hx
+
+end IGame.Numeric


### PR DESCRIPTION
This is Mathlib PR [14498](https://github.com/leanprover-community/mathlib4/pull/14498). Though I based the definition of the game inverse on Mathlib, the proof was basically remade from scratch, simplifying it from 600 lines down to 200. In particular, we can avoid having to "normalize" `x` by simply being a bit more careful with the inductive hypotheses.

Closes #12.