### PR TITLE
feat(Game/IGame): small speedup

### DIFF
--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -670,7 +670,7 @@ theorem exists_rightMoves_add {P : IGame → Prop} {x y : IGame} :
 theorem add_eq_zero_iff {x y : IGame} : x + y = 0 ↔ x = 0 ∧ y = 0 := by
   constructor <;> simp_all [IGame.ext_iff]
 
-private theorem zero_add' (x : IGame) : 0 + x = x := by
+private theorem add_zero' (x : IGame) : x + 0 = x := by
   refine moveRecOn x fun _ _ _ ↦ ?_
   aesop
 
@@ -694,8 +694,8 @@ termination_by (x, y, z)
 decreasing_by igame_wf
 
 instance : AddCommMonoid IGame where
-  zero_add := zero_add'
-  add_zero _ := add_comm' .. ▸ zero_add' _
+  add_zero := add_zero'
+  zero_add _ := add_comm' .. ▸ add_zero' _
   add_comm := add_comm'
   add_assoc := add_assoc'
   nsmul := nsmulRec

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -670,8 +670,8 @@ theorem exists_rightMoves_add {P : IGame → Prop} {x y : IGame} :
 theorem add_eq_zero_iff {x y : IGame} : x + y = 0 ↔ x = 0 ∧ y = 0 := by
   constructor <;> simp_all [IGame.ext_iff]
 
-private theorem add_zero' : ∀ x : IGame, x + 0 = x := by
-  refine (moveRecOn · fun _ _ _ ↦ ?_)
+private theorem zero_add' (x : IGame) : 0 + x = x := by
+  refine moveRecOn x fun _ _ _ ↦ ?_
   aesop
 
 private theorem add_comm' (x y : IGame) : x + y = y + x := by
@@ -694,8 +694,8 @@ termination_by (x, y, z)
 decreasing_by igame_wf
 
 instance : AddCommMonoid IGame where
-  add_zero := add_zero'
-  zero_add _ := add_comm' .. ▸ add_zero' _
+  zero_add := zero_add'
+  add_zero _ := add_comm' .. ▸ zero_add' _
   add_comm := add_comm'
   add_assoc := add_assoc'
   nsmul := nsmulRec
@@ -1052,15 +1052,12 @@ theorem exists_rightMoves_mul {P : IGame → Prop} {x y : IGame} :
       (∃ a ∈ x.rightMoves, ∃ b ∈ y.leftMoves, P (mulOption x y a b)) := by
   aesop
 
-instance : MulZeroClass IGame := by
-  constructor <;>
-  · refine (moveRecOn · fun _ _ _ ↦ ?_)
-    aesop
+private theorem zero_mul' (x : IGame) : 0 * x = 0 := by
+  ext <;> simp
 
-instance : MulOneClass IGame := by
-  constructor <;>
-  · refine (moveRecOn · fun _ _ _ ↦ ?_)
-    aesop (add simp [mulOption, and_assoc])
+private theorem one_mul' (x : IGame) : 1 * x = x := by
+  refine moveRecOn x fun _ _ _ ↦ ?_
+  aesop (add simp [mulOption, and_assoc, zero_mul'])
 
 private theorem mul_comm' (x y : IGame) : x * y = y * x := by
   ext
@@ -1077,6 +1074,14 @@ decreasing_by igame_wf
 
 instance : CommMagma IGame where
   mul_comm := mul_comm'
+
+instance : MulZeroClass IGame where
+  zero_mul := zero_mul'
+  mul_zero x := mul_comm' .. ▸ zero_mul' x
+
+instance : MulOneClass IGame where
+  one_mul := one_mul'
+  mul_one x := mul_comm' .. ▸ one_mul' x
 
 theorem mulOption_comm (x y a b : IGame) : mulOption x y a b = mulOption y x b a := by
   simp [mulOption, add_comm, mul_comm]


### PR DESCRIPTION
We can prove `mul_zero` without induction, and we only need to use `aesop` once to prove `mul_one`, rather than twice.