### PR TITLE
feat: surreal birthday

### DIFF
--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -430,7 +430,7 @@ theorem birthday_sub_le (x y : Game) : (x - y).birthday ≤ x.birthday + y.birth
 See https://mathoverflow.net/a/476829/147705. -/
 
 /-- Games with a bounded birthday form a small set. -/
-instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x // birthday x ≤ o} := by
+instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x | birthday x ≤ o} := by
   have : Small.{u} (mk '' {x | IGame.birthday x ≤ o}) :=
     @small_image _ _ _ _ (IGame.small_setOf_birthday_le o)
   refine @small_subset _ _ _ ?_ this
@@ -441,7 +441,7 @@ instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x // birthday
   simp_all
 
 /-- Games with a bounded birthday form a small set. -/
-instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x // birthday x < o} := by
+instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x | birthday x < o} := by
   apply @small_subset _ _ _ _ (small_setOf_birthday_le o)
   exact fun x (hx : x.birthday < _) ↦ le_of_lt hx
 

--- a/CombinatorialGames/Surreal/Birthday.lean
+++ b/CombinatorialGames/Surreal/Birthday.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2025 Aaron Liu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Liu
+-/
+import CombinatorialGames.Game.Birthday
+import CombinatorialGames.Surreal.Ordinal
+
+universe u
+noncomputable section
+
+namespace Surreal
+open IGame NatOrdinal Order Set
+
+def birthday (x : Surreal.{u}) : NatOrdinal.{u} :=
+  sInf (IGame.birthday '' {c | ∃ _ : Numeric c, mk c = x})
+
+theorem birthday_eq_iGameBirthday (x : Surreal) :
+    ∃ (y : IGame) (_ : Numeric y), mk y = x ∧ y.birthday = birthday x := by
+  have h : (IGame.birthday '' {c | ∃ _ : Numeric c, mk c = x}).Nonempty := by
+    rw [image_nonempty]
+    exact ⟨_, _, x.out_eq⟩
+  obtain ⟨c, ⟨cn, rfl⟩, hc⟩ := csInf_mem h
+  exact ⟨c, cn, rfl, hc⟩
+
+theorem birthday_mk_le (x : IGame) [Numeric x] : birthday (mk x) ≤ x.birthday :=
+  csInf_le' ⟨x, ⟨_, rfl⟩, rfl⟩
+
+@[simp]
+theorem birthday_zero : birthday 0 = 0 := by
+  simpa using birthday_mk_le 0
+
+@[simp]
+theorem birthday_eq_zero {x : Surreal} : birthday x = 0 ↔ x = 0 := by
+  obtain ⟨_, _, _, _⟩ := birthday_eq_iGameBirthday x
+  refine ⟨fun _ ↦ ?_, ?_⟩ <;> simp_all
+
+private theorem birthday_neg_le (x : Surreal) : (-x).birthday ≤ x.birthday := by
+  obtain ⟨y, _, hy, hy'⟩ := birthday_eq_iGameBirthday x
+  rw [← hy', ← hy]
+  apply (birthday_mk_le _).trans
+  rw [IGame.birthday_neg]
+
+@[simp]
+theorem birthday_neg (x : Surreal) : (-x).birthday = x.birthday := by
+  apply (birthday_neg_le x).antisymm
+  simpa using birthday_neg_le (-x)
+
+theorem le_toSurreal_birthday (x : Surreal) : x ≤ x.birthday.toSurreal := by
+  obtain ⟨y, _, hy, hy'⟩ := birthday_eq_iGameBirthday x
+  rw [← hy', ← hy]
+  exact y.le_toIGame_birthday
+
+theorem neg_toSurreal_birthday_le (x : Surreal) : -x.birthday.toSurreal ≤ x := by
+  simpa [neg_le] using le_toSurreal_birthday (-x)
+
+@[simp]
+theorem birthday_toSurreal (o : NatOrdinal) : birthday o.toSurreal = o := by
+  apply le_antisymm
+  · simpa using birthday_mk_le o.toIGame
+  · simpa using o.toSurreal.le_toSurreal_birthday
+
+@[simp, norm_cast]
+theorem birthday_natCast (n : ℕ) : birthday n = n := by
+  simpa using birthday_toSurreal n
+
+@[simp]
+theorem birthday_ofNat (n : ℕ) [n.AtLeastTwo] : birthday ofNat(n) = n :=
+  birthday_natCast n
+
+@[simp]
+theorem birthday_one : birthday 1 = 1 := by
+  simpa using birthday_natCast 1
+
+theorem birthday_add_le (x y : Surreal) : (x + y).birthday ≤ x.birthday + y.birthday := by
+  obtain ⟨a, _, ha, ha'⟩ := birthday_eq_iGameBirthday x
+  obtain ⟨b, _, hb, hb'⟩ := birthday_eq_iGameBirthday y
+  rw [← ha', ← hb', ← ha, ← hb, ← IGame.birthday_add]
+  exact birthday_mk_le _
+
+theorem birthday_sub_le (x y : Surreal) : (x - y).birthday ≤ x.birthday + y.birthday := by
+  simpa using birthday_add_le x (-y)
+
+/- The bound `(x * y).birthday ≤ x.birthday * y.birthday` on surreals is currently an open problem.
+See https://mathoverflow.net/a/476829/147705. -/
+
+/--
+The birthday of a surreal number is at least the birthday of the corresponding game.
+-/
+theorem birthday_toGame_le (x : Surreal) : x.toGame.birthday ≤ x.birthday := by
+  obtain ⟨c, _, rfl, h⟩ := birthday_eq_iGameBirthday x
+  rw [← h, toGame_mk]
+  exact Game.birthday_mk_le c
+
+-- See https://mathoverflow.net/q/497321
+proof_wanted birthday_toGame (x : Surreal) : x.toGame.birthday = x.birthday
+
+/-- Surreals with a bounded birthday form a small set. -/
+instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x | birthday x ≤ o} := by
+  have h₁ : {x | birthday x ≤ o} ⊆ toGame ⁻¹' {x | x.birthday ≤ o} := by
+    intro x hx
+    exact x.birthday_toGame_le.trans hx
+  have h₂ := Set.restrictPreimage_injective {x | x.birthday ≤ o} toGame.injective
+  have : Small.{u} (toGame ⁻¹' {x | x.birthday ≤ o}):= small_of_injective h₂
+  exact small_subset h₁
+
+/-- Surreals with a bounded birthday form a small set. -/
+instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x | birthday x < o} := by
+  apply @small_subset _ _ _ _ (small_setOf_birthday_le o)
+  exact fun x (hx : x.birthday < _) ↦ le_of_lt hx
+
+end Surreal

--- a/CombinatorialGames/Surreal/Birthday.lean
+++ b/CombinatorialGames/Surreal/Birthday.lean
@@ -12,6 +12,9 @@ noncomputable section
 namespace Surreal
 open IGame NatOrdinal Order Set
 
+/--
+The birthday of a surreal number is defined as the least birthday
+among all *numeric* pre-games that define it. -/
 def birthday (x : Surreal.{u}) : NatOrdinal.{u} :=
   sInf (IGame.birthday '' {c | ∃ _ : Numeric c, mk c = x})
 


### PR DESCRIPTION
Define the birthday of a surreal number as the least birthday among all *numeric* options defining it. Copy-paste some properties from the corresponding definition for games.