### PR TITLE
feat: make `Real.toIGame` a cast

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -287,5 +287,21 @@ theorem intCast_add_equiv (m n : ℤ) : ((m + n : ℤ) : IGame) ≈ m + n := by
 theorem intCast_sub_equiv (m n : ℤ) : ((m - n : ℤ) : IGame) ≈ m - n := by
   simp [← Game.mk_eq_mk]
 
+@[simp, norm_cast]
+theorem zero_lt_intCast {n : ℤ} : 0 < (n : IGame) ↔ 0 < n := by
+  simpa using intCast_lt (m := 0)
+
+@[simp, norm_cast]
+theorem intCast_lt_zero {n : ℤ} : (n : IGame) < 0 ↔ n < 0 := by
+  simpa using intCast_lt (n := 0)
+
+@[simp, norm_cast]
+theorem zero_le_intCast {n : ℤ} : 0 ≤ (n : IGame) ↔ 0 ≤ n := by
+  simpa using intCast_le (m := 0)
+
+@[simp, norm_cast]
+theorem intCast_le_zero {n : ℤ} : (n : IGame) ≤ 0 ↔ n ≤ 0 := by
+  simpa using intCast_le (n := 0)
+
 end IGame
 end

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -383,6 +383,22 @@ theorem ratCast_inv_equiv (m : ℚ) : ((m⁻¹ : ℚ) : IGame) ≈ m⁻¹ := by
 theorem ratCast_div_equiv (m n : ℚ) : ((m / n : ℚ) : IGame) ≈ m / n := by
   simp [← Surreal.mk_eq_mk]
 
+@[simp, norm_cast]
+theorem zero_lt_ratCast {q : ℚ} : 0 < (q : IGame) ↔ 0 < q := by
+  simpa using ratCast_lt (m := 0)
+
+@[simp, norm_cast]
+theorem ratCast_lt_zero {q : ℚ} : (q : IGame) < 0 ↔ q < 0 := by
+  simpa using ratCast_lt (n := 0)
+
+@[simp, norm_cast]
+theorem zero_le_ratCast {q : ℚ} : 0 ≤ (q : IGame) ↔ 0 ≤ q := by
+  simpa using ratCast_le (m := 0)
+
+@[simp, norm_cast]
+theorem ratCast_le_zero {q : ℚ} : (q : IGame) ≤ 0 ↔ q ≤ 0 := by
+  simpa using ratCast_le (n := 0)
+
 -- TODO: upstream
 attribute [simp] AntisymmRel.refl
 
@@ -469,5 +485,21 @@ theorem ratCast_add (m n : ℚ) : ((m + n : ℚ) : Game) = m + n :=
 @[simp, norm_cast]
 theorem ratCast_sub (m n : ℚ) : ((m - n : ℚ) : Game) = m - n :=
   Game.mk_eq (IGame.ratCast_sub_equiv m n)
+
+@[simp, norm_cast]
+theorem zero_lt_ratCast {q : ℚ} : 0 < (q : Game) ↔ 0 < q :=
+  IGame.zero_lt_ratCast
+
+@[simp, norm_cast]
+theorem ratCast_lt_zero {q : ℚ} : (q : Game) < 0 ↔ q < 0 :=
+  IGame.ratCast_lt_zero
+
+@[simp, norm_cast]
+theorem zero_le_ratCast {q : ℚ} : 0 ≤ (q : Game) ↔ 0 ≤ q :=
+  IGame.zero_le_ratCast
+
+@[simp, norm_cast]
+theorem ratCast_le_zero {q : ℚ} : (q : Game) ≤ 0 ↔ q ≤ 0 :=
+  IGame.ratCast_le_zero
 
 end Game

--- a/CombinatorialGames/Surreal/Multiplication.lean
+++ b/CombinatorialGames/Surreal/Multiplication.lean
@@ -479,7 +479,7 @@ variable {x x₁ x₂ y y₁ y₂: IGame}
 instance mul (x y : IGame) [hx : Numeric x] [hy : Numeric y] : Numeric (x * y) :=
   main _ <| Args.numeric_P1.mpr ⟨hx, hy⟩
 
-instance mulOption (x y a b : IGame) [Numeric x] [Numeric y] [Numeric a] [Numeric b] :
+protected instance mulOption (x y a b : IGame) [Numeric x] [Numeric y] [Numeric a] [Numeric b] :
     Numeric (mulOption x y a b) :=
   inferInstanceAs (Numeric (_ - _))
 
