### PR TITLE
fix: delab antisymmrel and incomprel (again)

### DIFF
--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -527,7 +527,7 @@ def delabEquiv : Delab := do
   have α : Q(Type u) := α
   have r : Q($α → $α → Prop) := r
   let .some le ← trySynthInstanceQ q(LE $α) | failure -- fail over to the default delaborator
-  _ ← assertDefEqQ q(($le).le) q($r)
+  if let .notDefEq ← isDefEqQ q(($le).le) q($r) then failure -- fail over to the default delaborator
   let x ← withNaryArg 2 delab
   let y ← withNaryArg 3 delab
   let stx : Term ← do
@@ -545,7 +545,7 @@ def delabFuzzy : Delab := do
   have α : Q(Type u) := α
   have r : Q($α → $α → Prop) := r
   let .some le ← trySynthInstanceQ q(LE $α) | failure -- fail over to the default delaborator
-  _ ← assertDefEqQ q(($le).le) q($r)
+  if let .notDefEq ← isDefEqQ q(($le).le) q($r) then failure -- fail over to the default delaborator
   let x ← withNaryArg 2 delab
   let y ← withNaryArg 3 delab
   let stx : Term ← do


### PR DESCRIPTION
Fail over to the default elaborator if the relation is not defeq to LE.

This *should* be the last PR fixing the delab.