### PR TITLE
fix: make `Real.toIGame` universe polymorphic

### DIFF
--- a/CombinatorialGames/Surreal/Pow.lean
+++ b/CombinatorialGames/Surreal/Pow.lean
@@ -17,6 +17,8 @@ We define here the ω-map on games and on surreal numbers, representing exponent
 - Define the normal form of a surreal number.
 -/
 
+universe u
+
 open Set
 
 -- TODO: upstream
@@ -38,7 +40,7 @@ namespace IGame
 
 The standard definition in the literature instead has `r` ranging over positive reals,
 but this makes no difference as to the equivalence class of the games. -/
-private def wpow (x : IGame) : IGame :=
+private def wpow (x : IGame.{u}) : IGame.{u} :=
   {insert 0 (range (fun y : Ioi (0 : Dyadic) × x.leftMoves ↦ y.1 * wpow y.2)) |
     range (fun y : Ioi (0 : Dyadic) × x.rightMoves ↦ y.1 * wpow y.2)}ᴵ
 termination_by x
@@ -47,7 +49,7 @@ decreasing_by igame_wf
 instance : Wpow IGame where
   wpow := wpow
 
-theorem wpow_def (x : IGame) : ω^ x =
+theorem wpow_def (x : IGame.{u}) : ω^ x =
     {insert 0 (image2 (fun r y ↦ ↑r * ω^ (y : IGame)) (Ioi (0 : Dyadic)) x.leftMoves) |
       image2 (fun r y ↦ ↑r * ω^ y) (Ioi (0 : Dyadic)) x.rightMoves}ᴵ := by
   change wpow _ = _

--- a/CombinatorialGames/Surreal/Real.lean
+++ b/CombinatorialGames/Surreal/Real.lean
@@ -16,11 +16,10 @@ that they are ring and field homomorphisms respectively.
 
 ## TODO
 
-Every real number has birthday at most `ω`. This can be proven by showing that a real number is
-equivalent to its Dedekind cut where only dyadic rationals are considered. At a later point, after
-we have the necessary API on dyadic numbers, we might want to prove this equivalence, or even
-re-define real numbers as Dedekind cuts of dyadic numbers specifically.
+Prove that every real number has birthday at most `ω`.
 -/
+
+universe u
 
 open IGame
 
@@ -53,7 +52,7 @@ namespace Real
 
 /-- The canonical map from `ℝ` to `IGame`, sending a real number to its Dedekind cut of dyadic
 rationals. -/
-@[coe, match_pattern] def toIGame (x : ℝ) : IGame :=
+@[coe, match_pattern] def toIGame (x : ℝ) : IGame.{u} :=
   {(↑) '' {q : Dyadic | q < x} | (↑) '' {q : Dyadic | x < q}}ᴵ
 
 instance : Coe ℝ IGame := ⟨toIGame⟩
@@ -427,10 +426,10 @@ private theorem toIGame_mul_le_mul' {x : ℝ} {q r : ℚ} (h : q * r ≤ x * r) 
   obtain hr | rfl | hr := lt_trichotomy r 0 <;> simp_all
 
 private theorem mulOption_lt_toIGame {x : ℝ} {q r s : ℚ} (h : x * s < x * q - r * q + r * s) :
-    mulOption (toIGame x) q r s < toIGame (x * q) := by
+    mulOption (toIGame x) q r s < toIGame.{u} (x * q) := by
   obtain ⟨t, ht, ht'⟩ := exists_rat_mul_btwn h
   apply lt_of_le_of_lt (b := ((r * q + t * s - r * s :) : IGame))
-  · have := toIGame_mul_le_mul ht
+  · have := toIGame_mul_le_mul.{u} ht
     simp_all [mulOption, ← Surreal.mk_le_mk]
   · rw [← sub_lt_iff_lt_add, lt_sub_iff_add_lt] at ht'
     convert ht'
@@ -438,14 +437,14 @@ private theorem mulOption_lt_toIGame {x : ℝ} {q r s : ℚ} (h : x * s < x * q 
     abel_nf
 
 private theorem toIGame_lt_mulOption {x : ℝ} {q r s : ℚ} (h : x * q - r * q + r * s < x * s) :
-    toIGame (x * q) < mulOption (toIGame x) q r s := by
+    toIGame.{u} (x * q) < mulOption (toIGame x) q r s := by
   obtain ⟨t, ht, ht'⟩ := exists_rat_mul_btwn' h
   apply lt_of_lt_of_le (b := ((r * q + t * s - r * s :) : IGame))
   · rw [← lt_sub_iff_add_lt, sub_lt_iff_lt_add] at ht
     convert ht
     simp only [toIGame_lt_ratCast, Rat.cast_sub, Rat.cast_add, Rat.cast_mul]
     abel_nf
-  · have := toIGame_mul_le_mul' ht'
+  · have := toIGame_mul_le_mul'.{u} ht'
     simp_all [mulOption, ← Surreal.mk_le_mk]
 
 theorem toIGame_mul_ratCast_equiv (x : ℝ) (q : ℚ) : (x * q).toIGame ≈ x * q := by
@@ -542,27 +541,27 @@ private theorem mul_toIGame_lt_dyadic' {x y : ℝ} {q : Dyadic}
       simp_all [← Rat.cast_div]
 
 private theorem dyadic_lt_mul_toIGame {x y : ℝ} (q : Dyadic) (h : q < x * y) :
-    (q : IGame) < x * y := by
+    (q : IGame.{u}) < x * y := by
   obtain hx | rfl | hx := lt_trichotomy x 0
   · obtain hy | rfl | hy := lt_trichotomy y 0
-    · have := @dyadic_lt_mul_toIGame' (-x) (-y) q
+    · have := @dyadic_lt_mul_toIGame'.{u} (-x) (-y) q
       simp_all
     · rw [(Numeric.mul_congr_right toIGame_zero_equiv).lt_congr_right]
       simp_all
-    · have := @mul_toIGame_lt_dyadic' (-x) y (-q)
+    · have := @mul_toIGame_lt_dyadic'.{u} (-x) y (-q)
       simp_all
   · rw [(Numeric.mul_congr_left toIGame_zero_equiv).lt_congr_right]
     simp_all
   · obtain hy | rfl | hy := lt_trichotomy y 0
-    · have := @mul_toIGame_lt_dyadic' x (-y) (-q)
+    · have := @mul_toIGame_lt_dyadic'.{u} x (-y) (-q)
       simp_all
     · rw [(Numeric.mul_congr_right toIGame_zero_equiv).lt_congr_right]
       simp_all
     · exact dyadic_lt_mul_toIGame' hx hy h
 
 private theorem mul_toIGame_lt_dyadic {x y : ℝ} (q : Dyadic) (h : x * y < q) :
-    x * y < (q : IGame) := by
-  have := @dyadic_lt_mul_toIGame (-x) y (-q)
+    x * y < (q : IGame.{u}) := by
+  have := @dyadic_lt_mul_toIGame.{u} (-x) y (-q)
   simp_all
 
 private theorem toSurreal_mul_ratCast (x : ℝ) (q : ℚ) : toSurreal (x * q) = x * q := by


### PR DESCRIPTION
For some reason, `Real.toIGame` and `IGame.wpow` were locked to return `IGame.{0}`. Also updated a docstring.