@@ -605,5 +605,25 @@ protected theorem mul_lt_mul_right_of_neg {x y z : IGame} [Numeric x] [Numeric y
 theorem mul_equiv_zero {x y : IGame} [Numeric x] [Numeric y] : x * y ≈ 0 ↔ x ≈ 0 ∨ y ≈ 0 := by
   repeat rw [← Surreal.mk_eq_mk]
   exact @mul_eq_zero Surreal _ _ (.mk x) (.mk y)
+
+theorem mulOption_congr₁ {x₁ x₂ y a b : IGame}
+    [Numeric x₁] [Numeric x₂] [Numeric y] [Numeric a] [Numeric b] (he : x₁ ≈ x₂) :
+    mulOption x₁ y a b ≈ mulOption x₂ y a b := by
+  simp_all [← Surreal.mk_eq_mk, mulOption]
+
+theorem mulOption_congr₂ {x y₁ y₂ a b : IGame}
+    [Numeric x] [Numeric y₁] [Numeric y₂] [Numeric a] [Numeric b] (he : y₁ ≈ y₂) :
+    mulOption x y₁ a b ≈ mulOption x y₂ a b := by
+  simp_all [← Surreal.mk_eq_mk, mulOption]
+
+theorem mulOption_congr₃ {x y a₁ a₂ b : IGame}
+    [Numeric x] [Numeric y] [Numeric a₁] [Numeric a₂] [Numeric b] (he : a₁ ≈ a₂) :
+    mulOption x y a₁ b ≈ mulOption x y a₂ b := by
+  simp_all [← Surreal.mk_eq_mk, mulOption]
+
+theorem mulOption_congr₄ {x y a b₁ b₂ : IGame}
+    [Numeric x] [Numeric y] [Numeric a] [Numeric b₁] [Numeric b₂] (he : b₁ ≈ b₂) :
+    mulOption x y a b₁ ≈ mulOption x y a b₂ := by
+  simp_all [← Surreal.mk_eq_mk, mulOption]
 
 end IGame.Numeric

--- a/CombinatorialGames/Surreal/Real.lean
+++ b/CombinatorialGames/Surreal/Real.lean
@@ -26,42 +26,6 @@ open IGame
 
 noncomputable section
 
-@[simp, norm_cast]
-theorem IGame.zero_lt_ratCast {q : ℚ} : 0 < (q : IGame) ↔ 0 < q := by
-  simpa using ratCast_lt (m := 0)
-
-@[simp, norm_cast]
-theorem IGame.ratCast_lt_zero {q : ℚ} : (q : IGame) < 0 ↔ q < 0 := by
-  simpa using ratCast_lt (n := 0)
-
-@[simp, norm_cast]
-theorem IGame.zero_le_ratCast {q : ℚ} : 0 ≤ (q : IGame) ↔ 0 ≤ q := by
-  simpa using ratCast_le (m := 0)
-
-@[simp, norm_cast]
-theorem IGame.ratCast_le_zero {q : ℚ} : (q : IGame) ≤ 0 ↔ q ≤ 0 := by
-  simpa using ratCast_le (n := 0)
-
-theorem IGame.mulOption_congr₁ {x₁ x₂ y a b : IGame}
-    [Numeric x₁] [Numeric x₂] [Numeric y] [Numeric a] [Numeric b] (he : x₁ ≈ x₂) :
-    mulOption x₁ y a b ≈ mulOption x₂ y a b := by
-  simp_all [← Surreal.mk_eq_mk, mulOption]
-
-theorem IGame.mulOption_congr₂ {x y₁ y₂ a b : IGame}
-    [Numeric x] [Numeric y₁] [Numeric y₂] [Numeric a] [Numeric b] (he : y₁ ≈ y₂) :
-    mulOption x y₁ a b ≈ mulOption x y₂ a b := by
-  simp_all [← Surreal.mk_eq_mk, mulOption]
-
-theorem IGame.mulOption_congr₃ {x y a₁ a₂ b : IGame}
-    [Numeric x] [Numeric y] [Numeric a₁] [Numeric a₂] [Numeric b] (he : a₁ ≈ a₂) :
-    mulOption x y a₁ b ≈ mulOption x y a₂ b := by
-  simp_all [← Surreal.mk_eq_mk, mulOption]
-
-theorem IGame.mulOption_congr₄ {x y a b₁ b₂ : IGame}
-    [Numeric x] [Numeric y] [Numeric a] [Numeric b₁] [Numeric b₂] (he : b₁ ≈ b₂) :
-    mulOption x y a b₁ ≈ mulOption x y a b₂ := by
-  simp_all [← Surreal.mk_eq_mk, mulOption]
-
 -- TODO: upstream
 open Pointwise in
 theorem Set.neg_image {α β : Type*} [InvolutiveNeg α] [InvolutiveNeg β]
@@ -72,71 +36,80 @@ namespace Real
 
 /-! ### `ℝ` to `IGame` -/
 
-/-- We make this private until we can build the `OrderEmbedding`. -/
-private def toIGame' (x : ℝ) : IGame :=
+/-- The canonical map from `ℝ` to `IGame`, sending a real number to its Dedekind cut. -/
+@[coe, match_pattern] def toIGame (x : ℝ) : IGame :=
   {(↑) '' {q : ℚ | q < x} | (↑) '' {q : ℚ | x < q}}ᴵ
 
-private theorem Numeric.toIGame' (x : ℝ) : Numeric (toIGame' x) := by
-  rw [Real.toIGame']
+instance : Coe ℝ IGame := ⟨toIGame⟩
+
+instance Numeric.toIGame (x : ℝ) : Numeric x := by
+  rw [Real.toIGame]
   apply Numeric.mk' <;> simp only [leftMoves_ofSets, rightMoves_ofSets, Set.forall_mem_image]
   · intro x hx y hy
     dsimp at *
     exact_mod_cast hx.trans hy
   all_goals infer_instance
 
-/-- The canonical map from `ℝ` to `IGame`, sending a real number to its Dedekind cut. -/
-def toIGame : ℝ ↪o IGame := by
-  refine .ofStrictMono toIGame' fun x y h ↦ ?_
-  have := Numeric.toIGame' x
-  have := Numeric.toIGame' y
-  obtain ⟨q, hx, hy⟩ := exists_rat_btwn h
-  trans (q : IGame)
-  · apply Numeric.lt_rightMove
-    simpa [toIGame']
-  · apply Numeric.leftMove_lt
-    simpa [toIGame']
-
-theorem toIGame_def (x : ℝ) : x.toIGame = {(↑) '' {q : ℚ | q < x} | (↑) '' {q : ℚ | x < q}}ᴵ :=
-  rfl
-
-instance (x : ℝ) : Numeric x.toIGame :=
-  Numeric.toIGame' x
-
 @[simp]
-theorem leftMoves_toIGame (x : ℝ) : x.toIGame.leftMoves = (↑) '' {q : ℚ | q < x} :=
+theorem leftMoves_toIGame (x : ℝ) : leftMoves x = (↑) '' {q : ℚ | q < x} :=
   leftMoves_ofSets ..
 
 @[simp]
-theorem rightMoves_toIGame (x : ℝ) : x.toIGame.rightMoves = (↑) '' {q : ℚ | x < q} :=
+theorem rightMoves_toIGame (x : ℝ) : rightMoves x = (↑) '' {q : ℚ | x < q} :=
   rightMoves_ofSets ..
 
 theorem forall_leftMoves_toIGame {P : IGame → Prop} {x : ℝ} :
-    (∀ y ∈ leftMoves (toIGame x), P y) ↔ ∀ q : ℚ, q < x → P q := by
+    (∀ y ∈ leftMoves x, P y) ↔ ∀ q : ℚ, q < x → P q := by
   simp
 
 theorem exists_leftMoves_toIGame {P : IGame → Prop} {x : ℝ} :
-    (∃ y ∈ leftMoves (toIGame x), P y) ↔ ∃ q : ℚ, q < x ∧ P q := by
+    (∃ y ∈ leftMoves x, P y) ↔ ∃ q : ℚ, q < x ∧ P q := by
   simp
 
 theorem forall_rightMoves_toIGame {P : IGame → Prop} {x : ℝ} :
-    (∀ y ∈ rightMoves (toIGame x), P y) ↔ ∀ q : ℚ, x < q → P q := by
+    (∀ y ∈ rightMoves x, P y) ↔ ∀ q : ℚ, x < q → P q := by
   simp
 
 theorem exists_rightMoves_toIGame {P : IGame → Prop} {x : ℝ} :
-    (∃ y ∈ rightMoves (toIGame x), P y) ↔ ∃ q : ℚ, x < q ∧ P q := by
+    (∃ y ∈ rightMoves x, P y) ↔ ∃ q : ℚ, x < q ∧ P q := by
   simp
 
-theorem mem_leftMoves_toIGame_of_lt {q : ℚ} {x : ℝ} (h : q < x) :
-    (q : IGame) ∈ x.toIGame.leftMoves := by
+theorem mem_leftMoves_toIGame_of_lt {q : ℚ} {x : ℝ} (h : q < x) : (q : IGame) ∈ leftMoves x := by
   simpa
 
-theorem mem_rightMoves_toIGame_of_lt {q : ℚ} {x : ℝ} (h : x < q) :
-    (q : IGame) ∈ x.toIGame.rightMoves := by
+theorem mem_rightMoves_toIGame_of_lt {q : ℚ} {x : ℝ} (h : x < q) : (q : IGame) ∈ rightMoves x := by
   simpa
+
+/-- `Real.toIGame` as an `OrderEmbedding`. -/
+@[simps!]
+def toIGameEmbedding : ℝ ↪o IGame := by
+  refine .ofStrictMono toIGame fun x y h ↦ ?_
+  obtain ⟨q, hx, hy⟩ := exists_rat_btwn h
+  trans (q : IGame)
+  · apply Numeric.lt_rightMove
+    simpa [toIGame]
+  · apply Numeric.leftMove_lt
+    simpa [toIGame]
+
+@[simp]
+theorem toIGame_le_iff {x y : ℝ} : (x : IGame) ≤ y ↔ x ≤ y :=
+  toIGameEmbedding.le_iff_le
+
+@[simp]
+theorem toIGame_lt_iff {x y : ℝ} : (x : IGame) < y ↔ x < y :=
+  toIGameEmbedding.lt_iff_lt
+
+@[simp]
+theorem toIGame_equiv_iff {x y : ℝ} : (x : IGame) ≈ y ↔ x = y := by
+  simp [AntisymmRel, le_antisymm_iff]
+
+@[simp]
+theorem toIGame_inj {x y : ℝ} : (x : IGame) = y ↔ x = y :=
+  toIGameEmbedding.inj
 
 @[simp]
 theorem toIGame_neg (x : ℝ) : toIGame (-x) = -toIGame x := by
-  simp_rw [toIGame_def, neg_ofSets, ofSets_inj, Set.neg_image (fun _ _ ↦ ratCast_neg _)]
+  simp_rw [toIGame, neg_ofSets, ofSets_inj, Set.neg_image (fun _ _ ↦ ratCast_neg _)]
   aesop (add simp [lt_neg, neg_lt])
 
 theorem toIGame_ratCast_equiv (q : ℚ) : toIGame q ≈ q := by
@@ -165,36 +138,36 @@ theorem toIGame_zero_equiv : toIGame 0 ≈ 0 := by simpa using toIGame_natCast_e
 theorem toIGame_one_equiv : toIGame 1 ≈ 1 := by simpa using toIGame_natCast_equiv 1
 
 @[simp]
-theorem ratCast_lt_toIGame {q : ℚ} {x : ℝ} : q < x.toIGame ↔ q < x := by
+theorem ratCast_lt_toIGame {q : ℚ} {x : ℝ} : q < (x : IGame) ↔ q < x := by
   obtain h | rfl | h := lt_trichotomy (q : ℝ) x
   · exact iff_of_true (Numeric.leftMove_lt (mem_leftMoves_toIGame_of_lt h)) h
   · simpa using (toIGame_ratCast_equiv q).not_gt
   · exact iff_of_false (Numeric.lt_rightMove (mem_rightMoves_toIGame_of_lt h)).asymm h.asymm
 
 @[simp]
-theorem toIGame_lt_ratCast {q : ℚ} {x : ℝ} : x.toIGame < q ↔ x < q := by
+theorem toIGame_lt_ratCast {q : ℚ} {x : ℝ} : (x : IGame) < q ↔ x < q := by
   obtain h | rfl | h := lt_trichotomy (q : ℝ) x
   · exact iff_of_false (Numeric.leftMove_lt (mem_leftMoves_toIGame_of_lt h)).asymm h.asymm
   · simpa using (toIGame_ratCast_equiv q).not_lt
   · exact iff_of_true (Numeric.lt_rightMove (mem_rightMoves_toIGame_of_lt h)) h
 
 @[simp]
-theorem ratCast_le_toIGame {q : ℚ} {x : ℝ} : q ≤ x.toIGame ↔ q ≤ x := by
+theorem ratCast_le_toIGame {q : ℚ} {x : ℝ} : q ≤ (x : IGame) ↔ q ≤ x := by
   simp [← not_lt, ← Numeric.not_lt]
 
 @[simp]
-theorem toIGame_le_ratCast {q : ℚ} {x : ℝ} : x.toIGame ≤ q ↔ x ≤ q := by
+theorem toIGame_le_ratCast {q : ℚ} {x : ℝ} : (x : IGame) ≤ q ↔ x ≤ q := by
   simp [← not_lt, ← Numeric.not_lt]
 
 @[simp]
-theorem ratCast_equiv_toIGame {q : ℚ} {x : ℝ} : (q : IGame) ≈ x.toIGame ↔ q = x := by
+theorem ratCast_equiv_toIGame {q : ℚ} {x : ℝ} : (q : IGame) ≈ (x : IGame) ↔ q = x := by
   simp [AntisymmRel, le_antisymm_iff]
 
 @[simp]
-theorem toIGame_equiv_ratCast {q : ℚ} {x : ℝ} : x.toIGame ≈ q ↔ x = q := by
+theorem toIGame_equiv_ratCast {q : ℚ} {x : ℝ} : (x : IGame) ≈ q ↔ x = q := by
   simp [AntisymmRel, le_antisymm_iff]
 
-theorem toIGame_add_ratCast_equiv (x : ℝ) (q : ℚ) : (x + q).toIGame ≈ x.toIGame + q := by
+theorem toIGame_add_ratCast_equiv (x : ℝ) (q : ℚ) : toIGame (x + q) ≈ x + q := by
   rw [AntisymmRel, le_iff_forall_lf, le_iff_forall_lf, forall_leftMoves_add, forall_rightMoves_add]
   simp_rw [forall_leftMoves_toIGame, forall_rightMoves_toIGame, Numeric.not_le]
   refine ⟨⟨fun r hr ↦ ?_, ⟨fun r hr ↦ ?_, ?_⟩⟩ ,⟨⟨fun r hr ↦ ?_, ?_⟩, fun r hr ↦ ?_⟩⟩
@@ -225,10 +198,10 @@ theorem toIGame_add_ratCast_equiv (x : ℝ) (q : ℚ) : (x + q).toIGame ≈ x.to
   · rw [← IGame.lt_sub_iff_add_lt, ← (IGame.ratCast_sub_equiv ..).lt_congr_right]
     simpa [lt_sub_iff_add_lt]
 
-theorem toIGame_ratCast_add_equiv (q : ℚ) (x : ℝ) : (q + x).toIGame ≈ q + x.toIGame := by
+theorem toIGame_ratCast_add_equiv (q : ℚ) (x : ℝ) : toIGame (q + x) ≈ q + x := by
   simpa [add_comm] using toIGame_add_ratCast_equiv x q
 
-theorem toIGame_add_equiv (x y : ℝ) : (x + y).toIGame ≈ x.toIGame + y.toIGame := by
+theorem toIGame_add_equiv (x y : ℝ) : toIGame (x + y) ≈ x + y := by
   rw [AntisymmRel, le_iff_forall_lf, le_iff_forall_lf, forall_leftMoves_add, forall_rightMoves_add]
   simp_rw [forall_leftMoves_toIGame, forall_rightMoves_toIGame, Numeric.not_le]
   refine ⟨⟨?_, ⟨?_, ?_⟩⟩, ⟨⟨?_, ?_⟩, ?_⟩⟩ <;> intro q hq
@@ -257,26 +230,48 @@ theorem toIGame_add_equiv (x y : ℝ) : (x + y).toIGame ≈ x.toIGame + y.toIGam
     · rw [add_comm, ← IGame.lt_sub_iff_add_lt, ← (ratCast_sub_equiv ..).lt_congr_right]
       simp_all [← Rat.cast_sub]
 
-theorem toIGame_sub_ratCast_equiv (x : ℝ) (q : ℚ) : (x - q).toIGame ≈ x.toIGame - q := by
+theorem toIGame_sub_ratCast_equiv (x : ℝ) (q : ℚ) : toIGame (x - q) ≈ x - q := by
   simpa using toIGame_add_ratCast_equiv x (-q)
 
-theorem toIGame_ratCast_sub_equiv (q : ℚ) (x : ℝ) : (q - x).toIGame ≈ q - x.toIGame := by
+theorem toIGame_ratCast_sub_equiv (q : ℚ) (x : ℝ) : toIGame (q - x) ≈ q - x := by
   simpa using toIGame_ratCast_add_equiv q (-x)
 
-theorem toIGame_sub_equiv (x y : ℝ) : (x - y).toIGame ≈ x.toIGame - y.toIGame := by
+theorem toIGame_sub_equiv (x y : ℝ) : toIGame (x - y) ≈ x - y := by
   simpa using toIGame_add_equiv x (-y)
 
 /-! ### `ℝ` to `Game` -/
 
 /-- The canonical map from `ℝ` to `Game`, sending a real number to its Dedekind cut. -/
-def toGame : ℝ ↪o Game :=
-  .ofStrictMono (fun o ↦ .mk o.toIGame) fun _ _ h ↦ toIGame.strictMono h
+@[coe, match_pattern] def toGame (x : ℝ) : Game := .mk x
+
+instance : Coe ℝ Game := ⟨toGame⟩
 
 @[simp] theorem _root_.Game.mk_real_toIGame (x : ℝ) : .mk x.toIGame = x.toGame := rfl
 
 theorem toGame_def (x : ℝ) : toGame x = {(↑) '' {q : ℚ | q < x} | (↑) '' {q : ℚ | x < q}}ᴳ := by
-  rw [← Game.mk_real_toIGame, toIGame_def]
+  rw [← Game.mk_real_toIGame, toIGame]
   simp [Set.image_image]
+
+/-- `Real.toGame` as an `OrderEmbedding`. -/
+@[simps!]
+def toGameEmbedding : ℝ ↪o Game :=
+  .ofStrictMono toGame fun _ _ h ↦ toIGameEmbedding.strictMono h
+
+@[simp]
+theorem toGame_le_iff {x y : ℝ} : (x : Game) ≤ y ↔ x ≤ y :=
+  toGameEmbedding.le_iff_le
+
+@[simp]
+theorem toGame_lt_iff {x y : ℝ} : (x : Game) < y ↔ x < y :=
+  toGameEmbedding.lt_iff_lt
+
+@[simp]
+theorem toGame_equiv_iff {x y : ℝ} : (x : Game) ≈ y ↔ x = y := by
+  simp [AntisymmRel, le_antisymm_iff]
+
+@[simp]
+theorem toGame_inj {x y : ℝ} : (x : Game) = y ↔ x = y :=
+  toGameEmbedding.inj
 
 @[simp] theorem toGame_ratCast (q : ℚ) : toGame q = q := Game.mk_eq (toIGame_ratCast_equiv q)
 @[simp] theorem toGame_natCast (n : ℕ) : toGame n = n := by simpa using toGame_ratCast n
@@ -299,13 +294,14 @@ def toGameAddHom : ℝ →+o Game where
   toFun := toGame
   map_zero' := toGame_zero
   map_add' := toGame_add
-  monotone' := toGame.monotone
+  monotone' := toGameEmbedding.monotone
 
 /-! ### `ℝ` to `Surreal` -/
 
 /-- The canonical map from `ℝ` to `Surreal`, sending a real number to its Dedekind cut. -/
-def toSurreal : ℝ ↪o Surreal :=
-  .ofStrictMono (fun o ↦ .mk o.toIGame) fun _ _ h ↦ toIGame.strictMono h
+@[coe, match_pattern] def toSurreal (x : ℝ) : Surreal := .mk x
+
+instance : Coe ℝ Surreal := ⟨toSurreal⟩
 
 @[simp] theorem _root_.Surreal.mk_real_toIGame (x : ℝ) : .mk x.toIGame = x.toSurreal := rfl
 
@@ -318,7 +314,7 @@ private theorem toSurreal_def_aux {x : ℝ} :
 theorem toSurreal_def (x : ℝ) : toSurreal x =
     .ofSets ((↑) '' {q : ℚ | q < x}) ((↑) '' {q : ℚ | x < q}) toSurreal_def_aux := by
   rw [← Surreal.mk_real_toIGame]
-  simp_rw [toIGame_def, Surreal.mk_ofSets]
+  simp_rw [toIGame, Surreal.mk_ofSets]
   congr
   all_goals
     ext
@@ -326,6 +322,27 @@ theorem toSurreal_def (x : ℝ) : toSurreal x =
     · aesop
     · rintro ⟨y, hy, rfl⟩
       refine ⟨⟨y, ?_⟩, ?_⟩ <;> simp_all
+
+/-- `Real.toSurreal` as an `OrderEmbedding`. -/
+@[simps!]
+def toSurrealEmbedding : ℝ ↪o Surreal :=
+  .ofStrictMono toSurreal fun _ _ h ↦ toIGameEmbedding.strictMono h
+
+@[simp]
+theorem toSurreal_le_iff {x y : ℝ} : (x : Surreal) ≤ y ↔ x ≤ y :=
+  toSurrealEmbedding.le_iff_le
+
+@[simp]
+theorem toSurreal_lt_iff {x y : ℝ} : (x : Surreal) < y ↔ x < y :=
+  toSurrealEmbedding.lt_iff_lt
+
+@[simp]
+theorem toSurreal_equiv_iff {x y : ℝ} : (x : Surreal) ≈ y ↔ x = y := by
+  simp [AntisymmRel, le_antisymm_iff]
+
+@[simp]
+theorem toSurreal_inj {x y : ℝ} : (x : Surreal) = y ↔ x = y :=
+  toSurrealEmbedding.inj
 
 @[simp]
 theorem toSurreal_ratCast (q : ℚ) : toSurreal q = q := by
@@ -338,11 +355,11 @@ theorem toSurreal_ratCast (q : ℚ) : toSurreal q = q := by
 @[simp] theorem toSurreal_one : toSurreal 1 = 1 := by simpa using toSurreal_natCast 1
 
 @[simp]
-theorem toSurreal_add (x y : ℝ) : toSurreal (x + y) = toSurreal x + toSurreal y := by
+theorem toSurreal_add (x y : ℝ) : toSurreal (x + y) = x + y := by
   simpa using Surreal.mk_eq (toIGame_add_equiv x y)
 
 @[simp]
-theorem toSurreal_sub (x y : ℝ) : toSurreal (x - y) = toSurreal x - toSurreal y := by
+theorem toSurreal_sub (x y : ℝ) : toSurreal (x - y) = x - y := by
   simpa using Surreal.mk_eq (toIGame_sub_equiv x y)
 
 /-! For convenience, we deal with multiplication after defining `Real.toSurreal`. -/
@@ -398,7 +415,7 @@ private theorem toIGame_lt_mulOption {x : ℝ} {q r s : ℚ} (h : x * q - r * q 
   · have := toIGame_mul_le_mul' ht'
     simp_all [mulOption, ← Surreal.mk_le_mk]
 
-theorem toIGame_mul_ratCast_equiv (x : ℝ) (q : ℚ) : (x * q).toIGame ≈ x.toIGame * q := by
+theorem toIGame_mul_ratCast_equiv (x : ℝ) (q : ℚ) : (x * q).toIGame ≈ x * q := by
   rw [AntisymmRel, le_iff_forall_lf, le_iff_forall_lf, forall_leftMoves_mul, forall_rightMoves_mul]
   simp_rw [forall_leftMoves_toIGame, forall_rightMoves_toIGame, Numeric.not_le]
   refine ⟨⟨?_, ⟨?_, ?_⟩⟩, ⟨⟨?_, ?_⟩, ?_⟩⟩
@@ -414,28 +431,28 @@ theorem toIGame_mul_ratCast_equiv (x : ℝ) (q : ℚ) : (x * q).toIGame ≈ x.to
   · intro r hr y hy
     have := Numeric.of_mem_rightMoves hy
     obtain ⟨s, hs, hy⟩ := equiv_ratCast_of_mem_rightMoves_ratCast hy
-    rw [(mulOption_congr₄ hy).le_congr_left]
+    rw [(Numeric.mulOption_congr₄ hy).le_congr_left]
     apply (toIGame_lt_mulOption _).not_le
     have : 0 < (x - r) * (s - q) := by apply mul_pos <;> simpa [sub_pos]
     simp_all [sub_mul, mul_sub, lt_sub_iff_add_lt]
   · intro r hr y hy
     have := Numeric.of_mem_leftMoves hy
     obtain ⟨s, hs, hy⟩ := equiv_ratCast_of_mem_leftMoves_ratCast hy
-    rw [(mulOption_congr₄ hy).le_congr_left]
+    rw [(Numeric.mulOption_congr₄ hy).le_congr_left]
     apply (toIGame_lt_mulOption _).not_le
     have : 0 < (x - r) * (s - q) := by apply mul_pos_of_neg_of_neg <;> simpa [sub_pos]
     simp_all [sub_mul, mul_sub, lt_sub_iff_add_lt]
   · intro r hr y hy
     have := Numeric.of_mem_leftMoves hy
     obtain ⟨s, hs, hy⟩ := equiv_ratCast_of_mem_leftMoves_ratCast hy
-    rw [(mulOption_congr₄ hy).le_congr_right]
+    rw [(Numeric.mulOption_congr₄ hy).le_congr_right]
     apply (mulOption_lt_toIGame _).not_le
     have : 0 < (x - r) * (q - s) := by apply mul_pos <;> simpa [sub_pos]
     simp_all [sub_mul, mul_sub, sub_lt_iff_lt_add]
   · intro r hr y hy
     have := Numeric.of_mem_rightMoves hy
     obtain ⟨s, hs, hy⟩ := equiv_ratCast_of_mem_rightMoves_ratCast hy
-    rw [(mulOption_congr₄ hy).le_congr_right]
+    rw [(Numeric.mulOption_congr₄ hy).le_congr_right]
     apply (mulOption_lt_toIGame _).not_le
     have : 0 < (x - r) * (q - s) := by apply mul_pos_of_neg_of_neg <;> simpa [sub_pos]
     simp_all [sub_mul, mul_sub, sub_lt_iff_lt_add]
@@ -449,11 +466,11 @@ theorem toIGame_mul_ratCast_equiv (x : ℝ) (q : ℚ) : (x * q).toIGame ≈ x.to
       rw [← Numeric.lt_div_iff (by simpa), ← (ratCast_div_equiv ..).lt_congr_right]
       simpa
 
-theorem toIGame_ratCast_mul_equiv (q : ℚ) (x : ℝ) : (q * x).toIGame ≈ q * x.toIGame := by
+theorem toIGame_ratCast_mul_equiv (q : ℚ) (x : ℝ) : (q * x).toIGame ≈ q * x := by
   simpa [mul_comm] using toIGame_mul_ratCast_equiv x q
 
 private theorem ratCast_lt_mul_toIGame' {x y : ℝ} {q : ℚ}
-    (hx : 0 < x) (hy : 0 < y) (h : q < x * y) : q < toIGame x * toIGame y := by
+    (hx : 0 < x) (hy : 0 < y) (h : q < x * y) : (q : IGame) < x * y := by
   rw [← div_lt_iff₀ hy] at h
   obtain ⟨r, hr, hr'⟩ := exists_rat_btwn (max_lt h hx)
   obtain ⟨hr, hr₀⟩ := max_lt_iff.1 hr
@@ -468,7 +485,7 @@ private theorem ratCast_lt_mul_toIGame' {x y : ℝ} {q : ℚ}
       simp_all [← toSurreal_zero, ← toSurreal_ratCast]
 
 private theorem mul_toIGame_lt_ratCast' {x y : ℝ} {q : ℚ}
-    (hx : 0 < x) (hy : 0 < y) (h : x * y < q) : toIGame x * toIGame y < q := by
+    (hx : 0 < x) (hy : 0 < y) (h : x * y < q) : x * y < (q : IGame) := by
   rw [← lt_div_iff₀ hy] at h
   obtain ⟨r, hr, hr'⟩ := exists_rat_btwn h
   have hr₀ := hx.trans hr
@@ -482,8 +499,7 @@ private theorem mul_toIGame_lt_ratCast' {x y : ℝ} {q : ℚ}
   · rw [mul_comm, ← IGame.Numeric.lt_div_iff, ← (ratCast_div_equiv ..).lt_congr_right] <;>
       simp_all [← Rat.cast_div]
 
-private theorem ratCast_lt_mul_toIGame {x y : ℝ} (q : ℚ) (h : q < x * y) :
-    q < toIGame x * toIGame y := by
+private theorem ratCast_lt_mul_toIGame {x y : ℝ} (q : ℚ) (h : q < x * y) : (q : IGame) < x * y := by
   obtain hx | rfl | hx := lt_trichotomy x 0
   · obtain hy | rfl | hy := lt_trichotomy y 0
     · have := @ratCast_lt_mul_toIGame' (-x) (-y) q
@@ -501,38 +517,37 @@ private theorem ratCast_lt_mul_toIGame {x y : ℝ} (q : ℚ) (h : q < x * y) :
       simp_all
     · exact ratCast_lt_mul_toIGame' hx hy h
 
-private theorem mul_toIGame_lt_ratCast {x y : ℝ} (q : ℚ) (h : x * y < q) :
-    toIGame x * toIGame y < q := by
+private theorem mul_toIGame_lt_ratCast {x y : ℝ} (q : ℚ) (h : x * y < q) : x * y < (q : IGame) := by
   have := @ratCast_lt_mul_toIGame (-x) y (-q)
   simp_all
 
-private theorem toSurreal_mul_ratCast (x : ℝ) (q : ℚ) : toSurreal (x * q) = toSurreal x * q := by
+private theorem toSurreal_mul_ratCast (x : ℝ) (q : ℚ) : toSurreal (x * q) = x * q := by
   simpa using Surreal.mk_eq (toIGame_mul_ratCast_equiv x q)
 
 private theorem mulOption_toIGame_equiv {x y : ℝ} {q r : ℚ} :
     mulOption (toIGame x) (toIGame y) q r ≈ toIGame (q * y + x * r - q * r) := by
   simp [← Surreal.mk_eq_mk, mulOption, mul_comm, toSurreal_mul_ratCast]
 
-theorem toIGame_mul_equiv (x y : ℝ) : (x * y).toIGame ≈ x.toIGame * y.toIGame := by
+theorem toIGame_mul_equiv (x y : ℝ) : (x * y).toIGame ≈ x * y := by
   rw [AntisymmRel, le_iff_forall_lf, le_iff_forall_lf, forall_leftMoves_mul, forall_rightMoves_mul]
   simp_rw [forall_leftMoves_toIGame, forall_rightMoves_toIGame, Numeric.not_le]
   refine ⟨⟨ratCast_lt_mul_toIGame, ⟨?_, ?_⟩⟩, ⟨⟨?_, ?_⟩, mul_toIGame_lt_ratCast⟩⟩ <;>
     intro q hq r hr
-  · rw [mulOption_toIGame_equiv.lt_congr_right, toIGame.lt_iff_lt]
+  · rw [mulOption_toIGame_equiv.lt_congr_right, toIGame_lt_iff]
     have : 0 < (x - q) * (r - y) := by apply mul_pos <;> simpa [sub_pos]
     simp_all [sub_mul, mul_sub, sub_lt_iff_lt_add', add_sub_assoc]
-  · rw [mulOption_toIGame_equiv.lt_congr_right, toIGame.lt_iff_lt]
+  · rw [mulOption_toIGame_equiv.lt_congr_right, toIGame_lt_iff]
     have : 0 < (x - q) * (r - y) := by apply mul_pos_of_neg_of_neg <;> simpa [sub_pos]
     simp_all [sub_mul, mul_sub, sub_lt_iff_lt_add', add_sub_assoc]
-  · rw [mulOption_toIGame_equiv.lt_congr_left, toIGame.lt_iff_lt]
+  · rw [mulOption_toIGame_equiv.lt_congr_left, toIGame_lt_iff]
     have : 0 < (x - q) * (y - r) := by apply mul_pos <;> simpa [sub_pos]
     simp_all [sub_mul, mul_sub, lt_sub_iff_add_lt', add_sub_assoc]
-  · rw [mulOption_toIGame_equiv.lt_congr_left, toIGame.lt_iff_lt]
+  · rw [mulOption_toIGame_equiv.lt_congr_left, toIGame_lt_iff]
     have : 0 < (x - q) * (y - r) := by apply mul_pos_of_neg_of_neg <;> simpa [sub_pos]
     simp_all [sub_mul, mul_sub, lt_sub_iff_add_lt', add_sub_assoc]
 
 @[simp]
-theorem toSurreal_mul (x y : ℝ) : (x * y).toSurreal = x.toSurreal * y.toSurreal :=
+theorem toSurreal_mul (x y : ℝ) : (x * y).toSurreal = x * y :=
   Surreal.mk_eq (toIGame_mul_equiv x y)
 
 /-- `Real.toSurreal` as an `OrderRingHom`. -/
@@ -543,20 +558,20 @@ def toSurrealRingHom : ℝ →+*o Surreal where
   map_one' := toSurreal_one
   map_add' := toSurreal_add
   map_mul' := toSurreal_mul
-  monotone' := toSurreal.monotone
+  monotone' := toSurrealEmbedding.monotone
 
 @[simp]
 theorem toSurreal_inv (x : ℝ) : x⁻¹.toSurreal = x.toSurreal⁻¹ :=
   map_inv₀ toSurrealRingHom x
 
 @[simp]
-theorem toSurreal_div (x y : ℝ) : (x / y).toSurreal = x.toSurreal / y.toSurreal :=
+theorem toSurreal_div (x y : ℝ) : (x / y).toSurreal = x / y :=
   map_div₀ toSurrealRingHom x y
 
 theorem toIGame_inv_equiv (x : ℝ) : x⁻¹.toIGame ≈ x.toIGame⁻¹ := by
   simp [← Surreal.mk_eq_mk]
 
-theorem toIGame_div_equiv (x y : ℝ) : (x / y).toIGame ≈ x.toIGame / y.toIGame := by
+theorem toIGame_div_equiv (x y : ℝ) : (x / y).toIGame ≈ x / y := by
   simp [← Surreal.mk_eq_mk]
 
 end Real


### PR DESCRIPTION
We lose out on some small convenience from having the order embedding structure available immediately, but in exchange we get consistency with the casts from other numeric types.

Also, move some theorems I forgot to move in #88.