### PR TITLE
feat: extra theorems on `ofSets`

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -59,7 +59,7 @@ theorem equiv_mk_out (x : IGame) : x ≈ (mk x).out := (mk_out_equiv x).symm
 /-- Construct a `Game` from its left and right sets.
 
 This is given notation `{s | t}ᴳ`, where the superscript `G` is to disambiguate from set builder
-notation, and from the analogous constructor on `IGame`.
+notation, and from the analogous constructors on `IGame` and `Surreal`.
 
 Note that although this function is well-defined, this function isn't injective, nor do equivalence
 classes in `Game` have a canonical representative.  -/

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -337,7 +337,7 @@ macro "igame_wf" : tactic =>
 /-- Construct an `IGame` from its left and right sets.
 
 This is given notation `{s | t}ᴵ`, where the superscript `I` is to disambiguate from set builder
-notation, and from the analogous constructor on `Game`.
+notation, and from the analogous constructors on `Game` and `Surreal`.
 
 This function is regrettably noncomputable. Among other issues, sets simply do not carry data in
 Lean. To perform computations on `IGame` we can instead make use of the `game_cmp` tactic. -/

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -200,10 +200,8 @@ theorem toIGame_nonneg (a : NatOrdinal) : 0 ≤ a.toIGame := by
 /-! ### `NatOrdinal` to `Game` -/
 
 /-- Converts an ordinal into the corresponding game. -/
-noncomputable def toGame : NatOrdinal.{u} ↪o Game.{u} where
-  toFun o := .mk o.toIGame
-  inj' a b := by simp [le_antisymm_iff]
-  map_rel_iff' := toIGame_le_iff
+noncomputable def toGame : NatOrdinal.{u} ↪o Game.{u} :=
+  .ofStrictMono (fun o ↦ .mk o.toIGame) fun _ _ h ↦ toIGame.strictMono h
 
 @[simp] theorem _root_.Game.mk_toIGame (o : NatOrdinal) : .mk o.toIGame = o.toGame := rfl
 

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -113,7 +113,7 @@ instance : CharZero NatOrdinal where
     apply_fun toOrdinal at h
     simpa using h
 
-/-! ### `NatOrdinal` to `PGame` -/
+/-! ### `NatOrdinal` to `IGame` -/
 
 /-- We make this private until we can build the `OrderEmbedding`. -/
 private def toIGame' (o : NatOrdinal.{u}) : IGame.{u} :=
@@ -205,10 +205,14 @@ noncomputable def toGame : NatOrdinal.{u} ↪o Game.{u} where
   inj' a b := by simp [le_antisymm_iff]
   map_rel_iff' := toIGame_le_iff
 
-@[simp] theorem _root_.Game.mk_toPGame (o : NatOrdinal) : .mk o.toIGame = o.toGame := rfl
+@[simp] theorem _root_.Game.mk_toIGame (o : NatOrdinal) : .mk o.toIGame = o.toGame := rfl
 
-@[simp] theorem toGame_zero : toGame 0 = 0 := by simp [← Game.mk_toPGame]
-@[simp] theorem toGame_one : toGame 1 = 1 := by simp [← Game.mk_toPGame]
+theorem toGame_def (o : NatOrdinal) : o.toGame = {toGame '' Iio o | ∅}ᴳ := by
+  rw [← Game.mk_toIGame, toIGame_def]
+  simp [image_image]
+
+@[simp] theorem toGame_zero : toGame 0 = 0 := by simp [← Game.mk_toIGame]
+@[simp] theorem toGame_one : toGame 1 = 1 := by simp [← Game.mk_toIGame]
 
 theorem toGame_le_iff {a b : NatOrdinal} : toGame a ≤ toGame b ↔ a ≤ b := by simp
 theorem toGame_lt_iff {a b : NatOrdinal} : toGame a < toGame b ↔ a < b := by simp
@@ -317,7 +321,7 @@ theorem Short.exists_lt_natCast (x : IGame) [Short x] : ∃ n : ℕ, x < n := by
     have := Short.of_mem_leftMoves y.2
     exact Short.exists_lt_natCast y
   choose f hf using this
-  obtain ⟨n, hn⟩ := (Set.finite_range f).bddAbove
+  obtain ⟨n, hn⟩ := (finite_range f).bddAbove
   refine ⟨n + 1, lt_of_le_of_lt ?_ (IGame.natCast_lt.2 (Nat.lt_succ_self _))⟩
   rw [le_iff_forall_lf]
   simpa using fun y hy ↦ ((hf ⟨y, hy⟩).trans_le (mod_cast hn ⟨⟨y, hy⟩, rfl⟩)).not_le

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -422,6 +422,10 @@ theorem game_out_eq (x : Surreal) : Game.mk x.out = x.toGame := by
 /-- Construct a `Surreal` from its left and right sets, and a proof that all elements from the left
 set are less than all the elements of the right set.
 
+This is given notation `{s | t}ˢ`, where the superscript `s` is to disambiguate from set builder
+notation, and from the analogous constructors on `IGame` and `Game`. This notation will attempt to
+construct the relevant proof using `aesop`.
+
 Note that although this function is well-defined, this function isn't injective, nor do equivalence
 classes in Surreal have a canonical representative. (Note however that every short numeric game has
 a unique "canonical" form!) -/
