### PR TITLE
feat: better junk values for `IGame` inverse

### DIFF
--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -1229,7 +1229,9 @@ private theorem inv_eq {x : IGame.{u}} (hx : 0 < x) :
 
 protected theorem div_eq_mul_inv (x y : IGame) : x / y = x * y⁻¹ := rfl
 
-@[simp] protected theorem inv_zero : (0 : IGame)⁻¹ = 0 := by simp [inv_eq']
+theorem inv_of_equiv_zero {x : IGame} (h : x ≈ 0) : x⁻¹ = 0 := by simp [inv_eq', h.not_lt, h.not_gt]
+
+@[simp] protected theorem inv_zero : (0 : IGame)⁻¹ = 0 := inv_of_equiv_zero .rfl
 @[simp] protected theorem zero_div (x : IGame) : 0 / x = 0 := zero_mul _
 @[simp] protected theorem neg_div (x y : IGame) : -x / y = -(x / y) := neg_mul ..
 
@@ -1342,14 +1344,11 @@ theorem invRec {x : IGame} (hx : 0 < x)
       Q _ (invOption_right_right_mem_rightMoves_inv hx hy hyx ha)) :
     (∀ y (hy : y ∈ x⁻¹.leftMoves), P y hy) ∧ (∀ y (hy : y ∈ x⁻¹.rightMoves), Q y hy) := by
   apply invRec' hx zero
-  · convert left₁ using 6 with _ ha
-    simp_rw [invOption_eq ha]
-  · convert left₂ using 6 with _ ha
-    simp_rw [invOption_eq ha]
-  · convert right₁ using 6 with _ ha
-    simp_rw [invOption_eq ha]
-  · convert right₂ using 6 with _ ha
-    simp_rw [invOption_eq ha]
+  on_goal 1 => convert left₁ using 6 with _ ha
+  on_goal 2 => convert left₂ using 6 with _ ha
+  on_goal 3 => convert right₁ using 6 with _ ha
+  on_goal 4 => convert right₂ using 6 with _ ha
+  all_goals simp_rw [invOption_eq ha]
 
 instance : RatCast IGame where
   ratCast q := q.num / q.den

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -1320,7 +1320,7 @@ private theorem invRec' {x : IGame} (hx : 0 < x)
   intro b i
   induction i
   · simpa
-  all_goals simp only [Bool.false_eq_true, if_false, if_true]
+  all_goals simp only [Bool.false_eq_true]
   on_goal 1 => apply left₁
   on_goal 5 => apply left₂
   on_goal 9 => apply right₁

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -6,7 +6,6 @@ Authors: Violeta Hernández Palacios
 import CombinatorialGames.Game.Basic
 import CombinatorialGames.Game.Short
 import CombinatorialGames.NatOrdinal
-import CombinatorialGames.Mathlib.Order
 import Mathlib.Algebra.Order.Hom.Monoid
 
 /-!

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Kim Morrison, Violeta Hernández Palacios
 -/
 import CombinatorialGames.Game.Birthday
-import CombinatorialGames.Mathlib.Order
 import Mathlib.Algebra.Order.Hom.Monoid
 
 /-!
@@ -209,10 +208,6 @@ protected instance ofNat (n : ℕ) [n.AtLeastTwo] : Numeric ofNat(n) :=
 protected instance intCast : ∀ n : ℤ, Numeric n
   | .ofNat n => inferInstanceAs (Numeric n)
   | .negSucc n => inferInstanceAs (Numeric (-(n + 1)))
-
-/-- Note that this assumes `x⁻¹` numeric. -/
-theorem inv_pos (x : IGame) [Numeric x⁻¹] : 0 < x⁻¹ :=
-  Numeric.lt_of_not_le (inv_nonneg x)
 
 end Numeric
 

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -230,6 +230,13 @@ protected instance inv (x : IGame) [Numeric x] : Numeric x⁻¹ := by
   · simp [inv_of_equiv_zero h]
   · exact (main h).1
 
+protected instance div (x y : IGame) [Numeric x] [Numeric y] : Numeric (x / y) := .mul ..
+protected instance ratCast (q : ℚ) : Numeric q := .div ..
+
+protected instance invOption (x y a : IGame) [Numeric x] [Numeric y] [Numeric a] :
+    Numeric (invOption x y a) :=
+  .div ..
+
 protected theorem mul_inv_cancel {x : IGame} [Numeric x] (hx : ¬ x ≈ 0) : x * x⁻¹ ≈ 1 := by
   obtain h | h | h := Numeric.lt_or_equiv_or_gt x 0
   · rw [← IGame.zero_lt_neg] at h
@@ -244,13 +251,6 @@ theorem inv_congr {x y : IGame} [Numeric x] [Numeric y] (he : x ≈ y) : x⁻¹ 
     have := (Numeric.mul_inv_cancel hx).trans (Numeric.mul_inv_cancel hy).symm
     rw [← (Numeric.mul_congr_left he).antisymmRel_congr_right] at this
     exact Numeric.mul_left_cancel hx this
-
-protected instance div (x y : IGame) [Numeric x] [Numeric y] : Numeric (x / y) := .mul ..
-protected instance ratCast (q : ℚ) : Numeric q := .div ..
-
-protected instance invOption (x y a : IGame) [Numeric x] [Numeric y] [Numeric a] :
-    Numeric (invOption x y a) :=
-  .div ..
 
 end IGame.Numeric
 

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -223,7 +223,7 @@ end Surreal.Division
 namespace IGame.Numeric
 open Surreal.Division
 
-protected instance inv {x : IGame} [Numeric x] : Numeric x⁻¹ := by
+protected instance inv (x : IGame) [Numeric x] : Numeric x⁻¹ := by
   obtain h | h | h := Numeric.lt_or_equiv_or_gt x 0
   · rw [← IGame.zero_lt_neg] at h
     simpa using (main h).1

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -30,13 +30,16 @@ numbers.
 
 open IGame
 
-private instance Numeric.div' (x y : IGame) [Numeric x] [Numeric y⁻¹] : Numeric (x / y) := .mul
+private instance {x y : IGame} [Numeric x] [Numeric y⁻¹] : Numeric (x / y) := .mul ..
 
-private instance Numeric.invOption' {x y a : IGame}
-    [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] : Numeric (invOption x y a) :=
-  .mul
+private instance {x y a : IGame} [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] :
+    Numeric (invOption x y a) :=
+  .mul ..
 
-private theorem Surreal.mk_div' (x y : IGame) [Numeric x] [Numeric y⁻¹] :
+private theorem inv_pos' {x : IGame} [Numeric x⁻¹] (hx : 0 < x) : 0 < x⁻¹ :=
+  Numeric.leftMove_lt (zero_mem_leftMoves_inv hx)
+
+private theorem mk_div' (x y : IGame) [Numeric x] [Numeric y⁻¹] :
     Surreal.mk (x / y) = Surreal.mk x * Surreal.mk y⁻¹ :=
   Surreal.mk_mul ..
 
@@ -85,113 +88,110 @@ theorem le_mulOption (x y : IGame) {a b : IGame} [Numeric x] [Numeric y] [Numeri
 
 /-! ### Inductive proof -/
 
-lemma numeric_option_inv {x : IGame} [Numeric x]
+lemma numeric_option_inv {x : IGame} (hx : 0 < x) [Numeric x]
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹) :
     (∀ y ∈ x⁻¹.leftMoves, Numeric y) ∧ (∀ y ∈ x⁻¹.rightMoves, Numeric y) := by
-  apply invRec x Numeric.zero
+  apply invRec hx Numeric.zero
   all_goals
-    intro y hy hy'
+    intro y hy hyx
     intros
     first |
-      have := Numeric.of_mem_leftMoves hy; have := hl _ hy hy' |
-      have := Numeric.of_mem_rightMoves hy; have := hr _ hy
+      have := Numeric.of_mem_leftMoves hyx; have := hl _ hyx hy |
+      have := Numeric.of_mem_rightMoves hyx; have := hr _ hyx
     infer_instance
 
-lemma mul_inv_option_mem {x : IGame} [Numeric x]
+lemma mul_inv_option_mem {x : IGame} (hx : 0 < x) [Numeric x]
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
     (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
     (∀ y ∈ x⁻¹.leftMoves, x * y < 1) ∧ (∀ y ∈ x⁻¹.rightMoves, 1 < x * y) := by
-  apply invRec x
+  apply invRec hx
   · simp
-  · intro y hy a ha h
-    have := Numeric.of_mem_rightMoves hy
-    have := hr y hy
-    have := (numeric_option_inv hl hr).1 a ha
-    rw [← IGame.sub_pos, (one_neg_mul_invOption x (hr' y hy) a).lt_congr_right]
-    apply Numeric.mul_pos (Numeric.mul_pos _ _) (Numeric.inv_pos y)
+  all_goals intro y hy hyx a ha h
+  · have := Numeric.of_mem_rightMoves hyx
+    have := hr y hyx
+    have := (numeric_option_inv hx hl hr).1 a ha
+    rw [← IGame.sub_pos, (one_neg_mul_invOption x (hr' y hyx) a).lt_congr_right]
+    apply Numeric.mul_pos (Numeric.mul_pos _ _) (inv_pos' hy)
     · rwa [IGame.sub_pos]
     · rw [IGame.sub_pos]
-      exact Numeric.lt_rightMove hy
-  · intro y hy hy' a ha h
-    have := Numeric.of_mem_leftMoves hy
-    have := hl y hy hy'
-    have := (numeric_option_inv hl hr).2 a ha
-    rw [← IGame.sub_pos, (one_neg_mul_invOption x (hl' y hy hy') a).lt_congr_right]
-    apply Numeric.mul_pos (Numeric.mul_pos_of_neg_of_neg _ _) (Numeric.inv_pos y)
+      exact Numeric.lt_rightMove hyx
+  · have := Numeric.of_mem_leftMoves hyx
+    have := hl y hyx hy
+    have := (numeric_option_inv hx hl hr).2 a ha
+    rw [← IGame.sub_pos, (one_neg_mul_invOption x (hl' y hyx hy) a).lt_congr_right]
+    apply Numeric.mul_pos (Numeric.mul_pos_of_neg_of_neg _ _) (inv_pos' hy)
     · rwa [IGame.sub_neg]
     · rw [IGame.sub_neg]
-      exact Numeric.leftMove_lt hy
-  · intro y hy hy' a ha h
-    have := Numeric.of_mem_leftMoves hy
-    have := hl y hy hy'
-    have := (numeric_option_inv hl hr).1 a ha
-    rw [← IGame.sub_neg, (one_neg_mul_invOption x (hl' y hy hy') a).lt_congr_left]
-    apply Numeric.mul_neg_of_neg_of_pos (Numeric.mul_neg_of_pos_of_neg _ _) (Numeric.inv_pos y)
+      exact Numeric.leftMove_lt hyx
+  · have := Numeric.of_mem_leftMoves hyx
+    have := hl y hyx hy
+    have := (numeric_option_inv hx hl hr).1 a ha
+    rw [← IGame.sub_neg, (one_neg_mul_invOption x (hl' y hyx hy) a).lt_congr_left]
+    apply Numeric.mul_neg_of_neg_of_pos (Numeric.mul_neg_of_pos_of_neg _ _) (inv_pos' hy)
     · rwa [IGame.sub_pos]
     · rw [IGame.sub_neg]
-      exact Numeric.leftMove_lt hy
-  · intro y hy a ha h
-    have := Numeric.of_mem_rightMoves hy
-    have := hr y hy
-    have := (numeric_option_inv hl hr).2 a ha
-    rw [← IGame.sub_neg, (one_neg_mul_invOption x (hr' y hy) a).lt_congr_left]
-    apply Numeric.mul_neg_of_neg_of_pos (Numeric.mul_neg_of_neg_of_pos _ _) (Numeric.inv_pos y)
+      exact Numeric.leftMove_lt hyx
+  · have := Numeric.of_mem_rightMoves hyx
+    have := hr y hyx
+    have := (numeric_option_inv hx hl hr).2 a ha
+    rw [← IGame.sub_neg, (one_neg_mul_invOption x (hr' y hyx) a).lt_congr_left]
+    apply Numeric.mul_neg_of_neg_of_pos (Numeric.mul_neg_of_neg_of_pos _ _) (inv_pos' hy)
     · rwa [IGame.sub_neg]
     · rw [IGame.sub_pos]
-      exact Numeric.lt_rightMove hy
+      exact Numeric.lt_rightMove hyx
 
-lemma numeric_inv {x : IGame} [Numeric x] (hx : 0 < x)
+lemma numeric_inv {x : IGame} (hx : 0 < x) [Numeric x]
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
     (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
     Numeric x⁻¹ := by
-  obtain ⟨Hl, Hr⟩ := mul_inv_option_mem hl hr hl' hr'
-  obtain ⟨Hl', Hr'⟩ := numeric_option_inv hl hr
+  obtain ⟨Hl, Hr⟩ := mul_inv_option_mem hx hl hr hl' hr'
+  obtain ⟨Hl', Hr'⟩ := numeric_option_inv hx hl hr
   refine Numeric.mk' (fun y hy z hz ↦ ?_) Hl' Hr'
   have := Hl' y hy
   have := Hr' z hz
   exact (Numeric.mul_lt_mul_left hx).1 <| (Hl y hy).trans (Hr z hz)
 
-lemma option_mul_inv_lt {x : IGame} [Numeric x] (hx : 0 < x)
+lemma option_mul_inv_lt {x : IGame} (hx : 0 < x) [Numeric x]
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
     (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
     (∀ y ∈ (x * x⁻¹).leftMoves, y < 1) ∧ (∀ y ∈ (x * x⁻¹).rightMoves, 1 < y) := by
   have := numeric_inv hx hl hr hl' hr'
-  obtain ⟨Hl, Hr⟩ := numeric_option_inv hl hr
+  obtain ⟨Hl, Hr⟩ := numeric_option_inv hx hl hr
   rw [forall_leftMoves_mul, forall_rightMoves_mul]
   refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩
   all_goals
-    intro y hy a ha
-    first | have := Numeric.of_mem_leftMoves hy | have := Numeric.of_mem_rightMoves hy
+    intro y hyx a ha
+    first | have := Numeric.of_mem_leftMoves hyx | have := Numeric.of_mem_rightMoves hyx
     first | have := Hl a ha | have := Hr a ha
-    try (have := hr y hy; have hy' := hx.trans (Numeric.lt_rightMove hy))
-  · obtain hy' | hy' := Numeric.lt_or_le 0 y
-    · have := hl y hy hy'
-      rw [(mulOption_self_inv x (hl' y hy hy') a).lt_congr_left, add_comm,
+    try (have := hr y hyx; have hy := hx.trans (Numeric.lt_rightMove hyx))
+  · obtain hy | hy := Numeric.lt_or_le 0 y
+    · have := hl y hyx hy
+      rw [(mulOption_self_inv x (hl' y hyx hy) a).lt_congr_left, add_comm,
         ← IGame.lt_sub_iff_add_lt, (IGame.sub_self_equiv _).lt_congr_right]
-      apply Numeric.mul_neg_of_neg_of_pos _ hy'
+      apply Numeric.mul_neg_of_neg_of_pos _ hy
       rw [IGame.sub_neg]
-      exact Numeric.lt_rightMove (invOption_left_left_mem_rightMoves_inv hy hy' ha)
-    · apply (mulOption_le _ _ hy' (Numeric.leftMove_lt ha).le).trans_lt
-      exact (mul_inv_option_mem hl hr hl' hr').1 a ha
-  · rw [(mulOption_self_inv x (hr' y hy) a).lt_congr_left, add_comm,
+      exact Numeric.lt_rightMove (invOption_left_left_mem_rightMoves_inv hx hy hyx ha)
+    · apply (mulOption_le _ _ hy (Numeric.leftMove_lt ha).le).trans_lt
+      exact (mul_inv_option_mem hx hl hr hl' hr').1 a ha
+  · rw [(mulOption_self_inv x (hr' y hyx) a).lt_congr_left, add_comm,
       ← IGame.lt_sub_iff_add_lt, (IGame.sub_self_equiv _).lt_congr_right]
-    apply Numeric.mul_neg_of_neg_of_pos _ hy'
+    apply Numeric.mul_neg_of_neg_of_pos _ hy
     rw [IGame.sub_neg]
-    exact Numeric.lt_rightMove (invOption_right_right_mem_rightMoves_inv hy ha)
-  · obtain hy' | hy' := Numeric.lt_or_le 0 y
-    · have := hl y hy hy'
-      rw [(mulOption_self_inv x (hl' y hy hy') a).lt_congr_right, add_comm,
+    exact Numeric.lt_rightMove (invOption_right_right_mem_rightMoves_inv hx hy hyx ha)
+  · obtain hy | hy := Numeric.lt_or_le 0 y
+    · have := hl y hyx hy
+      rw [(mulOption_self_inv x (hl' y hyx hy) a).lt_congr_right, add_comm,
         ← IGame.sub_lt_iff_lt_add, (IGame.sub_self_equiv _).lt_congr_left]
-      apply Numeric.mul_pos _ hy'
+      apply Numeric.mul_pos _ hy
       rw [IGame.sub_pos]
-      apply Numeric.leftMove_lt (invOption_left_right_mem_leftMoves_inv hy hy' ha)
-    · apply ((mul_inv_option_mem hl hr hl' hr').2 a ha).trans_le
-      exact le_mulOption _ _ hy' (Numeric.lt_rightMove ha).le
-  · rw [(mulOption_self_inv x (hr' y hy) a).lt_congr_right, add_comm,
+      apply Numeric.leftMove_lt (invOption_left_right_mem_leftMoves_inv hx hy hyx ha)
+    · apply ((mul_inv_option_mem hx hl hr hl' hr').2 a ha).trans_le
+      exact le_mulOption _ _ hy (Numeric.lt_rightMove ha).le
+  · rw [(mulOption_self_inv x (hr' y hyx) a).lt_congr_right, add_comm,
       ← IGame.sub_lt_iff_lt_add, (IGame.sub_self_equiv _).lt_congr_left]
-    apply Numeric.mul_pos _ hy'
+    apply Numeric.mul_pos _ hy
     rw [IGame.sub_pos]
-    exact Numeric.leftMove_lt (invOption_right_left_mem_leftMoves_inv hy ha)
+    exact Numeric.leftMove_lt (invOption_right_left_mem_leftMoves_inv hx hy hyx ha)
 
 lemma mul_inv_self {x : IGame} [Numeric x] (hx : 0 < x)
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
@@ -201,7 +201,7 @@ lemma mul_inv_self {x : IGame} [Numeric x] (hx : 0 < x)
   have := numeric_inv hx hl hr hl' hr'
   apply equiv_one_of_fits ⟨fun z hz ↦ (Hl z hz).not_le, fun z hz ↦ (Hr z hz).not_le⟩
   rw [Numeric.mul_equiv_zero, not_or]
-  exact ⟨hx.not_antisymmRel_symm, (Numeric.inv_pos x).not_antisymmRel_symm⟩
+  exact ⟨hx.not_antisymmRel_symm, (inv_pos' hx).not_antisymmRel_symm⟩
 
 theorem main {x : IGame} [Numeric x] (hx : 0 < x) : Numeric x⁻¹ ∧ x * x⁻¹ ≈ 1 := by
   have IHl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹ ∧ y * y⁻¹ ≈ 1 :=
@@ -220,96 +220,55 @@ end Surreal.Division
 
 /-! ### Instances and corollaries -/
 
-namespace IGame
+namespace IGame.Numeric
 open Surreal.Division
 
-namespace Numeric
-
--- don't forget invOption!
-
-protected theorem inv {x : IGame} [Numeric x] (hx : 0 < x) : Numeric x⁻¹ := (main hx).1
-protected theorem mul_inv_cancel {x : IGame} [Numeric x] (hx : 0 < x) : x * x⁻¹ ≈ 1 := (main hx).2
-
-theorem inv_congr {x y : IGame} [Numeric x] [Numeric y] (hx : 0 < x) (hy : x ≈ y) : x⁻¹ ≈ y⁻¹ := by
-  have hy' := hx.trans_antisymmRel hy
-  have := Numeric.inv hx
-  have := Numeric.inv hy'
-  have := (Numeric.mul_inv_cancel hx).trans (Numeric.mul_inv_cancel hy').symm
-  rw [← (Numeric.mul_congr_left hy).antisymmRel_congr_right] at this
-  exact Numeric.mul_left_cancel hx.not_antisymmRel_symm this
-
-protected instance ratCast (q : ℚ) : Numeric q := by
-  have : Numeric (q.den : IGame)⁻¹ := .inv (mod_cast q.den_pos)
-  change Numeric (_ * _)
-  infer_instance
-
-end Numeric
-
-/-- An auxiliary definition for the surreal inverse. -/
-private noncomputable def inv' (x : IGame) : IGame := by
-  classical exact if 0 < x then x⁻¹ else if x < 0 then -(-x)⁻¹ else 0
-
-private theorem inv'_zero : inv' 0 = 0 := by
-  simp [inv']
-
-private instance {x : IGame} [Numeric x] : Numeric (inv' x) := by
-  unfold inv'
+protected instance inv {x : IGame} [Numeric x] : Numeric x⁻¹ := by
   obtain h | h | h := Numeric.lt_or_equiv_or_gt x 0
-  · simpa [h, h.asymm] using Numeric.inv (IGame.zero_lt_neg.2 h)
-  · simp [h.not_lt, h.not_gt]
-  · simpa [h] using Numeric.inv h
+  · rw [← IGame.zero_lt_neg] at h
+    simpa using (main h).1
+  · simp [inv_of_equiv_zero h]
+  · exact (main h).1
 
-private theorem Numeric.mul_inv'_cancel {x : IGame} [Numeric x] (hx : ¬ x ≈ 0) :
-    x * (inv' x) ≈ 1 := by
-  unfold inv'
+protected theorem mul_inv_cancel {x : IGame} [Numeric x] (hx : ¬ x ≈ 0) : x * x⁻¹ ≈ 1 := by
   obtain h | h | h := Numeric.lt_or_equiv_or_gt x 0
-  · simpa [h, h.asymm] using Numeric.mul_inv_cancel (IGame.zero_lt_neg.2 h)
+  · rw [← IGame.zero_lt_neg] at h
+    simpa using (main h).2
   · contradiction
-  · simpa [h] using Numeric.mul_inv_cancel h
+  · exact (main h).2
 
-private theorem Numeric.inv'_congr {x y : IGame} [Numeric x] [Numeric y] (hy : x ≈ y) :
-    inv' x ≈ inv' y := by
-  unfold inv'
-  obtain h | h | h := Numeric.lt_or_equiv_or_gt y 0
-  · have h' := hy.trans_lt h
-    rw [if_neg h.asymm, if_neg h'.asymm, if_pos h, if_pos h', neg_equiv_neg_iff]
-    rw [← IGame.zero_lt_neg] at h'
-    apply Numeric.inv_congr h'
-    rwa [neg_equiv_neg_iff]
-  · have h' := hy.trans h
-    rw [if_neg h.not_lt, if_neg h'.not_lt, if_neg h.not_gt, if_neg h'.not_gt]
-  · have h' := h.trans_antisymmRel hy.symm
-    rw [if_pos h, if_pos h']
-    exact Numeric.inv_congr h' hy
+theorem inv_congr {x y : IGame} [Numeric x] [Numeric y] (he : x ≈ y) : x⁻¹ ≈ y⁻¹ := by
+  by_cases hy : y ≈ 0
+  · rw [inv_of_equiv_zero hy, inv_of_equiv_zero (he.trans hy)]
+  · have hx := (hy <| he.symm.trans ·)
+    have := (Numeric.mul_inv_cancel hx).trans (Numeric.mul_inv_cancel hy).symm
+    rw [← (Numeric.mul_congr_left he).antisymmRel_congr_right] at this
+    exact Numeric.mul_left_cancel hx this
 
-end IGame
+protected instance div (x y : IGame) [Numeric x] [Numeric y] : Numeric (x / y) := .mul ..
+protected instance ratCast (q : ℚ) : Numeric q := .div ..
+
+protected instance invOption (x y a : IGame) [Numeric x] [Numeric y] [Numeric a] :
+    Numeric (invOption x y a) :=
+  .div ..
+
+end IGame.Numeric
 
 namespace Surreal
 
 noncomputable instance : LinearOrderedField Surreal where
-  inv := Quotient.map (fun x ↦ ⟨inv' x, by infer_instance⟩) fun _ _ ↦ Numeric.inv'_congr
-  mul_inv_cancel := by rintro ⟨a⟩ h; exact mk_eq (Numeric.mul_inv'_cancel (mk_eq_mk.not.1 h))
-  inv_zero := by change mk (inv' 0) = _; simp [inv'_zero]
+  inv := Quotient.map (fun x ↦ ⟨x⁻¹, by infer_instance⟩) fun _ _ ↦ Numeric.inv_congr
+  mul_inv_cancel := by rintro ⟨a⟩ h; exact mk_eq (Numeric.mul_inv_cancel (mk_eq_mk.not.1 h))
+  inv_zero := by change mk 0⁻¹ = _; simp [inv_zero]
   qsmul := _
   nnqsmul := _
 
-theorem mk_inv_of_pos {x : IGame} (h : 0 < x) [Numeric x] : @mk x⁻¹ (.inv h) = (mk x)⁻¹ := by
-  change _ = mk (inv' _)
-  unfold inv'
-  simp_rw [if_pos h]
-
-theorem mk_div_of_pos (x : IGame) {y : IGame} (h : 0 < y) [Numeric x] [Numeric y] :
-    @mk (x / y) (@Numeric.div x y _ (.inv h)) = mk x / mk y := by
-  have := Numeric.inv h
-  simp_rw [IGame.div_eq_mul_inv, mk_mul, mk_inv_of_pos h]
-  rfl
+@[simp] theorem mk_inv (x : IGame) [Numeric x] : mk x⁻¹ = (mk x)⁻¹ := rfl
+@[simp] theorem mk_div (x y : IGame) [Numeric x] [Numeric y] : mk (x / y) = mk x / mk y := rfl
 
 @[simp]
 theorem mk_ratCast (q : ℚ) : mk q = q := by
-  simp_rw [ratCast_def]
-  rw [mk_div_of_pos]
-  · conv_rhs => rw [← q.num_div_den]
-    simp
-  · exact_mod_cast q.den_pos
+  conv_rhs => rw [← q.num_div_den]
+  simp [ratCast_def]
 
 end Surreal

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -88,7 +88,7 @@ theorem le_mulOption (x y : IGame) {a b : IGame} [Numeric x] [Numeric y] [Numeri
 
 /-! ### Inductive proof -/
 
-lemma numeric_option_inv {x : IGame} (hx : 0 < x) [Numeric x]
+lemma numeric_option_inv {x : IGame} [Numeric x] (hx : 0 < x)
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹) :
     (∀ y ∈ x⁻¹.leftMoves, Numeric y) ∧ (∀ y ∈ x⁻¹.rightMoves, Numeric y) := by
   apply invRec hx Numeric.zero
@@ -100,7 +100,7 @@ lemma numeric_option_inv {x : IGame} (hx : 0 < x) [Numeric x]
       have := Numeric.of_mem_rightMoves hyx; have := hr _ hyx
     infer_instance
 
-lemma mul_inv_option_mem {x : IGame} (hx : 0 < x) [Numeric x]
+lemma mul_inv_option_mem {x : IGame} [Numeric x] (hx : 0 < x)
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
     (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
     (∀ y ∈ x⁻¹.leftMoves, x * y < 1) ∧ (∀ y ∈ x⁻¹.rightMoves, 1 < x * y) := by
@@ -140,7 +140,7 @@ lemma mul_inv_option_mem {x : IGame} (hx : 0 < x) [Numeric x]
     · rw [IGame.sub_pos]
       exact Numeric.lt_rightMove hyx
 
-lemma numeric_inv {x : IGame} (hx : 0 < x) [Numeric x]
+lemma numeric_inv {x : IGame} [Numeric x] (hx : 0 < x)
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
     (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
     Numeric x⁻¹ := by
@@ -151,7 +151,7 @@ lemma numeric_inv {x : IGame} (hx : 0 < x) [Numeric x]
   have := Hr' z hz
   exact (Numeric.mul_lt_mul_left hx).1 <| (Hl y hy).trans (Hr z hz)
 
-lemma option_mul_inv_lt {x : IGame} (hx : 0 < x) [Numeric x]
+lemma option_mul_inv_lt {x : IGame} [Numeric x] (hx : 0 < x)
     (hl : ∀ y ∈ x.leftMoves, 0 < y → Numeric y⁻¹) (hr : ∀ y ∈ x.rightMoves, Numeric y⁻¹)
     (hl' : ∀ y ∈ x.leftMoves, 0 < y → y * y⁻¹ ≈ 1) (hr' : ∀ y ∈ x.rightMoves, y * y⁻¹ ≈ 1) :
     (∀ y ∈ (x * x⁻¹).leftMoves, y < 1) ∧ (∀ y ∈ (x * x⁻¹).rightMoves, 1 < y) := by

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -215,6 +215,8 @@ open Surreal.Division
 
 namespace Numeric
 
+-- don't forget invOption!
+
 protected theorem inv {x : IGame} [Numeric x] (hx : 0 < x) : Numeric x⁻¹ := (main hx).1
 protected theorem mul_inv_cancel {x : IGame} [Numeric x] (hx : 0 < x) : x * x⁻¹ ≈ 1 := (main hx).2
 

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -30,6 +30,16 @@ numbers.
 
 open IGame
 
+private instance Numeric.div' (x y : IGame) [Numeric x] [Numeric y⁻¹] : Numeric (x / y) := .mul
+
+private instance Numeric.invOption' {x y a : IGame}
+    [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] : Numeric (invOption x y a) :=
+  .mul
+
+private theorem Surreal.mk_div' (x y : IGame) [Numeric x] [Numeric y⁻¹] :
+    Surreal.mk (x / y) = Surreal.mk x * Surreal.mk y⁻¹ :=
+  Surreal.mk_mul ..
+
 namespace Surreal.Division
 
 /-! ### Arithmetic lemmas -/

--- a/CombinatorialGames/Surreal/Multiplication.lean
+++ b/CombinatorialGames/Surreal/Multiplication.lean
@@ -474,12 +474,12 @@ end Surreal.Multiplication
 namespace IGame.Numeric
 open Surreal.Multiplication
 
-variable {x x₁ x₂ y y₁ y₂ a b : IGame}
+variable {x x₁ x₂ y y₁ y₂: IGame}
 
-instance mul [hx : Numeric x] [hy : Numeric y] : Numeric (x * y) :=
+instance mul (x y : IGame) [hx : Numeric x] [hy : Numeric y] : Numeric (x * y) :=
   main _ <| Args.numeric_P1.mpr ⟨hx, hy⟩
 
-instance mulOption [Numeric x] [Numeric y] [Numeric a] [Numeric b] :
+instance mulOption (x y a b : IGame) [Numeric x] [Numeric y] [Numeric a] [Numeric b] :
     Numeric (mulOption x y a b) :=
   inferInstanceAs (Numeric (_ - _))
 

--- a/CombinatorialGames/Surreal/Multiplication.lean
+++ b/CombinatorialGames/Surreal/Multiplication.lean
@@ -483,15 +483,6 @@ instance mulOption [Numeric x] [Numeric y] [Numeric a] [Numeric b] :
     Numeric (mulOption x y a b) :=
   inferInstanceAs (Numeric (_ - _))
 
-/-- Note that this assumes `y⁻¹` numeric. -/
-instance div (x y : IGame) [Numeric x] [Numeric y⁻¹] : Numeric (x / y) :=
-  inferInstanceAs (Numeric (_ * _))
-
-/-- Note that this assumes `y⁻¹` numeric. -/
-instance invOption (x y a : IGame) [Numeric x] [Numeric y] [Numeric y⁻¹] [Numeric a] :
-    Numeric (invOption x y a) :=
-  inferInstanceAs (Numeric (_ / _))
-
 theorem mul_congr_left [Numeric x₁] [Numeric x₂] [Numeric y] (he : x₁ ≈ x₂) : x₁ * y ≈ x₂ * y :=
   Game.mk_eq_mk.1 ((main_P24 ..).1 he)
 
@@ -527,11 +518,6 @@ noncomputable instance : LinearOrderedCommRing Surreal where
 @[simp]
 theorem mk_mul (x y : IGame) [Numeric x] [Numeric y] :
     Surreal.mk (x * y) = Surreal.mk x * Surreal.mk y :=
-  rfl
-
-/-- Note that this assumes `y⁻¹` numeric. -/
-theorem mk_div' (x y : IGame) [Numeric x] [Numeric y⁻¹] :
-    Surreal.mk (x / y) = Surreal.mk x * Surreal.mk y⁻¹ :=
   rfl
 
 end Surreal


### PR DESCRIPTION
I originally intended to define `x⁻¹` on `IGame` only for positive games, leaving the inverse on negative games as just some junk value. This was a deliberate choice, since it reflects that the genetic definition for the inverse only works for positive games. However, this introduces persistent assumptions `0 < x` all over the place.

We instead redefine `x⁻¹` so that it satisfies `0⁻¹ = 0` and `(-x)⁻¹ = -x⁻¹`. This introduces extra `0 < x` assumptions on the most basic theorems for `x⁻¹`, but allows us to get rid of this assumption for everything afterwards. In particular, we now have `Numeric x → Numeric x⁻¹` and `Numeric x → ¬ x ≈ 0 → x * x⁻¹ ≈ 1`.