### PR TITLE
ci: build CI pages on PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,9 @@
-name: CI
+name: Pages CI
 
 on:
   push:
     branches: ["master"]
+  pull_request:
   workflow_dispatch:
 
 # Bestows GITHUB_TOKEN permission to deploy to GitHub Pages
@@ -39,6 +40,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.event_name != 'pull_request'
 
     permissions:
       pages: write


### PR DESCRIPTION
Adds the blank `pull_request` event, and ignores page deploy requests if the event is not a pull request. This is to make me less scared of mathlib bumps.