### PR TITLE
feat: surreal gaps (again)

### DIFF
--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -13,12 +13,14 @@ import CombinatorialGames.Game.Specific.Domineering
 import CombinatorialGames.Game.Specific.Nim
 import CombinatorialGames.Game.Specific.Poset
 import CombinatorialGames.Game.Tactic
+import CombinatorialGames.Mathlib.Concept
 import CombinatorialGames.Mathlib.Order
 import CombinatorialGames.NatOrdinal
 import CombinatorialGames.Nimber.Basic
 import CombinatorialGames.Nimber.Field
 import CombinatorialGames.Register
 import CombinatorialGames.Surreal.Basic
+import CombinatorialGames.Surreal.Cut
 import CombinatorialGames.Surreal.Division
 import CombinatorialGames.Surreal.Dyadic
 import CombinatorialGames.Surreal.Multiplication

--- a/CombinatorialGames/Mathlib/Concept.lean
+++ b/CombinatorialGames/Mathlib/Concept.lean
@@ -1,0 +1,387 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import Mathlib.Data.Set.Lattice
+
+/-!
+# Formal concept analysis
+
+This file is a near-copy of `Mathlib.Order.Concept`, but uses the updated names and has some extra
+lemmas.
+
+Once Mathlib and this repository update, remove this file!
+-/
+
+
+open Function OrderDual Set
+
+variable {ι : Sort*} {α β : Type*} {κ : ι → Sort*} (r : α → β → Prop) {s : Set α} {t : Set β}
+
+/-! ### Lower and upper polars -/
+
+
+/-- The upper polar of `s : Set α` along a relation `r : α → β → Prop` is the set of all elements
+which `r` relates to all elements of `s`. -/
+def upperPolar (s : Set α) : Set β :=
+  { b | ∀ ⦃a⦄, a ∈ s → r a b }
+
+/-- The lower polar of `t : Set β` along a relation `r : α → β → Prop` is the set of all elements
+which `r` relates to all elements of `t`. -/
+def lowerPolar (t : Set β) : Set α :=
+  { a | ∀ ⦃b⦄, b ∈ t → r a b }
+
+variable {r}
+
+theorem subset_upperPolar_iff_subset_lowerPolar :
+    t ⊆ upperPolar r s ↔ s ⊆ lowerPolar r t :=
+  ⟨fun h _ ha _ hb => h hb ha, fun h _ hb _ ha => h ha hb⟩
+
+variable (r)
+
+theorem gc_upperPolar_lowerPolar :
+    GaloisConnection (toDual ∘ upperPolar r) (lowerPolar r ∘ ofDual) := fun _ _ =>
+  subset_upperPolar_iff_subset_lowerPolar
+
+theorem upperPolar_swap (t : Set β) : upperPolar (swap r) t = lowerPolar r t :=
+  rfl
+
+theorem lowerPolar_swap (s : Set α) : lowerPolar (swap r) s = upperPolar r s :=
+  rfl
+
+@[simp]
+theorem upperPolar_empty : upperPolar r ∅ = univ :=
+  eq_univ_of_forall fun _ _ => False.elim
+
+@[simp]
+theorem lowerPolar_empty : lowerPolar r ∅ = univ :=
+  upperPolar_empty _
+
+@[simp]
+theorem upperPolar_union (s₁ s₂ : Set α) :
+    upperPolar r (s₁ ∪ s₂) = upperPolar r s₁ ∩ upperPolar r s₂ :=
+  ext fun _ => forall₂_or_left
+
+@[simp]
+theorem lowerPolar_union (t₁ t₂ : Set β) :
+    lowerPolar r (t₁ ∪ t₂) = lowerPolar r t₁ ∩ lowerPolar r t₂ :=
+  upperPolar_union ..
+
+@[simp]
+theorem upperPolar_iUnion (f : ι → Set α) :
+    upperPolar r (⋃ i, f i) = ⋂ i, upperPolar r (f i) :=
+  (gc_upperPolar_lowerPolar r).l_iSup
+
+@[simp]
+theorem lowerPolar_iUnion (f : ι → Set β) :
+    lowerPolar r (⋃ i, f i) = ⋂ i, lowerPolar r (f i) :=
+  upperPolar_iUnion ..
+
+theorem upperPolar_iUnion₂ (f : ∀ i, κ i → Set α) :
+    upperPolar r (⋃ (i) (j), f i j) = ⋂ (i) (j), upperPolar r (f i j) :=
+  (gc_upperPolar_lowerPolar r).l_iSup₂
+
+theorem lowerPolar_iUnion₂ (f : ∀ i, κ i → Set β) :
+    lowerPolar r (⋃ (i) (j), f i j) = ⋂ (i) (j), lowerPolar r (f i j) :=
+  upperPolar_iUnion₂ ..
+
+theorem subset_lowerPolar_upperPolar (s : Set α) :
+    s ⊆ lowerPolar r (upperPolar r s) :=
+  (gc_upperPolar_lowerPolar r).le_u_l _
+
+theorem subset_upperPolar_lowerPolar (t : Set β) :
+    t ⊆ upperPolar r (lowerPolar r t) :=
+  subset_lowerPolar_upperPolar _ t
+
+@[simp]
+theorem upperPolar_lowerPolar_upperPolar (s : Set α) :
+    upperPolar r (lowerPolar r <| upperPolar r s) = upperPolar r s :=
+  (gc_upperPolar_lowerPolar r).l_u_l_eq_l _
+
+@[simp]
+theorem lowerPolar_upperPolar_lowerPolar (t : Set β) :
+    lowerPolar r (upperPolar r <| lowerPolar r t) = lowerPolar r t :=
+  upperPolar_lowerPolar_upperPolar _ t
+
+theorem upperPolar_anti : Antitone (upperPolar r) :=
+  (gc_upperPolar_lowerPolar r).monotone_l
+
+theorem lowerPolar_anti : Antitone (lowerPolar r) :=
+  upperPolar_anti _
+
+/-! ### Concepts -/
+
+variable (α β)
+
+/-- The formal concepts of a relation. A concept of `r : α → β → Prop` is a pair of sets `s`, `t`
+such that `s` is the set of all elements that are `r`-related to all of `t` and `t` is the set of
+all elements that are `r`-related to all of `s`. -/
+structure Concept where
+  /-- The extent of a concept. -/
+  extent : Set α
+  /-- The intent of a concept. -/
+  intent : Set β
+  /-- The intent consists of all elements related to all elements of the extent. -/
+  upperPolar_extent : upperPolar r extent = intent
+  /-- The extent consists of all elements related to all elements of the intent. -/
+  lowerPolar_intent : lowerPolar r intent = extent
+
+namespace Concept
+
+variable {r r' α β}
+variable {c d : Concept α β r} {c' : Concept α α r'}
+
+attribute [simp] upperPolar_extent lowerPolar_intent
+
+@[ext]
+theorem ext (h : c.extent = d.extent) : c = d := by
+  obtain ⟨s₁, t₁, h₁, _⟩ := c
+  obtain ⟨s₂, t₂, h₂, _⟩ := d
+  dsimp at h₁ h₂ h
+  substs h h₁ h₂
+  rfl
+
+theorem ext' (h : c.intent = d.intent) : c = d := by
+  obtain ⟨s₁, t₁, _, h₁⟩ := c
+  obtain ⟨s₂, t₂, _, h₂⟩ := d
+  dsimp at h₁ h₂ h
+  substs h h₁ h₂
+  rfl
+
+theorem extent_injective : Injective (@extent α β r) := fun _ _ => ext
+
+theorem intent_injective : Injective (@intent α β r) := fun _ _ => ext'
+
+theorem rel_extent_intent {x y} (hx : x ∈ c.extent) (hy : y ∈ c.intent) : r x y := by
+  rw [← c.upperPolar_extent] at hy
+  exact hy hx
+
+/-- Note that if `r'` is the `≤` relation, this theorem will often not be true! -/
+theorem disjoint_extent_intent [IsIrrefl α r'] (c' : Concept α α r') :
+    Disjoint c'.extent c'.intent := by
+  rw [disjoint_iff_forall_ne]
+  rintro x hx _ hx' rfl
+  exact irrefl x (rel_extent_intent hx hx')
+
+theorem mem_extent_of_rel_extent [IsTrans α r'] {x y} (hy : r' y x) (hx : x ∈ c'.extent) :
+    y ∈ c'.extent := by
+  rw [← lowerPolar_intent]
+  exact fun z hz ↦ _root_.trans hy (rel_extent_intent hx hz)
+
+theorem mem_intent_of_intent_rel [IsTrans α r'] {x y} (hy : r' x y) (hx : x ∈ c'.intent) :
+    y ∈ c'.intent := by
+  rw [← upperPolar_extent]
+  exact fun z hz ↦ _root_.trans (rel_extent_intent hz hx) hy
+
+theorem codisjoint_extent_intent [IsTrichotomous α r'] [IsTrans α r'] (c' : Concept α α r') :
+    Codisjoint c'.extent c'.intent := by
+  rw [codisjoint_iff_le_sup]
+  refine fun x _ ↦ or_iff_not_imp_left.2 fun hx ↦ ?_
+  rw [← upperPolar_extent]
+  intro y hy
+  obtain h | rfl | h := trichotomous_of r' x y
+  · cases hx <| mem_extent_of_rel_extent h hy
+  · contradiction
+  · assumption
+
+theorem isCompl_extent_intent [IsStrictTotalOrder α r'] (c' : Concept α α r') :
+    IsCompl c'.extent c'.intent :=
+  ⟨c'.disjoint_extent_intent, c'.codisjoint_extent_intent⟩ 
+
+/-- See `isLowerSet_extent'` for the theorem on a `<`-concept. -/
+theorem isLowerSet_extent {α : Type*} [Preorder α] (c : Concept α α (· ≤ ·)) :
+    IsLowerSet c.extent :=
+  @mem_extent_of_rel_extent _ _ _ _
+
+/-- See `isUpperSet_intent'` for the theorem on a `<`-concept. -/
+theorem isUpperSet_intent {α : Type*} [Preorder α] (c : Concept α α (· ≤ ·)) :
+    IsUpperSet c.intent :=
+  @mem_intent_of_intent_rel _ _ _ _
+
+/-- See `isLowerSet_extent` for the theorem on a `≤`-concept. -/
+theorem isLowerSet_extent' {α : Type*} [PartialOrder α] (c : Concept α α (· < ·)) :
+    IsLowerSet c.extent := by
+  intro a b hb ha
+  obtain rfl | hb := hb.eq_or_lt
+  · assumption
+  · exact mem_extent_of_rel_extent hb ha
+
+/-- See `isUpperSet_intent` for the theorem on a `≤`-concept. -/
+theorem isUpperSet_intent' {α : Type*} [PartialOrder α] (c : Concept α α (· < ·)) :
+    IsUpperSet c.intent := by
+  intro a b hb ha
+  obtain rfl | hb := hb.eq_or_lt
+  · assumption
+  · exact mem_intent_of_intent_rel hb ha
+
+instance instSupConcept : Max (Concept α β r) :=
+  ⟨fun c d =>
+    { extent := lowerPolar r (c.intent ∩ d.intent)
+      intent := c.intent ∩ d.intent
+      upperPolar_extent := by
+        rw [← c.upperPolar_extent, ← d.upperPolar_extent, ← upperPolar_union,
+          upperPolar_lowerPolar_upperPolar]
+      lowerPolar_intent := rfl }⟩
+
+instance instInfConcept : Min (Concept α β r) :=
+  ⟨fun c d =>
+    { extent := c.extent ∩ d.extent
+      intent := upperPolar r (c.extent ∩ d.extent)
+      upperPolar_extent := rfl
+      lowerPolar_intent := by
+        rw [← c.lowerPolar_intent, ← d.lowerPolar_intent, ← lowerPolar_union,
+          lowerPolar_upperPolar_lowerPolar] }⟩
+
+instance instSemilatticeInfConcept : SemilatticeInf (Concept α β r) :=
+  (extent_injective.semilatticeInf _) fun _ _ => rfl
+
+@[simp]
+theorem extent_subset_extent_iff : c.extent ⊆ d.extent ↔ c ≤ d :=
+  Iff.rfl
+
+@[simp]
+theorem extent_ssubset_extent_iff : c.extent ⊂ d.extent ↔ c < d :=
+  Iff.rfl
+
+@[simp]
+theorem intent_subset_intent_iff : c.intent ⊆ d.intent ↔ d ≤ c := by
+  refine ⟨fun h => ?_, fun h => ?_⟩
+  · rw [← extent_subset_extent_iff, ← c.lowerPolar_intent, ← d.lowerPolar_intent]
+    exact lowerPolar_anti _ h
+  · rw [← c.upperPolar_extent, ← d.upperPolar_extent]
+    exact upperPolar_anti _ h
+
+@[simp]
+theorem intent_ssubset_intent_iff : c.intent ⊂ d.intent ↔ d < c := by
+  rw [ssubset_iff_subset_not_subset, lt_iff_le_not_ge,
+    intent_subset_intent_iff, intent_subset_intent_iff]
+
+theorem strictMono_extent : StrictMono (@extent α β r) := fun _ _ =>
+  extent_ssubset_extent_iff.2
+
+theorem strictAnti_intent : StrictAnti (@intent α β r) := fun _ _ =>
+  intent_ssubset_intent_iff.2
+
+instance instLatticeConcept : Lattice (Concept α β r) :=
+  { Concept.instSemilatticeInfConcept with
+    sup := (· ⊔ ·)
+    le_sup_left := fun _ _ => intent_subset_intent_iff.1 inter_subset_left
+    le_sup_right := fun _ _ => intent_subset_intent_iff.1 inter_subset_right
+    sup_le := fun c d e => by
+      simp_rw [← intent_subset_intent_iff]
+      exact subset_inter }
+
+instance instBoundedOrderConcept : BoundedOrder (Concept α β r) where
+  top := ⟨univ, upperPolar r univ, rfl, eq_univ_of_forall fun _ _ hb => hb trivial⟩
+  le_top _ := subset_univ _
+  bot := ⟨lowerPolar r univ, univ, eq_univ_of_forall fun _ _ ha => ha trivial, rfl⟩
+  bot_le _ := intent_subset_intent_iff.1 <| subset_univ _
+
+instance : SupSet (Concept α β r) :=
+  ⟨fun S =>
+    { extent := lowerPolar r (⋂ c ∈ S, intent c)
+      intent := ⋂ c ∈ S, intent c
+      upperPolar_extent := by
+        simp_rw [← upperPolar_extent, ← upperPolar_iUnion₂, upperPolar_lowerPolar_upperPolar]
+      lowerPolar_intent := rfl }⟩
+
+instance : InfSet (Concept α β r) :=
+  ⟨fun S =>
+    { extent := ⋂ c ∈ S, extent c
+      intent := upperPolar r (⋂ c ∈ S, extent c)
+      upperPolar_extent := rfl
+      lowerPolar_intent := by
+        simp_rw [← lowerPolar_intent, ← lowerPolar_iUnion₂, lowerPolar_upperPolar_lowerPolar] }⟩
+
+instance : CompleteLattice (Concept α β r) :=
+  { Concept.instLatticeConcept,
+    Concept.instBoundedOrderConcept with
+    sup := Concept.instSupConcept.max
+    le_sSup := fun _ _ hc => intent_subset_intent_iff.1 <| biInter_subset_of_mem hc
+    sSup_le := fun _ _ hc =>
+      intent_subset_intent_iff.1 <| subset_iInter₂ fun d hd => intent_subset_intent_iff.2 <| hc d hd
+    inf := Concept.instInfConcept.min
+    sInf_le := fun _ _ => biInter_subset_of_mem
+    le_sInf := fun _ _ => subset_iInter₂ }
+
+@[simp]
+theorem extent_top : (⊤ : Concept α β r).extent = univ :=
+  rfl
+
+@[simp]
+theorem intent_top : (⊤ : Concept α β r).intent = upperPolar r univ :=
+  rfl
+
+@[simp]
+theorem extent_bot : (⊥ : Concept α β r).extent = lowerPolar r univ :=
+  rfl
+
+@[simp]
+theorem intent_bot : (⊥ : Concept α β r).intent = univ :=
+  rfl
+
+@[simp]
+theorem extent_sup (c d : Concept α β r) : (c ⊔ d).extent = lowerPolar r (c.intent ∩ d.intent) :=
+  rfl
+
+@[simp]
+theorem intent_sup (c d : Concept α β r) : (c ⊔ d).intent = c.intent ∩ d.intent :=
+  rfl
+
+@[simp]
+theorem extent_inf (c d : Concept α β r) : (c ⊓ d).extent = c.extent ∩ d.extent :=
+  rfl
+
+@[simp]
+theorem intent_inf (c d : Concept α β r) : (c ⊓ d).intent = upperPolar r (c.extent ∩ d.extent) :=
+  rfl
+
+@[simp]
+theorem extent_sSup (S : Set (Concept α β r)) :
+    (sSup S).extent = lowerPolar r (⋂ c ∈ S, intent c) :=
+  rfl
+
+@[simp]
+theorem intent_sSup (S : Set (Concept α β r)) : (sSup S).intent = ⋂ c ∈ S, intent c :=
+  rfl
+
+@[simp]
+theorem extent_sInf (S : Set (Concept α β r)) : (sInf S).extent = ⋂ c ∈ S, extent c :=
+  rfl
+
+@[simp]
+theorem intent_sInf (S : Set (Concept α β r)) :
+    (sInf S).intent = upperPolar r (⋂ c ∈ S, extent c) :=
+  rfl
+
+instance : Inhabited (Concept α β r) :=
+  ⟨⊥⟩
+
+/-- Swap the sets of a concept to make it a concept of the dual context. -/
+@[simps]
+def swap (c : Concept α β r) : Concept β α (swap r) :=
+  ⟨c.intent, c.extent, c.lowerPolar_intent, c.upperPolar_extent⟩
+
+@[simp]
+theorem swap_swap (c : Concept α β r) : c.swap.swap = c :=
+  ext rfl
+
+@[simp]
+theorem swap_le_swap_iff : c.swap ≤ d.swap ↔ d ≤ c :=
+  intent_subset_intent_iff
+
+@[simp]
+theorem swap_lt_swap_iff : c.swap < d.swap ↔ d < c :=
+  intent_ssubset_intent_iff
+
+/-- The dual of a concept lattice is isomorphic to the concept lattice of the dual context. -/
+@[simps]
+def swapEquiv : (Concept α β r)ᵒᵈ ≃o Concept β α (Function.swap r) where
+  toFun := swap ∘ ofDual
+  invFun := toDual ∘ swap
+  left_inv := swap_swap
+  right_inv := swap_swap
+  map_rel_iff' := swap_le_swap_iff
+
+end Concept

--- a/CombinatorialGames/Mathlib/Concept.lean
+++ b/CombinatorialGames/Mathlib/Concept.lean
@@ -153,6 +153,31 @@ theorem extent_injective : Injective (@extent α β r) := fun _ _ => ext
 
 theorem intent_injective : Injective (@intent α β r) := fun _ _ => ext'
 
+/-- Copy a concept, adjusting definitional equalities. -/
+def copy (c : Concept α β r) (e : Set α) (he : e = c.extent) (i : Set β) (hi : i = c.intent) :
+    Concept α β r where
+  extent := e
+  intent := i
+  upperPolar_extent := by simp_all
+  lowerPolar_intent := by simp_all
+
+@[simp]
+theorem extent_copy (c : Concept α β r)
+    (e : Set α) (he : e = c.extent) (i : Set β) (hi : i = c.intent) :
+    (c.copy e he i hi).extent = e :=
+  rfl
+
+@[simp]
+theorem intent_copy (c : Concept α β r)
+    (e : Set α) (he : e = c.extent) (i : Set β) (hi : i = c.intent) :
+    (c.copy e he i hi).intent = i :=
+  rfl
+
+theorem copy_eq (c : Concept α β r)
+    (e : Set α) (he : e = c.extent) (i : Set β) (hi : i = c.intent) :
+    c.copy e he i hi = c := by
+  ext; simp_all
+
 theorem rel_extent_intent {x y} (hx : x ∈ c.extent) (hy : y ∈ c.intent) : r x y := by
   rw [← c.upperPolar_extent] at hy
   exact hy hx
@@ -187,7 +212,7 @@ theorem codisjoint_extent_intent [IsTrichotomous α r'] [IsTrans α r'] (c' : Co
 
 theorem isCompl_extent_intent [IsStrictTotalOrder α r'] (c' : Concept α α r') :
     IsCompl c'.extent c'.intent :=
-  ⟨c'.disjoint_extent_intent, c'.codisjoint_extent_intent⟩ 
+  ⟨c'.disjoint_extent_intent, c'.codisjoint_extent_intent⟩
 
 /-- See `isLowerSet_extent'` for the theorem on a `<`-concept. -/
 theorem isLowerSet_extent {α : Type*} [Preorder α] (c : Concept α α (· ≤ ·)) :

--- a/CombinatorialGames/Surreal/Cut.lean
+++ b/CombinatorialGames/Surreal/Cut.lean
@@ -160,3 +160,5 @@ theorem leftGame_lt_rightGame_iff {x : Game} :
     exact ⟨y, le_antisymm hyl hyr⟩
   · rintro ⟨x, rfl⟩
     simpa using leftSurreal_lt_rightSurreal x
+
+end Cut

--- a/CombinatorialGames/Surreal/Cut.lean
+++ b/CombinatorialGames/Surreal/Cut.lean
@@ -1,0 +1,254 @@
+/-
+Copyright (c) 2025 Aaron Liu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Liu
+-/
+import Mathlib.Order.UpperLower.CompleteLattice
+import CombinatorialGames.Mathlib.Concept
+import CombinatorialGames.Surreal.Basic
+
+/-!
+# Surreal cuts
+
+A surreal cut is defined as consisting of two sets of surreals with the following properties:
+
+- They are complementary sets.
+- Every surreal in the first set is less than every surreal in the second set.
+
+This construction resembles the construction of the surreals themselves, but yields a "bigger"
+structure, which can embed the surreals, but is also a complete linear order.
+
+Note that surreal cuts are is **not** the same as the Dedekind completion of the surreals. Whereas
+the Dedekind completion maps every element of the original order to a unique Dedekind cut, every
+surreal number `x` actually corresponds to two cuts `(Iio x, Ici x)` and `(Iic x, Ioi x)`, which we
+call the left and right cut, respectively.
+
+The theory of concept lattices gives us a very simple definition of surreal cuts as
+`Concept Surreal Surreal (⬝ < ⬝)`. However, we've attempted to provide a thin wrapper for all
+concept terminology.
+-/
+
+universe u
+
+namespace Surreal
+open Set IGame
+
+/-- A surreal cut consists of two complementary sets of surreals, where every surreal in the former
+is less than every surreal in the latter. -/
+abbrev Cut := Concept Surreal Surreal (· < ·)
+
+namespace Cut
+
+noncomputable instance : DecidableEq Cut := Classical.decEq Cut
+
+/-- The left set in a cut. This is an alias for `Concept.extent`. -/
+def left (x : Cut) := x.extent
+/-- The right set in a cut. This is an alias for `Concept.intent`. -/
+def right (x : Cut) := x.intent
+
+alias left_lt_right := Concept.rel_extent_intent
+alias disjoint_left_right := Concept.disjoint_extent_intent
+alias codisjoint_left_right := Concept.codisjoint_extent_intent
+alias isCompl_left_right := Concept.isCompl_extent_intent
+
+alias isLowerSet_left := Concept.isLowerSet_extent'
+alias isUpperSet_left := Concept.isUpperSet_intent'
+
+-- add le and lt iffs
+
+instance : IsTotal Cut (· ≤ ·) where
+  total a b := le_total (α := LowerSet _) ⟨_, isLowerSet_left a⟩ ⟨_, isLowerSet_left b⟩
+
+noncomputable instance : LinearOrder Cut :=
+  by classical exact Lattice.toLinearOrder _
+
+noncomputable instance : CompleteLinearOrder Cut where
+  __ := instLinearOrder
+  __ := Concept.instCompleteLattice
+  __ := LinearOrder.toBiheytingAlgebra
+
+@[simp] theorem compl_left (x : Cut) : (left x)ᶜ = right x := (isCompl_left_right x).compl_eq
+@[simp] theorem compl_right (x : Cut) : (right x)ᶜ = left x := (isCompl_left_right x).eq_compl.symm
+
+theorem lt_iff_nonempty_inter {x y : Cut} : x < y ↔ (right x ∩ left y).Nonempty := by
+  rw [← not_le, ← Concept.extent_subset_extent_iff, ← diff_nonempty, diff_eq, ← left, compl_left,
+    inter_comm]
+
+  #exit
+
+/-- The cut just to the left of a surreal number. -/
+def leftSurreal : Surreal ↪o Cut where
+  toFun x := {
+    extent := Iio x
+    intent := Ici x
+    upperPolar_extent := by ext; simpa [upperPolar] using forall_lt_iff_le
+    lowerPolar_intent := by
+      aesop (add apply unsafe [lt_trans]) (add simp [lowerPolar, le_iff_eq_or_lt])
+  }
+  inj' x y := by simp [Ici_inj]
+  map_rel_iff' := Iio_subset_Iio_iff
+
+/-- The cut just to the right of a surreal number. -/
+def rightSurreal : Surreal ↪o Cut where
+  toFun x := {
+    extent := Iic x
+    intent := Ioi x
+    upperPolar_extent := by
+      aesop (add apply unsafe [lt_trans]) (add simp [upperPolar, le_iff_eq_or_lt])
+    lowerPolar_intent := by ext; simpa [lowerPolar] using forall_gt_iff_le
+  }
+  inj' x y := by simp [Ioi_inj]
+  map_rel_iff' := Iic_subset_Iic
+
+@[simp] theorem left_leftSurreal {x : Surreal} : left (leftSurreal x) = Iio x := rfl
+@[simp] theorem right_leftSurreal {x : Surreal} : right (leftSurreal x) = Ici x := rfl
+@[simp] theorem left_rightSurreal {x : Surreal} : left (rightSurreal x) = Iic x := rfl
+@[simp] theorem right_rightSurreal {x : Surreal} : right (rightSurreal x) = Ioi x := rfl
+
+theorem leftSurreal_lt_rightSurreal (x : Surreal) : leftSurreal x < rightSurreal x := by
+  rw [← not_le, extent_in]
+
+  #exit
+
+theorem leftSurreal_le_rightSurreal (x : Surreal) : leftSurreal x ≤ rightSurreal x :=
+  (leftSurreal_lt_rightSurreal x).le
+
+/--
+The cut to the left of a game.
+-/
+def leftGame : Game →o Cut where
+  toFun x := {
+    left := {y | y.toGame ⧏ x}
+    right := {y | x ≤ y.toGame}
+    left_lf_right' l hl r hr := mt toGame.le_iff_le.2 (not_le_of_not_le_of_le hl hr)
+    codisjoint' := codisjoint_iff_le_sup.2 (by simp [union_def, (em (x ≤ toGame _)).symm])
+  }
+  monotone' x y hxy := le_iff_right.2 (by simp +contextual [hxy.trans])
+
+/--
+The cut to the right of a game.
+-/
+def rightGame : Game →o Cut where
+  toFun x := {
+    left := {y | y.toGame ≤ x}
+    right := {y | x ⧏ y.toGame}
+    left_lf_right' l hl r hr := mt toGame.le_iff_le.2 (not_le_of_le_of_not_le hl hr)
+    codisjoint' := codisjoint_iff_le_sup.2 (by simp [union_def, em (toGame _ ≤ x)])
+  }
+  monotone' x y hxy := le_iff_left.2 (by simp +contextual [hxy.trans'])
+
+@[simp]
+theorem mem_left_leftGame {x : Game} {y : Surreal} :
+    y ∈ (leftGame x).left ↔ y.toGame ⧏ x := Iff.rfl
+
+@[simp]
+theorem mem_right_leftGame {x : Game} {y : Surreal} :
+    y ∈ (leftGame x).right ↔ x ≤ y.toGame := Iff.rfl
+
+@[simp]
+theorem mem_left_rightGame {x : Game} {y : Surreal} :
+    y ∈ (rightGame x).left ↔ y.toGame ≤ x := Iff.rfl
+
+@[simp]
+theorem mem_right_rightGame {x : Game} {y : Surreal} :
+    y ∈ (rightGame x).right ↔ x ⧏ y.toGame := Iff.rfl
+
+@[simp]
+theorem leftGame_toGame (x : Surreal) : leftGame x.toGame = leftSurreal x := by
+  apply Cut.ext <;> apply Set.ext <;> simp
+
+@[simp]
+theorem rightGame_toGame (x : Surreal) : rightGame x.toGame = rightSurreal x := by
+  apply Cut.ext <;> apply Set.ext <;> simp
+
+theorem leftGame_lt_rightGame_iff {x : Game} :
+    leftGame x < rightGame x ↔ x ∈ range Surreal.toGame := by
+  constructor
+  · rintro ⟨y, hyl, hyr⟩
+    exact ⟨y, le_antisymm hyl hyr⟩
+  · rintro ⟨x, rfl⟩
+    simp [leftSurreal_lt_rightSurreal]
+
+/--
+Auxiliary definition for computing the `leftGame` of an explicitly given game.
+-/
+abbrev iGameLeft (x : IGame) : Cut :=
+  ⨆ i ∈ x.leftMoves, rightGame (.mk i)
+/--
+Auxiliary definition for computing the `rightGame` of an explicitly given game.
+-/
+abbrev iGameRight (x : IGame) : Cut :=
+  ⨅ i ∈ x.rightMoves, leftGame (.mk i)
+
+theorem equiv_of_mem_iGameLeft_of_mem_iGameRight {x y : IGame} [y.Numeric]
+    (hyl : .mk y ∈ (iGameLeft x).right) (hyr : .mk y ∈ (iGameRight x).left)
+    (hol : ∀ z ∈ y.leftMoves, ∀ (_ : z.Numeric), .mk z ∈ (iGameLeft x).left)
+    (hor : ∀ z ∈ y.rightMoves, ∀ (_ : z.Numeric), .mk z ∈ (iGameRight x).right) :
+    x ≈ y := by
+  refine ⟨le_iff_forall_lf.2 ⟨?_, ?_⟩, le_iff_forall_lf.2 ⟨?_, ?_⟩⟩
+  · intro z hz
+    simp_rw [right_iSup, mem_iInter] at hyl
+    simpa using hyl z hz
+  · intro z hz
+    have nz := Numeric.of_mem_rightMoves hz
+    specialize hor z hz nz
+    simp_rw [iGameRight, right_iInf, mem_iUnion] at hor
+    obtain ⟨i, hi, hor⟩ := hor
+    refine lf_of_rightMove_le ?_ hi
+    simpa using hor
+  · intro z hz
+    have nz := Numeric.of_mem_leftMoves hz
+    specialize hol z hz nz
+    simp_rw [iGameLeft, left_iSup, mem_iUnion] at hol
+    obtain ⟨i, hi, hol⟩ := hol
+    refine lf_of_le_leftMove ?_ hi
+    simpa using hol
+  · intro z hz
+    simp_rw [left_iInf, mem_iInter] at hyr
+    simpa using hyr z hz
+
+theorem leftGame_eq_iGameLeft_of_le {x : IGame} (h : iGameRight x ≤ iGameLeft x) :
+    leftGame (.mk x) = iGameLeft x := by
+  refine ext_right (Set.ext fun y => ⟨fun hy => ?_, fun hy => ?_⟩)
+  · rw [mem_right_leftGame] at hy
+    simp_rw [right_iSup, mem_iInter, mem_right_rightGame]
+    intro i hi
+    refine not_le_of_not_le_of_le ?_ hy
+    exact mt Game.mk_le_mk.1 (lf_of_le_leftMove le_rfl hi)
+  · rw [mem_right_leftGame, ← y.out_eq, toGame_mk, Game.mk_le_mk, le_iff_forall_lf]
+    constructor
+    · intro i hi
+      simp_rw [right_iSup, mem_iInter, mem_right_rightGame] at hy
+      rw [← Game.mk_le_mk, ← toGame_mk, y.out_eq]
+      exact hy i hi
+    · intro z hz
+      rw [le_iff_right] at h
+      apply h at hy
+      simp_rw [right_iInf, mem_iUnion, mem_right_leftGame] at hy
+      obtain ⟨i, hi, hy⟩ := hy
+      refine lf_of_rightMove_le ?_ hi
+      rw [← y.out_eq, toGame_mk, Game.mk_le_mk] at hy
+      exact hy.trans (Numeric.lt_rightMove hz).le
+
+theorem rightGame_eq_iGameRight_of_le {x : IGame} (h : iGameRight x ≤ iGameLeft x) :
+    rightGame (.mk x) = iGameRight x := by
+  refine ext_left (Set.ext fun y => ⟨fun hy => ?_, fun hy => ?_⟩)
+  · rw [mem_left_rightGame] at hy
+    simp_rw [left_iInf, mem_iInter, mem_left_leftGame]
+    intro i hi
+    apply not_le_of_le_of_not_le hy
+    exact mt Game.mk_le_mk.1 (lf_of_rightMove_le le_rfl hi)
+  · rw [mem_left_rightGame, ← y.out_eq, toGame_mk, Game.mk_le_mk, le_iff_forall_lf]
+    constructor
+    · intro z hz
+      rw [le_iff_left] at h
+      apply h at hy
+      simp_rw [left_iSup, mem_iUnion, mem_left_rightGame] at hy
+      obtain ⟨i, hi, hy⟩ := hy
+      refine lf_of_le_leftMove ?_ hi
+      rw [← y.out_eq, toGame_mk, Game.mk_le_mk] at hy
+      exact (Numeric.leftMove_lt hz).le.trans hy
+    · intro i hi
+      simp_rw [left_iInf, mem_iInter, mem_left_leftGame] at hy
+      rw [← Game.mk_le_mk, ← toGame_mk y.out, y.out_eq]
+      exact hy i hi

--- a/CombinatorialGames/Surreal/Cut.lean
+++ b/CombinatorialGames/Surreal/Cut.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Aaron Liu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Aaron Liu
+Authors: Aaron Liu, Violeta Hernández Palacios
 -/
 import Mathlib.Order.UpperLower.CompleteLattice
 import CombinatorialGames.Mathlib.Concept
@@ -39,8 +39,6 @@ abbrev Cut := Concept Surreal Surreal (· < ·)
 
 namespace Cut
 
-noncomputable instance : DecidableEq Cut := Classical.decEq Cut
-
 /-- The left set in a cut. This is an alias for `Concept.extent`. -/
 def left (x : Cut) := x.extent
 /-- The right set in a cut. This is an alias for `Concept.intent`. -/
@@ -54,7 +52,13 @@ alias isCompl_left_right := Concept.isCompl_extent_intent
 alias isLowerSet_left := Concept.isLowerSet_extent'
 alias isUpperSet_left := Concept.isUpperSet_intent'
 
--- add le and lt iffs
+@[simp] theorem left_subset_left_iff {c d : Cut}: c.left ⊆ d.left ↔ c ≤ d := .rfl
+@[simp] theorem left_ssubset_left_iff {c d : Cut} : c.left ⊂ d.left ↔ c < d := .rfl
+
+@[simp] theorem right_subset_right_iff {c d : Cut}: c.right ⊆ d.right ↔ d ≤ c :=
+  Concept.intent_subset_intent_iff
+@[simp] theorem right_ssubset_right_iff {c d : Cut} : c.right ⊂ d.right ↔ d < c :=
+  Concept.intent_ssubset_intent_iff
 
 instance : IsTotal Cut (· ≤ ·) where
   total a b := le_total (α := LowerSet _) ⟨_, isLowerSet_left a⟩ ⟨_, isLowerSet_left b⟩
@@ -67,188 +71,92 @@ noncomputable instance : CompleteLinearOrder Cut where
   __ := Concept.instCompleteLattice
   __ := LinearOrder.toBiheytingAlgebra
 
-@[simp] theorem compl_left (x : Cut) : (left x)ᶜ = right x := (isCompl_left_right x).compl_eq
-@[simp] theorem compl_right (x : Cut) : (right x)ᶜ = left x := (isCompl_left_right x).eq_compl.symm
+@[simp] theorem compl_left (x : Cut) : x.leftᶜ = x.right := (isCompl_left_right x).compl_eq
+@[simp] theorem compl_right (x : Cut) : x.rightᶜ = x.left := (isCompl_left_right x).eq_compl.symm
 
-theorem lt_iff_nonempty_inter {x y : Cut} : x < y ↔ (right x ∩ left y).Nonempty := by
-  rw [← not_le, ← Concept.extent_subset_extent_iff, ← diff_nonempty, diff_eq, ← left, compl_left,
-    inter_comm]
+theorem lt_iff_nonempty_inter {x y : Cut} : x < y ↔ (x.right ∩ y.left).Nonempty := by
+  rw [← not_le, ← left_subset_left_iff, ← diff_nonempty, diff_eq_compl_inter, compl_left]
 
-  #exit
+/-- The left cut of a game `x` is such that its right set consists of surreals
+equal or larger to it. -/
+def leftGame : Game →o Cut where
+  toFun x := {
+    extent := {y | y.toGame ⧏ x}
+    intent := {y | x ≤ y.toGame}
+    upperPolar_extent := by
+      refine ext fun y ↦ ⟨?_, fun hy z hz ↦ ?_⟩
+      · simp_all [upperPolar, not_imp_comm]
+      · simpa using not_le_of_not_le_of_le hz hy
+    lowerPolar_intent := by
+      refine ext fun y ↦ ⟨fun H hx ↦ (H hx).false, fun hy z hz ↦ ?_⟩
+      simpa using not_le_of_not_le_of_le hy hz
+  }
+  monotone' x y hy z hz := not_le_of_not_le_of_le hz hy
+
+/-- The right cut of a game `x` is such that its right set consists of surreals
+equal or lesser to it. -/
+def rightGame : Game →o Cut where
+  toFun x := {
+    extent := {y | y.toGame ≤ x}
+    intent := {y | x ⧏ y.toGame}
+    upperPolar_extent := by
+      refine ext fun y ↦ ⟨fun H hx ↦ (H hx).false, fun hy z hz ↦ ?_⟩
+      simpa using not_le_of_le_of_not_le hz hy
+    lowerPolar_intent := by
+      refine ext fun y ↦ ⟨?_, fun hy z hz ↦ ?_⟩
+      · simp_all [lowerPolar, not_imp_comm]
+      · simpa using not_le_of_le_of_not_le hy hz
+  }
+  monotone' x y hy z := le_trans' hy
 
 /-- The cut just to the left of a surreal number. -/
 def leftSurreal : Surreal ↪o Cut where
-  toFun x := {
-    extent := Iio x
-    intent := Ici x
-    upperPolar_extent := by ext; simpa [upperPolar] using forall_lt_iff_le
-    lowerPolar_intent := by
-      aesop (add apply unsafe [lt_trans]) (add simp [lowerPolar, le_iff_eq_or_lt])
-  }
-  inj' x y := by simp [Ici_inj]
+  toFun x := (leftGame x.toGame).copy
+    (Iio x) (by rw [leftGame]; aesop) (Ici x) (by rw [leftGame]; aesop)
+  inj' _ := by simp [Concept.copy, Ici_inj]
   map_rel_iff' := Iio_subset_Iio_iff
 
 /-- The cut just to the right of a surreal number. -/
 def rightSurreal : Surreal ↪o Cut where
-  toFun x := {
-    extent := Iic x
-    intent := Ioi x
-    upperPolar_extent := by
-      aesop (add apply unsafe [lt_trans]) (add simp [upperPolar, le_iff_eq_or_lt])
-    lowerPolar_intent := by ext; simpa [lowerPolar] using forall_gt_iff_le
-  }
-  inj' x y := by simp [Ioi_inj]
+  toFun x := (rightGame x.toGame).copy
+    (Iic x) (by rw [rightGame]; aesop) (Ioi x) (by rw [rightGame]; aesop)
+  inj' _ := by simp [Concept.copy, Ioi_inj]
   map_rel_iff' := Iic_subset_Iic
 
-@[simp] theorem left_leftSurreal {x : Surreal} : left (leftSurreal x) = Iio x := rfl
-@[simp] theorem right_leftSurreal {x : Surreal} : right (leftSurreal x) = Ici x := rfl
-@[simp] theorem left_rightSurreal {x : Surreal} : left (rightSurreal x) = Iic x := rfl
-@[simp] theorem right_rightSurreal {x : Surreal} : right (rightSurreal x) = Ioi x := rfl
+@[simp] theorem left_leftGame (x : Game) : (leftGame x).left = {y | y.toGame ⧏ x}:= rfl
+@[simp] theorem right_leftGame (x : Game) : (leftGame x).right = {y | x ≤ y.toGame} := rfl
+@[simp] theorem left_rightGame (x : Game) : left (rightGame x) = {y | y.toGame ≤ x} := rfl
+@[simp] theorem right_rightGame (x : Game) : right (rightGame x) = {y | x ⧏ y.toGame} := rfl
 
-theorem leftSurreal_lt_rightSurreal (x : Surreal) : leftSurreal x < rightSurreal x := by
-  rw [← not_le, extent_in]
+@[simp] theorem left_leftSurreal (x : Surreal) : left (leftSurreal x) = Iio x := rfl
+@[simp] theorem right_leftSurreal (x : Surreal) : right (leftSurreal x) = Ici x := rfl
+@[simp] theorem left_rightSurreal (x : Surreal) : left (rightSurreal x) = Iic x := rfl
+@[simp] theorem right_rightSurreal (x : Surreal) : right (rightSurreal x) = Ioi x := rfl
 
-  #exit
+theorem mem_left_leftGame {x y} : y ∈ (leftGame x).left ↔ y.toGame ⧏ x := .rfl
+theorem mem_right_leftGame {x y} : y ∈ (leftGame x).right ↔ x ≤ y.toGame := .rfl
+theorem mem_left_rightGame {x y} : y ∈ (rightGame x).left ↔ y.toGame ≤ x := .rfl
+theorem mem_right_rightGame {x y} : y ∈ (rightGame x).right ↔ x ⧏ y.toGame := .rfl
 
-theorem leftSurreal_le_rightSurreal (x : Surreal) : leftSurreal x ≤ rightSurreal x :=
-  (leftSurreal_lt_rightSurreal x).le
+theorem mem_left_leftSurreal {x y} : y ∈ (leftSurreal x).left ↔ y < x := .rfl
+theorem mem_right_leftSurreal {x y} : y ∈ (leftSurreal x).right ↔ x ≤ y := .rfl
+theorem mem_left_rightSurreal {x y} : y ∈ (rightSurreal x).left ↔ y ≤ x := .rfl
+theorem mem_right_rightSurreal {x y} : y ∈ (rightSurreal x).right ↔ x < y := .rfl
 
-/--
-The cut to the left of a game.
--/
-def leftGame : Game →o Cut where
-  toFun x := {
-    left := {y | y.toGame ⧏ x}
-    right := {y | x ≤ y.toGame}
-    left_lf_right' l hl r hr := mt toGame.le_iff_le.2 (not_le_of_not_le_of_le hl hr)
-    codisjoint' := codisjoint_iff_le_sup.2 (by simp [union_def, (em (x ≤ toGame _)).symm])
-  }
-  monotone' x y hxy := le_iff_right.2 (by simp +contextual [hxy.trans])
+@[simp] theorem leftGame_toGame (x : Surreal) : leftGame x.toGame = leftSurreal x := by
+  apply Concept.copy_eq <;> simp <;> rfl
 
-/--
-The cut to the right of a game.
--/
-def rightGame : Game →o Cut where
-  toFun x := {
-    left := {y | y.toGame ≤ x}
-    right := {y | x ⧏ y.toGame}
-    left_lf_right' l hl r hr := mt toGame.le_iff_le.2 (not_le_of_le_of_not_le hl hr)
-    codisjoint' := codisjoint_iff_le_sup.2 (by simp [union_def, em (toGame _ ≤ x)])
-  }
-  monotone' x y hxy := le_iff_left.2 (by simp +contextual [hxy.trans'])
+@[simp] theorem rightGame_toGame (x : Surreal) : rightGame x.toGame = rightSurreal x := by
+  apply Concept.copy_eq <;> simp <;> rfl
 
-@[simp]
-theorem mem_left_leftGame {x : Game} {y : Surreal} :
-    y ∈ (leftGame x).left ↔ y.toGame ⧏ x := Iff.rfl
-
-@[simp]
-theorem mem_right_leftGame {x : Game} {y : Surreal} :
-    y ∈ (leftGame x).right ↔ x ≤ y.toGame := Iff.rfl
-
-@[simp]
-theorem mem_left_rightGame {x : Game} {y : Surreal} :
-    y ∈ (rightGame x).left ↔ y.toGame ≤ x := Iff.rfl
-
-@[simp]
-theorem mem_right_rightGame {x : Game} {y : Surreal} :
-    y ∈ (rightGame x).right ↔ x ⧏ y.toGame := Iff.rfl
-
-@[simp]
-theorem leftGame_toGame (x : Surreal) : leftGame x.toGame = leftSurreal x := by
-  apply Cut.ext <;> apply Set.ext <;> simp
-
-@[simp]
-theorem rightGame_toGame (x : Surreal) : rightGame x.toGame = rightSurreal x := by
-  apply Cut.ext <;> apply Set.ext <;> simp
+theorem leftSurreal_lt_rightSurreal (x : Surreal) : leftSurreal x < rightSurreal x :=
+  lt_iff_nonempty_inter.2 ⟨x, by simp⟩
 
 theorem leftGame_lt_rightGame_iff {x : Game} :
     leftGame x < rightGame x ↔ x ∈ range Surreal.toGame := by
   constructor
-  · rintro ⟨y, hyl, hyr⟩
+  · rw [lt_iff_nonempty_inter]
+    rintro ⟨y, hyr, hyl⟩
     exact ⟨y, le_antisymm hyl hyr⟩
   · rintro ⟨x, rfl⟩
-    simp [leftSurreal_lt_rightSurreal]
-
-/--
-Auxiliary definition for computing the `leftGame` of an explicitly given game.
--/
-abbrev iGameLeft (x : IGame) : Cut :=
-  ⨆ i ∈ x.leftMoves, rightGame (.mk i)
-/--
-Auxiliary definition for computing the `rightGame` of an explicitly given game.
--/
-abbrev iGameRight (x : IGame) : Cut :=
-  ⨅ i ∈ x.rightMoves, leftGame (.mk i)
-
-theorem equiv_of_mem_iGameLeft_of_mem_iGameRight {x y : IGame} [y.Numeric]
-    (hyl : .mk y ∈ (iGameLeft x).right) (hyr : .mk y ∈ (iGameRight x).left)
-    (hol : ∀ z ∈ y.leftMoves, ∀ (_ : z.Numeric), .mk z ∈ (iGameLeft x).left)
-    (hor : ∀ z ∈ y.rightMoves, ∀ (_ : z.Numeric), .mk z ∈ (iGameRight x).right) :
-    x ≈ y := by
-  refine ⟨le_iff_forall_lf.2 ⟨?_, ?_⟩, le_iff_forall_lf.2 ⟨?_, ?_⟩⟩
-  · intro z hz
-    simp_rw [right_iSup, mem_iInter] at hyl
-    simpa using hyl z hz
-  · intro z hz
-    have nz := Numeric.of_mem_rightMoves hz
-    specialize hor z hz nz
-    simp_rw [iGameRight, right_iInf, mem_iUnion] at hor
-    obtain ⟨i, hi, hor⟩ := hor
-    refine lf_of_rightMove_le ?_ hi
-    simpa using hor
-  · intro z hz
-    have nz := Numeric.of_mem_leftMoves hz
-    specialize hol z hz nz
-    simp_rw [iGameLeft, left_iSup, mem_iUnion] at hol
-    obtain ⟨i, hi, hol⟩ := hol
-    refine lf_of_le_leftMove ?_ hi
-    simpa using hol
-  · intro z hz
-    simp_rw [left_iInf, mem_iInter] at hyr
-    simpa using hyr z hz
-
-theorem leftGame_eq_iGameLeft_of_le {x : IGame} (h : iGameRight x ≤ iGameLeft x) :
-    leftGame (.mk x) = iGameLeft x := by
-  refine ext_right (Set.ext fun y => ⟨fun hy => ?_, fun hy => ?_⟩)
-  · rw [mem_right_leftGame] at hy
-    simp_rw [right_iSup, mem_iInter, mem_right_rightGame]
-    intro i hi
-    refine not_le_of_not_le_of_le ?_ hy
-    exact mt Game.mk_le_mk.1 (lf_of_le_leftMove le_rfl hi)
-  · rw [mem_right_leftGame, ← y.out_eq, toGame_mk, Game.mk_le_mk, le_iff_forall_lf]
-    constructor
-    · intro i hi
-      simp_rw [right_iSup, mem_iInter, mem_right_rightGame] at hy
-      rw [← Game.mk_le_mk, ← toGame_mk, y.out_eq]
-      exact hy i hi
-    · intro z hz
-      rw [le_iff_right] at h
-      apply h at hy
-      simp_rw [right_iInf, mem_iUnion, mem_right_leftGame] at hy
-      obtain ⟨i, hi, hy⟩ := hy
-      refine lf_of_rightMove_le ?_ hi
-      rw [← y.out_eq, toGame_mk, Game.mk_le_mk] at hy
-      exact hy.trans (Numeric.lt_rightMove hz).le
-
-theorem rightGame_eq_iGameRight_of_le {x : IGame} (h : iGameRight x ≤ iGameLeft x) :
-    rightGame (.mk x) = iGameRight x := by
-  refine ext_left (Set.ext fun y => ⟨fun hy => ?_, fun hy => ?_⟩)
-  · rw [mem_left_rightGame] at hy
-    simp_rw [left_iInf, mem_iInter, mem_left_leftGame]
-    intro i hi
-    apply not_le_of_le_of_not_le hy
-    exact mt Game.mk_le_mk.1 (lf_of_rightMove_le le_rfl hi)
-  · rw [mem_left_rightGame, ← y.out_eq, toGame_mk, Game.mk_le_mk, le_iff_forall_lf]
-    constructor
-    · intro z hz
-      rw [le_iff_left] at h
-      apply h at hy
-      simp_rw [left_iSup, mem_iUnion, mem_left_rightGame] at hy
-      obtain ⟨i, hi, hy⟩ := hy
-      refine lf_of_le_leftMove ?_ hi
-      rw [← y.out_eq, toGame_mk, Game.mk_le_mk] at hy
-      exact (Numeric.leftMove_lt hz).le.trans hy
-    · intro i hi
-      simp_rw [left_iInf, mem_iInter, mem_left_leftGame] at hy
-      rw [← Game.mk_le_mk, ← toGame_mk y.out, y.out_eq]
-      exact hy i hi
+    simpa using leftSurreal_lt_rightSurreal x


### PR DESCRIPTION
This is a partial port of #115 using the theory of concept lattices. This avoids a lengthy proof that surreal gaps form a complete lattice, though we still have to do busywork in the form of setting up aliases that hide away the concept implementation.

This PR embeds the entirety of the concept file from Mathlib; we recently did some major refactors, and I want those to be included in now rather than later. I did actually add a few theorems to that file, but they all exist (or will shortly) in other Mathlib PRs, so I don't think any reviewers of this PR need to look too carefully into them.

I didn't port the results on `iGameLeft` and `iGameRight` just yet. I think those can go into a subsequent PR.

Co-authored by: @plp127