### PR TITLE
feat: game outcomes

### DIFF
--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -20,6 +20,8 @@ import CombinatorialGames.Mathlib.Order
 import CombinatorialGames.NatOrdinal
 import CombinatorialGames.Nimber.Basic
 import CombinatorialGames.Nimber.Field
+import CombinatorialGames.Outcome.Defs
+import CombinatorialGames.Outcome.Misere
 import CombinatorialGames.Register
 import CombinatorialGames.Surreal.Basic
 import CombinatorialGames.Surreal.Birthday.Basic

--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -22,6 +22,7 @@ import CombinatorialGames.Nimber.Basic
 import CombinatorialGames.Nimber.Field
 import CombinatorialGames.Outcome.Defs
 import CombinatorialGames.Outcome.Misere
+import CombinatorialGames.Outcome.Normal
 import CombinatorialGames.Register
 import CombinatorialGames.Surreal.Basic
 import CombinatorialGames.Surreal.Birthday.Basic

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -244,6 +244,12 @@ instance (x : IGame.{u}) : Small.{u} x.rightMoves := by
   rw [rightMoves_mk]
   infer_instance
 
+/-- A game is a Left end if Left has no immediate moves -/
+def IsLeftEnd (g : IGame) : Prop := g.leftMoves = ∅
+
+/-- A game is a Right end if Right has no immediate moves -/
+def IsRightEnd (g : IGame) : Prop := g.rightMoves = ∅
+
 @[ext]
 theorem ext {x y : IGame} (hl : x.leftMoves = y.leftMoves) (hr : x.rightMoves = y.rightMoves) :
     x = y := by