@@ -433,17 +437,22 @@ def ofSets (s t : Set Surreal.{u}) [Small.{u} s] [Small.{u} t]
   rw [← Surreal.mk_lt_mk, out_eq, out_eq]
   exact H x hx y hy
 
+@[inherit_doc] notation "{" s " | " t "}ˢ" => ofSets s t (by aesop)
+
 theorem toGame_ofSets (s t : Set Surreal.{u}) [Small.{u} s] [Small.{u} t]
-    (H : ∀ x ∈ s, ∀ y ∈ t, x < y) : toGame (ofSets s t H) = {toGame '' s | toGame '' t}ᴳ := by
+    (H : ∀ x ∈ s, ∀ y ∈ t, x < y) : toGame {s | t}ˢ = {toGame '' s | toGame '' t}ᴳ := by
   simp_rw [ofSets, toGame_mk, Game.mk_ofSets, Set.image_image, game_out_eq]
 
-theorem mk_ofSets {s t : Set IGame.{u}} [Small.{u} s] [Small.{u} t] [H : Numeric {s | t}ᴵ] :
+theorem mk_ofSets {s t : Set IGame.{u}} [Small.{u} s] [Small.{u} t] {H : Numeric {s | t}ᴵ} :
     mk {s | t}ᴵ = ofSets
       (.range fun x : s ↦ have : Numeric x := H.of_mem_leftMoves (by simp); mk x)
       (.range fun x : t ↦ have : Numeric x := H.of_mem_rightMoves (by simp); mk x)
       (by have := @H.leftMove_lt_rightMove; aesop) := by
   simp_rw [ofSets, ← toGame_inj, toGame_mk, Game.mk_ofSets]
   congr <;> aesop
+
+theorem zero_def : 0 = {∅ | ∅}ˢ := by apply (mk_ofSets ..).trans; congr <;> simp
+theorem one_def : 1 = {{0} | ∅}ˢ := by apply (mk_ofSets ..).trans; congr <;> aesop
 
 end Surreal
 end

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -13,7 +13,7 @@ import Mathlib.Algebra.Order.Hom.Ring
 We define the canonical map `NatOrdinal → Surreal` in terms of the map `NatOrdinal.toIGame`.
 -/
 
-open IGame Surreal
+open IGame Set Surreal
 
 noncomputable section
 
@@ -32,6 +32,10 @@ def toSurreal : NatOrdinal ↪o Surreal where
   map_rel_iff' := @toIGame_le_iff
 
 @[simp] theorem _root_.Surreal.mk_toIGame (o : NatOrdinal) : .mk o.toIGame = o.toSurreal := rfl
+
+theorem toSurreal_def (o : NatOrdinal) : o.toSurreal = {toSurreal '' Iio o | ∅}ˢ := by
+  simp_rw [← Surreal.mk_toIGame, toIGame_def o, Surreal.mk_ofSets]
+  congr <;> aesop
 
 @[simp] theorem toSurreal_zero : toSurreal 0 = 0 := by simp [← Surreal.mk_toIGame]
 @[simp] theorem toSurreal_one : toSurreal 1 = 1 := by simp [← Surreal.mk_toIGame]

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -26,10 +26,8 @@ termination_by o
 namespace NatOrdinal
 
 /-- Converts an ordinal into the corresponding surreal. -/
-def toSurreal : NatOrdinal ↪o Surreal where
-  toFun o := .mk o.toIGame
-  inj' _ _ h := toIGame_equiv_iff.1 (Quotient.exact h :)
-  map_rel_iff' := @toIGame_le_iff
+def toSurreal : NatOrdinal ↪o Surreal :=
+  .ofStrictMono (fun o ↦ .mk o.toIGame) fun _ _ h ↦ toIGame.strictMono h
 
 @[simp] theorem _root_.Surreal.mk_toIGame (o : NatOrdinal) : .mk o.toIGame = o.toSurreal := rfl
 

--- a/CombinatorialGames/Surreal/Ordinal.lean
+++ b/CombinatorialGames/Surreal/Ordinal.lean
@@ -31,6 +31,10 @@ def toSurreal : NatOrdinal ↪o Surreal :=
 
 @[simp] theorem _root_.Surreal.mk_toIGame (o : NatOrdinal) : .mk o.toIGame = o.toSurreal := rfl
 
+@[simp]
+theorem _root_.Surreal.toGame_toSurreal (o : NatOrdinal) : o.toSurreal.toGame = o.toGame :=
+  rfl
+
 theorem toSurreal_def (o : NatOrdinal) : o.toSurreal = {toSurreal '' Iio o | ∅}ˢ := by
   simp_rw [← Surreal.mk_toIGame, toIGame_def o, Surreal.mk_ofSets]
   congr <;> aesop


### PR DESCRIPTION
Most notably, we introduce notation `{s | t}ˢ` for `Surreal.ofSets s t (by aesop)`, which makes it slightly less painful to work with.

We also fix some small `PGame` → `IGame` typos.