### PR TITLE
feat: define `IntCast` and `RatCast` for games

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -91,7 +91,8 @@ instance : OrderedAddCommGroup Game where
   nsmul := nsmulRec
   zsmul := zsmulRec
 
-instance : AddMonoidWithOne Game where
+instance : AddGroupWithOne Game where
+  __ := Game.instOrderedAddCommGroup
 
 @[simp] theorem mk_zero : mk 0 = 0 := rfl
 @[simp] theorem mk_one : mk 1 = 1 := rfl
@@ -110,6 +111,10 @@ theorem mk_mulOption (x y a b : IGame) :
 theorem mk_natCast : ∀ n : ℕ, mk n = n
   | 0 => rfl
   | n + 1 => by rw [Nat.cast_add, Nat.cast_add, mk_add, mk_natCast]; rfl
+
+@[simp]
+theorem mk_intCast (n : ℤ) : mk n = n := by
+  cases n <;> simp
 
 theorem zero_def : 0 = {∅ | ∅}ᴳ := by apply (mk_ofSets _ _).trans; simp
 theorem one_def : 1 = {{0} | ∅}ᴳ := by apply (mk_ofSets _ _).trans; simp

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -967,6 +967,26 @@ theorem rightMoves_ofNat (n : ℕ) [n.AtLeastTwo] : rightMoves ofNat(n) = ∅ :=
 theorem natCast_succ_eq (n : ℕ) : (n + 1 : IGame) = {{(n : IGame)} | ∅}ᴵ := by
   ext <;> simp
 
+instance : IntCast IGame where
+  intCast
+  | .ofNat n => n
+  | .negSucc n => -(n + 1)
+
+@[simp] theorem intCast_nat (n : ℕ) : ((n : ℤ) : IGame) = n := rfl
+@[simp] theorem intCast_ofNat (n : ℕ) : ((ofNat(n) : ℤ) : IGame) = n := rfl
+
+theorem intCast_zero : ((0 : ℤ) : IGame) = 0 := rfl
+theorem intCast_one : ((1 : ℤ) : IGame) = 1 := by simp
+
+@[simp]
+theorem intCast_neg (n : ℤ) : ((-n : ℤ) : IGame) = -(n : IGame) := by
+  cases n with
+  | ofNat n =>
+    cases n with
+    | zero => simp
+    | succ n => rfl
+  | negSucc n => exact (neg_neg _).symm
+
 /-! ### Multiplication -/
 
 -- TODO: upstream
@@ -1194,6 +1214,9 @@ instance : Div IGame where
 
 protected theorem div_eq_mul_inv (x y : IGame) : x / y = x * y⁻¹ := rfl
 
+@[simp] protected theorem zero_div (x : IGame) : 0 / x = 0 := zero_mul _
+@[simp] protected theorem neg_div (x y : IGame) : -x / y = -(x / y) := neg_mul ..
+
 private theorem inv_eq (x : IGame.{u}) :
     x⁻¹ = {.range (InvTy.val x false) | .range (InvTy.val x true)}ᴵ := by
   change inv' x = _