@@ -1067,6 +1073,69 @@ theorem eq_intCast_of_mem_rightMoves_intCast {n : ℤ} {x : IGame} (hx : x ∈ r
     ∃ m : ℤ, n < m ∧ m = x := by
   use n + 1
   simp [eq_add_one_of_mem_rightMoves_intCast hx]
+
+/-- A game with no Left and Right options is zero -/
+theorem leftEnd_rightEnd_eq_zero {g : IGame} (hl : IsLeftEnd g) (hr : IsRightEnd g) : g = 0 := by
+  rw [zero_def]
+  rw [IsLeftEnd] at hl
+  rw [IsRightEnd] at hr
+  ext
+  · simp only [hl, Set.mem_empty_iff_false, leftMoves_ofSets]
+  · simp only [hr, Set.mem_empty_iff_false, rightMoves_ofSets]
+
+/-- A game with Left options is not zero -/
+theorem mem_leftMoves_ne_zero {g gl : IGame} (h1 : gl ∈ g.leftMoves) : g ≠ 0 := by
+  intro h2
+  simp only [h2, leftMoves_zero, Set.mem_empty_iff_false] at h1
+
+/-- A game with Right options is not zero -/
+theorem mem_rightMoves_ne_zero {g gr : IGame} (h1 : gr ∈ g.rightMoves) : g ≠ 0 := by
+  intro h2
+  simp only [h2, rightMoves_zero, Set.mem_empty_iff_false] at h1
+
+/-- A game with Left options is not zero -/
+theorem not_leftEnd_ne_zero {g : IGame} (h1 : ¬(IsLeftEnd g)) : g ≠ 0 := by
+  intro h2
+  simp only [h2, IsLeftEnd, leftMoves_zero, not_true_eq_false] at h1
+
+/-- A game with Right options is not zero -/
+theorem not_rightEnd_ne_zero {g : IGame} (h1 : ¬(IsRightEnd g)) : g ≠ 0 := by
+  intro h2
+  simp only [h2, IsRightEnd, rightMoves_zero, not_true_eq_false] at h1
+
+theorem leftEnd_neg_iff_rightEnd {g : IGame} : IsLeftEnd (-g) ↔ IsRightEnd g := by
+  constructor
+  all_goals
+  · intro h1
+    simp only [IsLeftEnd, leftMoves_neg, Set.neg_eq_empty] at *
+    exact h1
+
+theorem rightEnd_neg_iff_leftEnd {g : IGame} : IsRightEnd (-g) ↔ IsLeftEnd g := by
+  constructor
+  all_goals
+  · intro h1
+    simp only [IsRightEnd, rightMoves_neg, Set.neg_eq_empty] at *
+    exact h1
+
+/-- Non-zero game has either Left or Right options -/
+theorem ne_zero_not_leftEnd_or_not_rightEnd {g : IGame} (h1 : g ≠ 0) :
+    ¬(IsLeftEnd g) ∨ ¬(IsRightEnd g) := by
+  by_contra h2
+  simp only [not_or, not_not] at h2
+  obtain ⟨h2, h3⟩ := h2
+  exact h1 (leftEnd_rightEnd_eq_zero h2 h3)
+
+/-- Sum of Left ends is a Left end -/
+theorem add_leftEnd_leftEnd {g h : IGame} (h1 : IsLeftEnd g) (h2 : IsLeftEnd h) :
+    IsLeftEnd (g + h) := by
+  unfold IsLeftEnd at h1 h2
+  simp [h1, h2, IsLeftEnd]
+
+/-- Sum of Right ends is a Right end -/
+theorem add_rightEnd_rightEnd {g h : IGame} (h1 : IsRightEnd g) (h2 : IsRightEnd h) :
+    IsRightEnd (g + h) := by
+  unfold IsRightEnd at h1 h2
+  simp [h1, h2, IsRightEnd]
 
 /-! ### Multiplication -/
 

--- a/CombinatorialGames/Outcome/Defs.lean
+++ b/CombinatorialGames/Outcome/Defs.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2025 Tomasz Maciosowski. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomasz Maciosowski
+-/
+
+import Mathlib.Order.Defs.PartialOrder
+import Batteries.Tactic.Init
+
+inductive PlayerOutcome where
+  /-- Left wins going first -/
+  | L
+  /-- Right wins going first -/
+  | R
+
+def PlayerOutcome.Conjugate : PlayerOutcome → PlayerOutcome
+  | .L => .R
+  | .R => .L
+
+@[simp]
+theorem PlayerOutcome.eq_iff_conjugate_eq {a b : PlayerOutcome} :
+    (a.Conjugate = b.Conjugate) ↔ (a = b) := by
+  cases a <;> cases b <;> simp only [reduceCtorEq, PlayerOutcome.Conjugate]
+
+@[simp]
+theorem PlayerOutcome.conjugate_conjugate_eq_self {o : PlayerOutcome} :
+    o.Conjugate.Conjugate = o := by
+  cases o <;> exact rfl
+
+inductive Outcome where
+  /-- Left wins -/
+  | L
+  /-- Next player wins -/
+  | N
+  /-- Previous (second) player wins -/
+  | P
+  /-- Right wins -/
+  | R
+
+/--
+Game outcomes are ordered in favour of Left player (see Hasse diagram)
+
+```
+  L
+ / \
+N   P
+ \ /
+  R
+```
+-/
+instance : LT Outcome where
+  lt lhs rhs :=
+    (lhs ≠ Outcome.L ∧ rhs = Outcome.L) ∨
+    (lhs = Outcome.R ∧ rhs = Outcome.N) ∨
+    (lhs = Outcome.R ∧ rhs = Outcome.P)
+
+instance : LE Outcome where
+  le lhs rhs := (lhs = rhs) ∨ (lhs < rhs)
+
+instance : Preorder Outcome where
+  le_refl _ := Or.inl rfl
+  le_trans a b c _ _ := by
+    cases a <;> cases b <;> cases c <;> simp [LE.le, LT.lt] at *
+  lt_iff_le_not_ge a b := by
+    cases a <;> cases b <;> simp [LE.le, LT.lt] at *
+
+instance : PartialOrder Outcome where
+  le_antisymm a b _ _ := by
+    cases a <;> cases b <;> simp [LE.le, LT.lt] at *
+
+def PlayerOutcomesToGameOutcome : PlayerOutcome → PlayerOutcome → Outcome
+  | PlayerOutcome.L, PlayerOutcome.L => Outcome.L
+  | PlayerOutcome.R, PlayerOutcome.R => Outcome.R
+  | PlayerOutcome.R, PlayerOutcome.L => Outcome.P
+  | PlayerOutcome.L, PlayerOutcome.R => Outcome.N
+
+@[simp]
+theorem Outcome.ge_R (o : Outcome) : o ≥ Outcome.R := by
+  simp only [ge_iff_le]
+  unfold LE.le
+  cases o <;> simp [instLEOutcome, LT.lt]
+
+@[simp]
+theorem Outcome.L_ge (o : Outcome) : Outcome.L ≥ o := by
+  simp only [ge_iff_le]
+  unfold LE.le
+  cases o <;> simp [instLEOutcome, LT.lt]
+
+@[simp]
+theorem Outcome.ge_P_ge_N_eq_L {o : Outcome} (hp : o ≥ Outcome.P) (hn : o ≥ Outcome.N)
+    : o = Outcome.L := by
+  cases o <;> simp [LE.le, LT.lt, LE.le] at *
+
+def Outcome.Conjugate : Outcome → Outcome
+  | .L => .R
+  | .R => .L
+  | .P => .P
+  | .N => .N
+
+theorem Outcome.conjugate_conjugate_eq_self {o : Outcome} : o.Conjugate.Conjugate = o := by
+  cases o <;> rfl
+
+theorem Outcome.outcome_ge_conjugate_le {x y : Outcome} (h1 : x ≥ y) : x.Conjugate ≤ y.Conjugate := by
+  cases h2 : x
+    <;> cases h3 : y
+    <;> unfold Outcome.Conjugate
+    <;> simp only [LE.le, LT.lt, and_false, and_self, and_true, ne_eq, not_false_eq_true,
+                   not_true_eq_false, or_self, reduceCtorEq, or_false, or_true]
+    <;> simp only [h2, h3, ge_iff_le] at h1
+    <;> absurd h1
+    <;> simp only [LE.le, LT.lt, and_false, and_self, and_true, ne_eq, not_false_eq_true,
+                   not_true_eq_false, or_self, reduceCtorEq]

--- a/CombinatorialGames/Outcome/Defs.lean
+++ b/CombinatorialGames/Outcome/Defs.lean
@@ -68,7 +68,7 @@ instance : PartialOrder Outcome where
   le_antisymm a b _ _ := by
     cases a <;> cases b <;> simp [LE.le, LT.lt] at *
 
-def PlayerOutcomesToGameOutcome : PlayerOutcome → PlayerOutcome → Outcome
+def PlayerOutcome.toOutcome : PlayerOutcome → PlayerOutcome → Outcome
   | PlayerOutcome.L, PlayerOutcome.L => Outcome.L
   | PlayerOutcome.R, PlayerOutcome.R => Outcome.R
   | PlayerOutcome.R, PlayerOutcome.L => Outcome.P

--- a/CombinatorialGames/Outcome/Misere.lean
+++ b/CombinatorialGames/Outcome/Misere.lean
@@ -8,6 +8,8 @@ import CombinatorialGames.Game.Birthday
 import CombinatorialGames.Game.Short
 import CombinatorialGames.Outcome.Defs
 
+namespace Outcome.Misere
+
 mutual
 
 -- NOTE: We define these using ∀ instead of ∃ like the literature does because ∃ desugares to
@@ -65,7 +67,7 @@ noncomputable def RightOutcome (g : IGame) : PlayerOutcome :=
   if RightWinsGoingFirst g then PlayerOutcome.R else PlayerOutcome.L
 
 noncomputable def MisereOutcome : IGame → Outcome :=
-  fun g => PlayerOutcomesToGameOutcome (LeftOutcome g) (RightOutcome g)
+  fun g => PlayerOutcome.toOutcome (LeftOutcome g) (RightOutcome g)
 
 def MisereEq (A : IGame → Prop) (g h : IGame) : Prop :=
   ∀ (x : IGame), A x → MisereOutcome (g + x) = MisereOutcome (h + x)
@@ -125,20 +127,20 @@ theorem not_MisereEq_of_not_MisereGe {A : IGame → Prop} {g h : IGame} (h1 : ¬
 
 theorem not_leftWinsGoingFirst_le_P {g : IGame} (h1 : ¬LeftWinsGoingFirst g) :
     MisereOutcome g ≤ Outcome.P := by
-  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome
+  unfold MisereOutcome PlayerOutcome.toOutcome LeftOutcome
   cases h2 : LeftOutcome g <;> cases h3 : RightOutcome g
   all_goals simp only [h1, reduceIte, Outcome.ge_R, le_refl]
 
 /-- `o(G) ≥ P` is equivalent to "Left can win playing second on `G`" -/
 theorem not_rightWinsGoingFirst_ge_P {g : IGame} (h1 : ¬RightWinsGoingFirst g) :
     MisereOutcome g ≥ Outcome.P := by
-  unfold MisereOutcome PlayerOutcomesToGameOutcome RightOutcome
+  unfold MisereOutcome PlayerOutcome.toOutcome RightOutcome
   cases h2 : LeftOutcome g
   all_goals simp only [h1, reduceIte, ge_iff_le, le_refl, Outcome.L_ge]
 
 theorem outcome_eq_P_leftWinsGoingFirst {g gl : IGame} (h1 : gl ∈ g.leftMoves)
     (h2 : MisereOutcome gl = Outcome.P) : LeftWinsGoingFirst g := by
-  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome RightOutcome at h2
+  unfold MisereOutcome PlayerOutcome.toOutcome LeftOutcome RightOutcome at h2
   by_cases h3 : LeftWinsGoingFirst gl
     <;> by_cases h4 : RightWinsGoingFirst gl
     <;> simp only [h3, h4, reduceIte, reduceCtorEq] at h2
@@ -147,7 +149,7 @@ theorem outcome_eq_P_leftWinsGoingFirst {g gl : IGame} (h1 : gl ∈ g.leftMoves)
 
 theorem outcome_eq_P_rightWinsGoingFirst {g gr : IGame} (h1 : gr ∈ g.rightMoves)
     (h2 : MisereOutcome gr = Outcome.P) : RightWinsGoingFirst g := by
-  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome RightOutcome at h2
+  unfold MisereOutcome PlayerOutcome.toOutcome LeftOutcome RightOutcome at h2
   by_cases h3 : RightWinsGoingFirst gr
     <;> by_cases h4 : LeftWinsGoingFirst gr
     <;> simp only [h3, h4, reduceIte, reduceCtorEq] at h2
@@ -164,26 +166,26 @@ theorem add_rightEnd_RightWinsGoingFirst {g h : IGame} (h1 : IGame.IsRightEnd g)
 
 theorem leftWinsGoingFirst_outcome_ge_N {g : IGame} (h1 : LeftWinsGoingFirst g) :
     MisereOutcome g ≥ Outcome.N := by
-  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome
+  unfold MisereOutcome PlayerOutcome.toOutcome LeftOutcome
   cases h2 : RightOutcome g
   all_goals simp only [h1, reduceIte, ge_iff_le, le_refl, Outcome.L_ge]
 
 theorem rightWinsGoingFirst_outcome_le_N {g : IGame} (h1 : RightWinsGoingFirst g) :
     MisereOutcome g ≤ Outcome.N := by
-  unfold MisereOutcome PlayerOutcomesToGameOutcome RightOutcome
+  unfold MisereOutcome PlayerOutcome.toOutcome RightOutcome
   cases h2 : LeftOutcome g
   all_goals simp only [h1, reduceIte, le_refl, Outcome.ge_R]
 
 theorem outcome_eq_P_not_leftWinsGoingFirst {g : IGame} (h1 : MisereOutcome g = Outcome.P) :
     ¬LeftWinsGoingFirst g := by
   intro h2
-  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome at h1
+  unfold MisereOutcome PlayerOutcome.toOutcome LeftOutcome at h1
   cases h3 : RightOutcome g <;> simp only [h2, h3, reduceIte, reduceCtorEq] at h1
 
 theorem outcome_eq_P_not_rightWinsGoingFirst {g : IGame} (h1 : MisereOutcome g = Outcome.P) :
     ¬RightWinsGoingFirst g := by
   intro h2
-  unfold MisereOutcome PlayerOutcomesToGameOutcome RightOutcome at h1
+  unfold MisereOutcome PlayerOutcome.toOutcome RightOutcome at h1
   cases h3 : LeftOutcome g <;> simp only [h2, h3, reduceIte, reduceCtorEq] at h1
 
 @[simp]
@@ -389,10 +391,10 @@ end
 
 @[simp]
 theorem conjugate_of_conjugates {g : IGame} :
-    PlayerOutcomesToGameOutcome (RightOutcome g).Conjugate (LeftOutcome g).Conjugate
+    PlayerOutcome.toOutcome (RightOutcome g).Conjugate (LeftOutcome g).Conjugate
     = (MisereOutcome g).Conjugate := by
   cases h1 : RightOutcome g <;> cases h2 : LeftOutcome g
-  all_goals simp only [h1, h2, PlayerOutcomesToGameOutcome, PlayerOutcome.Conjugate,
+  all_goals simp only [h1, h2, PlayerOutcome.toOutcome, PlayerOutcome.Conjugate,
                        Outcome.Conjugate, MisereOutcome]
 
 @[simp]
@@ -467,3 +469,5 @@ private theorem proposition6_1 (g h : IGame) :
       have h5 := h3 (Outcome.L_ge Outcome.N)
       have h6 := Outcome.ge_P_ge_N_eq_L h4 h5
       exact le_of_eq (Eq.symm h6)
+
+end Outcome.Misere

--- a/CombinatorialGames/Outcome/Misere.lean
+++ b/CombinatorialGames/Outcome/Misere.lean
@@ -1,0 +1,469 @@
+/-
+Copyright (c) 2025 Tomasz Maciosowski. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tomasz Maciosowski
+-/
+
+import CombinatorialGames.Game.Birthday
+import CombinatorialGames.Game.Short
+import CombinatorialGames.Outcome.Defs
+
+mutual
+
+-- NOTE: We define these using ∀ instead of ∃ like the literature does because ∃ desugares to
+-- `∃ gl, gl ∈ g.leftMoves ∧ ¬RightWinsGoingFirst gl` thus the termination check fails
+-- use _def theorems instead of unfolding these
+
+def LeftWinsGoingFirst (g : IGame) : Prop :=
+  IGame.IsLeftEnd g ∨ ¬(∀ gl ∈ g.leftMoves, RightWinsGoingFirst gl)
+termination_by g
+decreasing_by igame_wf
+
+def RightWinsGoingFirst (g : IGame) : Prop :=
+  IGame.IsRightEnd g ∨ ¬(∀ gr ∈ g.rightMoves, LeftWinsGoingFirst gr)
+termination_by g
+decreasing_by igame_wf
+
+end
+
+theorem LeftWinsGoingFirst_def {g : IGame} :
+    LeftWinsGoingFirst g
+    ↔ (IGame.IsLeftEnd g ∨ (∃ gl ∈ g.leftMoves, ¬RightWinsGoingFirst gl)) := by
+  constructor <;> intro h1
+  · simp only [LeftWinsGoingFirst, not_forall] at h1
+    apply Or.elim h1 <;> intro h2
+    · exact Or.inl h2
+    · exact Or.inr (bex_def.mp h2)
+  · unfold LeftWinsGoingFirst
+    simp only [not_forall]
+    apply Or.elim h1 <;> intro h2
+    · exact Or.inl h2
+    · exact Or.inr (bex_def.mpr h2)
+
+theorem RightWinsGoingFirst_def {g : IGame} :
+    RightWinsGoingFirst g
+    ↔ (IGame.IsRightEnd g ∨ (∃ gr ∈ g.rightMoves, ¬LeftWinsGoingFirst gr)) := by
+  constructor <;> intro h1
+  · simp only [RightWinsGoingFirst, not_forall] at h1
+    apply Or.elim h1 <;> intro h2
+    · exact Or.inl h2
+    · exact Or.inr (bex_def.mp h2)
+  · unfold RightWinsGoingFirst
+    simp only [not_forall]
+    apply Or.elim h1 <;> intro h2
+    · exact Or.inl h2
+    · exact Or.inr (bex_def.mpr h2)
+
+open Classical in
+/-- Game outcome if Left goes first -/
+noncomputable def LeftOutcome (g : IGame) : PlayerOutcome :=
+  if LeftWinsGoingFirst g then PlayerOutcome.L else PlayerOutcome.R
+
+open Classical in
+/-- Game outcome if Right goes first -/
+noncomputable def RightOutcome (g : IGame) : PlayerOutcome :=
+  if RightWinsGoingFirst g then PlayerOutcome.R else PlayerOutcome.L
+
+noncomputable def MisereOutcome : IGame → Outcome :=
+  fun g => PlayerOutcomesToGameOutcome (LeftOutcome g) (RightOutcome g)
+
+def MisereEq (A : IGame → Prop) (g h : IGame) : Prop :=
+  ∀ (x : IGame), A x → MisereOutcome (g + x) = MisereOutcome (h + x)
+
+/-- `G =m A H` means that G =_A H -/
+macro_rules | `($x =m $u $y) => `(MisereEq $u $x $y)
+
+recommended_spelling "eq" for "=m" in [MisereEq]
+
+theorem MisereEq_symm {A : IGame → Prop} {g h : IGame} (h1 : g =m A h) : h =m A g := by
+  intro x h2
+  have h3 := h1 x h2
+  exact Eq.symm h3
+
+def MisereGe (A : IGame → Prop) (g h : IGame) : Prop :=
+  ∀ x, (A x → MisereOutcome (g + x) ≥ MisereOutcome (h + x))
+
+/-- `G ≥m A H` means that G ≥_A H -/
+macro_rules | `($x ≥m $u $y) => `(MisereGe $u $x $y)
+
+recommended_spelling "ge" for "≥m" in [MisereGe]
+
+theorem MisereGe_antisymm {A : IGame → Prop} {g h : IGame} (h1 : g ≥m A h) (h2 : h ≥m A g) :
+    g =m A h := fun x h3 =>
+  PartialOrder.le_antisymm (MisereOutcome (g + x)) (MisereOutcome (h + x)) (h2 x h3) (h1 x h3)
+
+/-- No constraints (transfinite) on game form. You can prove `AnyGame x` with `trivial` -/
+def AnyGame (_ : IGame) := True
+
+class HasNeg (A : IGame → Prop) where
+  has_neg (g : IGame) (h1 : A g) : A (-g)
+
+instance : HasNeg AnyGame where
+  has_neg _ _ := trivial
+
+instance : HasNeg IGame.Short where
+  has_neg g _ := IGame.Short.neg g
+
+theorem leftEnd_leftWinsGoingFirst {g : IGame} (h1 : IGame.IsLeftEnd g) :
+    LeftWinsGoingFirst g := by
+  unfold LeftWinsGoingFirst
+  exact Or.inl h1
+
+theorem rightEnd_rightWinsGoingFirst {g : IGame} (h1 : IGame.IsRightEnd g) :
+    RightWinsGoingFirst g := by
+  unfold RightWinsGoingFirst
+  exact Or.inl h1
+
+theorem not_MisereEq_of_not_MisereGe {A : IGame → Prop} {g h : IGame} (h1 : ¬(g ≥m A h)) :
+    ¬(g =m A h) := by
+  simp only [MisereGe, ge_iff_le, not_forall] at h1
+  obtain ⟨x, ⟨h1, h2⟩⟩ := h1
+  simp only [MisereEq, not_forall]
+  use x
+  use h1
+  exact Ne.symm (ne_of_not_le h2)
+
+theorem not_leftWinsGoingFirst_le_P {g : IGame} (h1 : ¬LeftWinsGoingFirst g) :
+    MisereOutcome g ≤ Outcome.P := by
+  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome
+  cases h2 : LeftOutcome g <;> cases h3 : RightOutcome g
+  all_goals simp only [h1, reduceIte, Outcome.ge_R, le_refl]
+
+/-- `o(G) ≥ P` is equivalent to "Left can win playing second on `G`" -/
+theorem not_rightWinsGoingFirst_ge_P {g : IGame} (h1 : ¬RightWinsGoingFirst g) :
+    MisereOutcome g ≥ Outcome.P := by
+  unfold MisereOutcome PlayerOutcomesToGameOutcome RightOutcome
+  cases h2 : LeftOutcome g
+  all_goals simp only [h1, reduceIte, ge_iff_le, le_refl, Outcome.L_ge]
+
+theorem outcome_eq_P_leftWinsGoingFirst {g gl : IGame} (h1 : gl ∈ g.leftMoves)
+    (h2 : MisereOutcome gl = Outcome.P) : LeftWinsGoingFirst g := by
+  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome RightOutcome at h2
+  by_cases h3 : LeftWinsGoingFirst gl
+    <;> by_cases h4 : RightWinsGoingFirst gl
+    <;> simp only [h3, h4, reduceIte, reduceCtorEq] at h2
+  rw [LeftWinsGoingFirst_def]
+  exact Or.inr (by use gl)
+
+theorem outcome_eq_P_rightWinsGoingFirst {g gr : IGame} (h1 : gr ∈ g.rightMoves)
+    (h2 : MisereOutcome gr = Outcome.P) : RightWinsGoingFirst g := by
+  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome RightOutcome at h2
+  by_cases h3 : RightWinsGoingFirst gr
+    <;> by_cases h4 : LeftWinsGoingFirst gr
+    <;> simp only [h3, h4, reduceIte, reduceCtorEq] at h2
+  rw [RightWinsGoingFirst_def]
+  exact Or.inr (by use gr)
+
+theorem add_leftEnd_LeftWinsGoingFirst {g h : IGame} (h1 : IGame.IsLeftEnd g)
+    (h2 : IGame.IsLeftEnd h) : LeftWinsGoingFirst (g + h) :=
+  leftEnd_leftWinsGoingFirst (IGame.add_leftEnd_leftEnd h1 h2)
+
+theorem add_rightEnd_RightWinsGoingFirst {g h : IGame} (h1 : IGame.IsRightEnd g)
+    (h2 : IGame.IsRightEnd h) : RightWinsGoingFirst (g + h) :=
+  rightEnd_rightWinsGoingFirst (IGame.add_rightEnd_rightEnd h1 h2)
+
+theorem leftWinsGoingFirst_outcome_ge_N {g : IGame} (h1 : LeftWinsGoingFirst g) :
+    MisereOutcome g ≥ Outcome.N := by
+  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome
+  cases h2 : RightOutcome g
+  all_goals simp only [h1, reduceIte, ge_iff_le, le_refl, Outcome.L_ge]
+
+theorem rightWinsGoingFirst_outcome_le_N {g : IGame} (h1 : RightWinsGoingFirst g) :
+    MisereOutcome g ≤ Outcome.N := by
+  unfold MisereOutcome PlayerOutcomesToGameOutcome RightOutcome
+  cases h2 : LeftOutcome g
+  all_goals simp only [h1, reduceIte, le_refl, Outcome.ge_R]
+
+theorem outcome_eq_P_not_leftWinsGoingFirst {g : IGame} (h1 : MisereOutcome g = Outcome.P) :
+    ¬LeftWinsGoingFirst g := by
+  intro h2
+  unfold MisereOutcome PlayerOutcomesToGameOutcome LeftOutcome at h1
+  cases h3 : RightOutcome g <;> simp only [h2, h3, reduceIte, reduceCtorEq] at h1
+
+theorem outcome_eq_P_not_rightWinsGoingFirst {g : IGame} (h1 : MisereOutcome g = Outcome.P) :
+    ¬RightWinsGoingFirst g := by
+  intro h2
+  unfold MisereOutcome PlayerOutcomesToGameOutcome RightOutcome at h1
+  cases h3 : LeftOutcome g <;> simp only [h2, h3, reduceIte, reduceCtorEq] at h1
+
+@[simp]
+theorem leftOutcome_eq_R_iff_not_leftWinsFirst {g : IGame} :
+    (LeftOutcome g = PlayerOutcome.R) ↔ ¬LeftWinsGoingFirst g := by
+  constructor <;> intro h1
+  · unfold LeftOutcome at h1
+    intro h2
+    simp only [h2, reduceIte, reduceCtorEq] at h1
+  · unfold LeftOutcome
+    simp only [h1, reduceIte]
+
+@[simp]
+theorem rightOutcome_eq_L_iff_not_rightWinsFirst {g : IGame} :
+    (RightOutcome g = PlayerOutcome.L) ↔ ¬RightWinsGoingFirst g := by
+  constructor <;> intro h1
+  · unfold RightOutcome at h1
+    intro h2
+    simp only [h2, reduceIte, reduceCtorEq] at h1
+  · unfold RightOutcome
+    simp only [h1, reduceIte]
+
+@[simp]
+theorem neg_leftWinsFirst_iff_rightWinsFirst (g : IGame) :
+    (LeftWinsGoingFirst (-g)) ↔ (RightWinsGoingFirst g) := by
+  constructor <;> intro h1
+  · rw [LeftWinsGoingFirst_def] at h1
+    apply Or.elim h1 <;> intro h1
+    · apply rightEnd_rightWinsGoingFirst
+      exact IGame.leftEnd_neg_iff_rightEnd.mp h1
+    · obtain ⟨gl, h1, h2⟩ := h1
+      rw [RightWinsGoingFirst_def]
+      apply Or.inr
+      use -gl
+      simp only [IGame.leftMoves_neg, Set.mem_neg] at h1
+      apply And.intro h1
+      exact (neg_leftWinsFirst_iff_rightWinsFirst gl).not.mpr h2
+  · rw [RightWinsGoingFirst_def] at h1
+    apply Or.elim h1 <;> intro h1
+    · apply leftEnd_leftWinsGoingFirst
+      rwa [IGame.leftEnd_neg_iff_rightEnd]
+    · obtain ⟨gr, h1, h2⟩ := h1
+      rw [LeftWinsGoingFirst_def]
+      apply Or.inr
+      use -gr
+      simp only [IGame.leftMoves_neg, Set.mem_neg, neg_neg]
+      apply And.intro h1
+      have h3 := (neg_leftWinsFirst_iff_rightWinsFirst (-gr)).not.mp
+      simp only [neg_neg] at h3
+      exact h3 h2
+termination_by IGame.birthday g
+decreasing_by
+  · simp only [IGame.leftMoves_neg, Set.mem_neg] at h1
+    rw [IGame.lt_birthday_iff]
+    apply Or.inr
+    use -gl
+    apply And.intro h1
+    rw [IGame.birthday_neg]
+  · rw [IGame.birthday_neg, IGame.lt_birthday_iff]
+    apply Or.inr
+    use gr
+
+@[simp]
+theorem neg_rightWinsFirst_iff_leftWinsFirst (g : IGame) :
+    (RightWinsGoingFirst (-g)) ↔ (LeftWinsGoingFirst g) := by
+  constructor <;> intro h1
+  · rwa [<-neg_neg g, neg_leftWinsFirst_iff_rightWinsFirst]
+  · rw [<-neg_neg g] at h1
+    exact (neg_leftWinsFirst_iff_rightWinsFirst (-g)).mp h1
+
+mutual
+
+@[simp]
+theorem leftOutcome_neg_eq_rightOutcome_conjugate (g : IGame) :
+    LeftOutcome (-g) = (RightOutcome g).Conjugate := by
+  unfold LeftOutcome
+  rw [LeftWinsGoingFirst_def, IGame.leftMoves_neg]
+  split_ifs with h1
+  · apply Or.elim h1 <;> intro h1
+    · have h2 : IGame.IsRightEnd g := IGame.leftEnd_neg_iff_rightEnd.mp h1
+      unfold RightOutcome
+      rw [RightWinsGoingFirst_def]
+      simp only [h2, true_or, reduceIte]
+      rfl
+    · obtain ⟨gl, h1, h2⟩ := h1
+      unfold RightOutcome
+      have h3 : RightWinsGoingFirst g := by
+        rw [RightWinsGoingFirst_def]
+        apply Or.inr
+        use -gl
+        apply And.intro h1
+        rw [<-rightOutcome_eq_L_iff_not_rightWinsFirst] at h2
+        rw [<-leftOutcome_eq_R_iff_not_leftWinsFirst]
+        apply Eq.symm
+        have h3 : PlayerOutcome.R.Conjugate = PlayerOutcome.L  := rfl
+        rw [<-PlayerOutcome.eq_iff_conjugate_eq, h3, <-h2]
+        have h4 := rightOutcome_neg_eq_leftOutcome_conjugate (-gl)
+        rwa [neg_neg] at h4
+      simp only [h3, reduceIte]
+      rfl
+  · simp only [Set.mem_neg, not_or, not_exists, not_and, not_not] at h1
+    obtain ⟨h1, h2⟩ := h1
+    unfold RightOutcome
+    have h3 : ¬RightWinsGoingFirst g := by
+      unfold RightWinsGoingFirst
+      simp only [not_forall, not_or, not_exists, not_not]
+      have h3 : ¬IGame.IsRightEnd g := by
+        intro h3
+        unfold IGame.IsLeftEnd at h1
+        simp only [IGame.leftMoves_neg, Set.neg_eq_empty] at h1
+        exact h1 h3
+      apply And.intro h3
+      intro gl h4
+      have h5 := h2 (-gl)
+      rw [neg_neg] at h5
+      have h6 := h5 h4
+      rw [RightWinsGoingFirst_def] at h6
+      apply Or.elim h6 <;> intro h6
+      · rw [LeftWinsGoingFirst_def]
+        apply Or.inl
+        unfold IGame.IsRightEnd at h6
+        simp only [IGame.rightMoves_neg, Set.neg_eq_empty] at h6
+        exact h6
+      · obtain ⟨x, h6, h7⟩ := h6
+        simp only [IGame.rightMoves_neg, Set.mem_neg] at h6
+        rw [LeftWinsGoingFirst_def]
+        apply Or.inr
+        use -x
+        apply And.intro h6
+        have h8 : ¬LeftWinsGoingFirst (- (-x)) := by
+          simp only [neg_neg]
+          exact h7
+        exact (neg_leftWinsFirst_iff_rightWinsFirst (-x)).not.mp h8
+    simp only [h3, reduceIte]
+    rfl
+termination_by g
+decreasing_by igame_wf
+
+@[simp]
+theorem rightOutcome_neg_eq_leftOutcome_conjugate (g : IGame) :
+    RightOutcome (-g) = (LeftOutcome g).Conjugate := by
+  unfold RightOutcome
+  rw [RightWinsGoingFirst_def, IGame.rightMoves_neg]
+  split_ifs with h1
+  · apply Or.elim h1 <;> intro h1
+    · have h2 : IGame.IsLeftEnd g := IGame.rightEnd_neg_iff_leftEnd.mp h1
+      unfold LeftOutcome
+      rw [LeftWinsGoingFirst_def]
+      simp only [h2, true_or, reduceIte]
+      rfl
+    · obtain ⟨gr, h1, h2⟩ := h1
+      unfold LeftOutcome
+      have h3 : LeftWinsGoingFirst g := by
+        rw [LeftWinsGoingFirst_def]
+        apply Or.inr
+        use -gr
+        apply And.intro h1
+        rw [<-leftOutcome_eq_R_iff_not_leftWinsFirst] at h2
+        rw [<-rightOutcome_eq_L_iff_not_rightWinsFirst]
+        apply Eq.symm
+        have h3 : PlayerOutcome.L.Conjugate = PlayerOutcome.R  := rfl
+        rw [<-PlayerOutcome.eq_iff_conjugate_eq, h3, <-h2]
+        have h4 := leftOutcome_neg_eq_rightOutcome_conjugate (-gr)
+        rwa [neg_neg] at h4
+      simp only [h3, reduceIte]
+      rfl
+  · simp only [Set.mem_neg, not_or, not_exists, not_and, not_not] at h1
+    obtain ⟨h1, h2⟩ := h1
+    unfold LeftOutcome
+    have h3 : ¬LeftWinsGoingFirst g := by
+      unfold LeftWinsGoingFirst
+      simp only [not_forall, not_or, not_exists, not_not]
+      have h3 : ¬IGame.IsLeftEnd g := by
+        intro h3
+        unfold IGame.IsRightEnd at h1
+        simp only [IGame.rightMoves_neg, Set.neg_eq_empty] at h1
+        exact h1 h3
+      apply And.intro h3
+      intro gl h4
+      have h5 := h2 (-gl)
+      rw [neg_neg] at h5
+      have h6 := h5 h4
+      rw [LeftWinsGoingFirst_def] at h6
+      apply Or.elim h6 <;> intro h6
+      · rw [RightWinsGoingFirst_def]
+        apply Or.inl
+        unfold IGame.IsLeftEnd at h6
+        simp only [IGame.leftMoves_neg, Set.neg_eq_empty] at h6
+        exact h6
+      · obtain ⟨x, h6, h7⟩ := h6
+        simp only [IGame.leftMoves_neg, Set.mem_neg] at h6
+        rw [RightWinsGoingFirst_def]
+        apply Or.inr
+        use -x
+        apply And.intro h6
+        exact (neg_leftWinsFirst_iff_rightWinsFirst x).not.mpr h7
+    simp only [h3, reduceIte]
+    rfl
+termination_by g
+decreasing_by igame_wf
+
+end
+
+@[simp]
+theorem conjugate_of_conjugates {g : IGame} :
+    PlayerOutcomesToGameOutcome (RightOutcome g).Conjugate (LeftOutcome g).Conjugate
+    = (MisereOutcome g).Conjugate := by
+  cases h1 : RightOutcome g <;> cases h2 : LeftOutcome g
+  all_goals simp only [h1, h2, PlayerOutcomesToGameOutcome, PlayerOutcome.Conjugate,
+                       Outcome.Conjugate, MisereOutcome]
+
+@[simp]
+theorem outcome_conjugate_eq_outcome_neg {g : IGame} :
+    (MisereOutcome g).Conjugate = MisereOutcome (-g) := by
+  unfold Outcome.Conjugate
+  cases h1 : MisereOutcome g
+  all_goals
+  · unfold MisereOutcome
+    rw [rightOutcome_neg_eq_leftOutcome_conjugate, leftOutcome_neg_eq_rightOutcome_conjugate,
+        conjugate_of_conjugates, h1]
+    rfl
+
+private theorem HasNeg.not_ge_neg_iff.aux {A : IGame → Prop} [HasNeg A] {g h : IGame} (h1 : g ≥m A h) :
+    (-h) ≥m A (-g) := by
+  unfold MisereGe at *
+  intro x h0
+  have h2 := h1 (-x)
+  have h3 := Outcome.outcome_ge_conjugate_le (h2 (HasNeg.has_neg x h0))
+  have h4 : MisereOutcome (-h + x) = (MisereOutcome (-h + x)).Conjugate.Conjugate :=
+    Eq.symm Outcome.conjugate_conjugate_eq_self
+  have h5 : (MisereOutcome (-h + x)).Conjugate.Conjugate = (MisereOutcome (h + (-x))).Conjugate :=
+    by rw [outcome_conjugate_eq_outcome_neg, neg_add_rev, neg_neg, add_comm]
+  rw [h4, h5]
+  have h6 : (MisereOutcome (g + (-x))).Conjugate = MisereOutcome (-g + x) :=
+    by rw [outcome_conjugate_eq_outcome_neg, neg_add_rev, neg_neg, add_comm]
+  rw [<-h6]
+  apply Outcome.outcome_ge_conjugate_le
+  exact h2 (HasNeg.has_neg x h0)
+
+@[simp]
+theorem HasNeg.neg_ge_neg_iff {A : IGame → Prop} [HasNeg A] {g h : IGame} :
+    (-h) ≥m A (-g) ↔ g ≥m A h := by
+  constructor <;> intro h1
+  · have h2 := not_ge_neg_iff.aux h1
+    simp only [neg_neg] at h2
+    exact h2
+  · exact not_ge_neg_iff.aux h1
+
+private theorem proposition6_1 (g h : IGame) :
+    (g ≥m AnyGame h)
+    ↔ (∀ (x : IGame),
+      (MisereOutcome (h + x) ≥ Outcome.P → MisereOutcome (g + x) ≥ Outcome.P)
+      ∧ (MisereOutcome (h + x) ≥ Outcome.N → MisereOutcome (g + x) ≥ Outcome.N)) := by
+  constructor <;> intro h1
+  · -- => is immediate
+    intro x
+    unfold MisereGe at h1
+    constructor <;> intro h2
+    · exact Preorder.le_trans _ (MisereOutcome (h + x)) (MisereOutcome (g + x)) h2 (h1 x trivial)
+    · exact Preorder.le_trans _ (MisereOutcome (h + x)) (MisereOutcome (g + x)) h2 (h1 x trivial)
+  · -- For the converse, we must show that o(G + X) > o(H + X), for all X.
+    unfold MisereGe
+    intro x _
+    obtain ⟨h2, h3⟩ := h1 x
+    cases ho : MisereOutcome (h + x) with
+    | R =>
+      -- If o(H + X) = R, then there is nothing to prove
+      exact Outcome.ge_R (MisereOutcome (g + x))
+    | N =>
+      -- If o(H + X) = P or N, it is immediate from (i) or (ii)
+      rw [ho] at h3
+      exact h3 (Preorder.le_refl Outcome.N)
+    | P =>
+      rw [ho] at h2
+      exact h2 (Preorder.le_refl Outcome.P)
+    | L =>
+      -- Finally, if o(H + X) = L, then by (i) and (ii) we have o(G + X) > both P and N,
+      -- whence o(G + X) = L.
+      rw [ho] at h2 h3
+      have h4 := h2 (Outcome.L_ge Outcome.P)
+      have h5 := h3 (Outcome.L_ge Outcome.N)
+      have h6 := Outcome.ge_P_ge_N_eq_L h4 h5
+      exact le_of_eq (Eq.symm h6)

--- a/CombinatorialGames/Outcome/Normal.lean
+++ b/CombinatorialGames/Outcome/Normal.lean
@@ -1,6 +1,8 @@
 import CombinatorialGames.Outcome.Defs
 import CombinatorialGames.Game.IGame
 
+namespace Outcome.Normal
+
 mutual
 
 def LeftWinsGoingFirst (g : IGame) : Prop := ¬(∀ gl ∈ g.leftMoves, RightWinsGoingFirst gl)
@@ -44,7 +46,7 @@ noncomputable def RightOutcome (g : IGame) : PlayerOutcome :=
   if RightWinsGoingFirst g then PlayerOutcome.R else PlayerOutcome.L
 
 noncomputable def NormalOutcome : IGame → Outcome :=
-  fun g => PlayerOutcomesToGameOutcome (LeftOutcome g) (RightOutcome g)
+  fun g => PlayerOutcome.toOutcome (LeftOutcome g) (RightOutcome g)
 
 theorem eq_zero_outcome_P (g : IGame) (h1 : g = 0) : NormalOutcome g = Outcome.P := by
   rw [h1]
@@ -53,3 +55,5 @@ theorem eq_zero_outcome_P (g : IGame) (h1 : g = 0) : NormalOutcome g = Outcome.P
   simp only [IGame.leftMoves_zero, Set.mem_empty_iff_false, false_and, exists_const, reduceIte,
              IGame.rightMoves_zero]
   rfl
+
+end Outcome.Normal

--- a/CombinatorialGames/Outcome/Normal.lean
+++ b/CombinatorialGames/Outcome/Normal.lean
@@ -1,0 +1,55 @@
+import CombinatorialGames.Outcome.Defs
+import CombinatorialGames.Game.IGame
+
+mutual
+
+def LeftWinsGoingFirst (g : IGame) : Prop := ¬(∀ gl ∈ g.leftMoves, RightWinsGoingFirst gl)
+termination_by g
+decreasing_by igame_wf
+
+def RightWinsGoingFirst (g : IGame) : Prop := ¬(∀ gr ∈ g.rightMoves, LeftWinsGoingFirst gr)
+termination_by g
+decreasing_by igame_wf
+
+end
+
+theorem LeftWinsGoingFirst_def {g : IGame} :
+    LeftWinsGoingFirst g ↔ (∃ gl ∈ g.leftMoves, ¬RightWinsGoingFirst gl) := by
+  constructor <;> intro h1
+  · simp only [LeftWinsGoingFirst, not_forall] at h1
+    obtain ⟨gl, h1, h2⟩ := h1
+    use gl
+  · obtain ⟨gl, h1, h2⟩ := h1
+    simp only [LeftWinsGoingFirst, not_forall]
+    use gl
+
+theorem RightWinsGoingFirst_def {g : IGame} :
+    RightWinsGoingFirst g ↔ (∃ gr ∈ g.rightMoves, ¬LeftWinsGoingFirst gr) := by
+  constructor <;> intro h1
+  · simp only [RightWinsGoingFirst, not_forall] at h1
+    obtain ⟨gr, h1, h2⟩ := h1
+    use gr
+  · obtain ⟨gr, h1, h2⟩ := h1
+    simp only [RightWinsGoingFirst, not_forall]
+    use gr
+
+open Classical in
+/-- Game outcome if Left goes first -/
+noncomputable def LeftOutcome (g : IGame) : PlayerOutcome :=
+  if LeftWinsGoingFirst g then PlayerOutcome.L else PlayerOutcome.R
+
+open Classical in
+/-- Game outcome if Right goes first -/
+noncomputable def RightOutcome (g : IGame) : PlayerOutcome :=
+  if RightWinsGoingFirst g then PlayerOutcome.R else PlayerOutcome.L
+
+noncomputable def NormalOutcome : IGame → Outcome :=
+  fun g => PlayerOutcomesToGameOutcome (LeftOutcome g) (RightOutcome g)
+
+theorem eq_zero_outcome_P (g : IGame) (h1 : g = 0) : NormalOutcome g = Outcome.P := by
+  rw [h1]
+  unfold NormalOutcome LeftOutcome RightOutcome
+  rw [LeftWinsGoingFirst_def, RightWinsGoingFirst_def]
+  simp only [IGame.leftMoves_zero, Set.mem_empty_iff_false, false_and, exists_const, reduceIte,
+             IGame.rightMoves_zero]
+  rfl


### PR DESCRIPTION
Defined games outcomes and proved basic theorems. These are basic building blocks required for the proof of
```lean
theorem Transfinite.eq_zero_iff_identical_zero {g : IGame} : (g =m AnyGame 0 ↔ g = 0) := sorry
```


Also defined the normal play outcome with the plan to later prove
```lean
theorem outcome_p_iff_equiv_zero (g : IGame) : NormalOutcome g = Outcome.P ↔ g ≈ 0 := sorry
```
which later on should yield equivalence of Conway's inequality definition and the one via game outcomes (from "Lessons in Play" and onwards)

Used definitions are from "Lessons in Play" but I'd say (in my limited experience) that these are the definitions most papers are using as well