### PR TITLE
ci: mv concurrency to workflow level

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,11 +12,6 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one maximum concurrent deployment to prevent previous updates
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -41,6 +36,10 @@ jobs:
   deploy:
     needs: build
     if: github.event_name != 'pull_request'
+    # Allow only one maximum concurrent deployment to prevent previous updates
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
 
     permissions:
       pages: write


### PR DESCRIPTION
Otherwise, the build job cancels the deploy one.