@@ -1286,6 +1309,14 @@ theorem invRec (x : IGame) {P : ∀ y ∈ x⁻¹.leftMoves, Prop} {Q : ∀ y ∈
   all_goals first |
     exact ((equivShrink {y ∈ x.leftMoves | 0 < y}).symm _).2.1 |
     exact ((equivShrink {y ∈ x.leftMoves | 0 < y}).symm _).2.2
+
+instance : RatCast IGame where
+  ratCast q := q.num / q.den
+
+theorem ratCast_def (q : ℚ) : (q : IGame) = q.num / q.den := rfl
+
+@[simp] theorem ratCast_zero : ((0 : ℚ) : IGame) = 0 := by simp [ratCast_def]
+@[simp] theorem ratCast_neg (q : ℚ) : ((-q : ℚ) : IGame) = -(q : IGame) := by simp [ratCast_def]
 
 end IGame
 end

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -974,6 +974,7 @@ instance : IntCast IGame where
 
 @[simp] theorem intCast_nat (n : ℕ) : ((n : ℤ) : IGame) = n := rfl
 @[simp] theorem intCast_ofNat (n : ℕ) : ((ofNat(n) : ℤ) : IGame) = n := rfl
+@[simp] theorem intCast_negSucc (n : ℕ) : (Int.negSucc n : IGame) = -(n + 1) := rfl
 
 theorem intCast_zero : ((0 : ℤ) : IGame) = 0 := rfl
 theorem intCast_one : ((1 : ℤ) : IGame) = 1 := by simp

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -206,6 +206,10 @@ protected instance natCast : ∀ n : ℕ, Numeric n
 protected instance ofNat (n : ℕ) [n.AtLeastTwo] : Numeric ofNat(n) :=
   inferInstanceAs (Numeric n)
 
+protected instance intCast : ∀ n : ℤ, Numeric n
+  | .ofNat n => inferInstanceAs (Numeric n)
+  | .negSucc n => inferInstanceAs (Numeric (-(n + 1)))
+
 /-- Note that this assumes `x⁻¹` numeric. -/
 theorem inv_pos (x : IGame) [Numeric x⁻¹] : 0 < x⁻¹ :=
   Numeric.lt_of_not_le (inv_nonneg x)
@@ -339,7 +343,8 @@ instance : LinearOrderedAddCommGroup Surreal where
   nsmul := nsmulRec
   zsmul := zsmulRec
 
-instance : AddMonoidWithOne Surreal where
+instance : AddGroupWithOne Surreal where
+  __ := Surreal.instLinearOrderedAddCommGroup
 
 @[simp] theorem mk_zero : mk 0 = 0 := rfl
 @[simp] theorem mk_one : mk 1 = 1 := rfl
@@ -354,6 +359,10 @@ instance : AddMonoidWithOne Surreal where
 theorem mk_natCast : ∀ n : ℕ, mk n = n
   | 0 => rfl
   | n + 1 => by simp_rw [Nat.cast_add_one, mk_add, mk_one, mk_natCast n]
+
+@[simp]
+theorem mk_intCast (n : ℤ) : mk n = n := by
+  cases n <;> simp
 
 instance : ZeroLEOneClass Surreal where
   zero_le_one := zero_le_one (α := IGame)
@@ -401,9 +410,8 @@ theorem toGame_neg (x : Surreal) : toGame (-x) = -toGame x :=
 theorem toGame_sub (x y : Surreal) : toGame (x - y) = toGame x - toGame y :=
   toGameAddHom.map_sub x y
 
-@[simp]
-theorem toGame_natCast (n : ℕ) : toGame n = n :=
-  map_natCast' toGameAddHom rfl n
+@[simp] theorem toGame_natCast (n : ℕ) : toGame n = n := map_natCast' toGameAddHom rfl n
+@[simp] theorem toGame_intCast (n : ℤ) : toGame n = n := map_intCast' toGameAddHom rfl n
 
 @[simp]
 theorem game_out_eq (x : Surreal) : Game.mk x.out = x.toGame := by

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -213,17 +213,25 @@ end Surreal.Division
 namespace IGame
 open Surreal.Division
 
-theorem Numeric.inv {x : IGame} [Numeric x] (hx : 0 < x) : Numeric x⁻¹ := (main hx).1
-theorem Numeric.mul_inv_cancel {x : IGame} [Numeric x] (hx : 0 < x) : x * x⁻¹ ≈ 1 := (main hx).2
+namespace Numeric
 
-theorem Numeric.inv_congr {x y : IGame} [Numeric x] [Numeric y] (hx : 0 < x) (hy : x ≈ y) :
-    x⁻¹ ≈ y⁻¹ := by
+protected theorem inv {x : IGame} [Numeric x] (hx : 0 < x) : Numeric x⁻¹ := (main hx).1
+protected theorem mul_inv_cancel {x : IGame} [Numeric x] (hx : 0 < x) : x * x⁻¹ ≈ 1 := (main hx).2
+
+theorem inv_congr {x y : IGame} [Numeric x] [Numeric y] (hx : 0 < x) (hy : x ≈ y) : x⁻¹ ≈ y⁻¹ := by
   have hy' := hx.trans_antisymmRel hy
   have := Numeric.inv hx
   have := Numeric.inv hy'
   have := (Numeric.mul_inv_cancel hx).trans (Numeric.mul_inv_cancel hy').symm
   rw [← (Numeric.mul_congr_left hy).antisymmRel_congr_right] at this
   exact Numeric.mul_left_cancel hx.not_antisymmRel_symm this
+
+protected instance ratCast (q : ℚ) : Numeric q := by
+  have : Numeric (q.den : IGame)⁻¹ := .inv (mod_cast q.den_pos)
+  change Numeric (_ * _)
+  infer_instance
+
+end Numeric
 
 /-- An auxiliary definition for the surreal inverse. -/
 private noncomputable def inv' (x : IGame) : IGame := by
@@ -272,5 +280,24 @@ noncomputable instance : LinearOrderedField Surreal where
   inv_zero := by change mk (inv' 0) = _; simp [inv'_zero]
   qsmul := _
   nnqsmul := _
+
+theorem mk_inv_of_pos {x : IGame} (h : 0 < x) [Numeric x] : @mk x⁻¹ (.inv h) = (mk x)⁻¹ := by
+  change _ = mk (inv' _)
+  unfold inv'
+  simp_rw [if_pos h]
+
+theorem mk_div_of_pos (x : IGame) {y : IGame} (h : 0 < y) [Numeric x] [Numeric y] :
+    @mk (x / y) (@Numeric.mul _ _ _ (.inv h)) = mk x / mk y := by
+  have := Numeric.inv h
+  simp_rw [IGame.div_eq_mul_inv, mk_mul, mk_inv_of_pos h]
+  rfl
+
+@[simp]
+theorem mk_ratCast (q : ℚ) : mk q = q := by
+  simp_rw [ratCast_def]
+  rw [mk_div_of_pos]
+  · conv_rhs => rw [← q.num_div_den]
+    simp
+  · exact_mod_cast q.den_pos 
 
 end Surreal

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -287,7 +287,7 @@ theorem mk_inv_of_pos {x : IGame} (h : 0 < x) [Numeric x] : @mk x⁻¹ (.inv h) 
   simp_rw [if_pos h]
 
 theorem mk_div_of_pos (x : IGame) {y : IGame} (h : 0 < y) [Numeric x] [Numeric y] :
-    @mk (x / y) (@Numeric.mul _ _ _ (.inv h)) = mk x / mk y := by
+    @mk (x / y) (@Numeric.div x y _ (.inv h)) = mk x / mk y := by
   have := Numeric.inv h
   simp_rw [IGame.div_eq_mul_inv, mk_mul, mk_inv_of_pos h]
   rfl
@@ -298,6 +298,6 @@ theorem mk_ratCast (q : ℚ) : mk q = q := by
   rw [mk_div_of_pos]
   · conv_rhs => rw [← q.num_div_den]
     simp
-  · exact_mod_cast q.den_pos 
+  · exact_mod_cast q.den_pos
 
 end Surreal


### PR DESCRIPTION
We define `IntCast` and `RatCast` instances for `IGame` in the obvious way, and prove that they interact as expected with the instances from `Game` and `Surreal`.