### PR TITLE
feat: surreal number from left and right sets

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -61,8 +61,8 @@ theorem equiv_mk_out (x : IGame) : x ≈ (mk x).out := (mk_out_equiv x).symm
 This is given notation `{s | t}ᴳ`, where the superscript `G` is to disambiguate from set builder
 notation, and from the analogous constructor on `IGame`.
 
-Note that although this function is well-defined, recovering the left/right sets from a game is not,
-as there are many sets that can generate a single game. -/
+Note that although this function is well-defined, this function isn't injective, nor do equivalence
+classes in `Game` have a canonical representative.  -/
 def ofSets (s t : Set Game.{u}) [Small.{u} s] [Small.{u} t] : Game.{u} :=
   mk {out '' s | out '' t}ᴵ
 

--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -68,6 +68,7 @@ def ofSets (s t : Set Game.{u}) [Small.{u} s] [Small.{u} t] : Game.{u} :=
 
 @[inherit_doc] notation "{" s " | " t "}ᴳ" => ofSets s t
 
+@[simp]
 theorem mk_ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] :
     mk {s | t}ᴵ = {mk '' s | mk '' t}ᴳ := by
   refine mk_eq <| IGame.equiv_of_exists ?_ ?_ ?_ ?_ <;>

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -380,8 +380,9 @@ theorem game_out_eq (x : Surreal) : Game.mk x.out = x.toGame := by
 /-- Construct a `Surreal` from its left and right sets, and a proof that all elements from the left
 set are less than all the elements of the right set.
 
-Note that although this function is well-defined, recovering the left/right sets from a surreal
-number is not, as there are many sets that can generate a single number. -/
+Note that although this function is well-defined, this function isn't injective, nor do equivalence
+classes in Surreal have a canonical representative. (Note however that every short numeric game has
+a unique "canonical" form!) -/
 def ofSets (s t : Set Surreal.{u}) [Small.{u} s] [Small.{u} t]
     (H : ∀ x ∈ s, ∀ y ∈ t, x < y) : Surreal.{u} := by
   refine @mk {out '' s | out '' t}ᴵ (.mk' ?_ (by simp) (by simp))


### PR DESCRIPTION
I'm a bit unsure as to what API we should have for `Surreal.ofSets`, but I think that should become clearer once we start making use of it (this is needed e.g. to define `ω ^ x`).