### PR TITLE
feat: use `recommended_spelling`

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -68,6 +68,7 @@ def ofSets (s t : Set Game.{u}) [Small.{u} s] [Small.{u} t] : Game.{u} :=
   mk {out '' s | out '' t}ᴵ
 
 @[inherit_doc] notation "{" s " | " t "}ᴳ" => ofSets s t
+recommended_spelling "ofSets" for "{· | ·}ᴳ" in [«term{_|_}ᴳ»]
 
 @[simp]
 theorem mk_ofSets (s t : Set IGame.{u}) [Small.{u} s] [Small.{u} t] :

--- a/CombinatorialGames/Game/Computability/FGame.lean
+++ b/CombinatorialGames/Game/Computability/FGame.lean
@@ -309,6 +309,7 @@ def ofFinsets (s t : Finset FGame) : FGame :=
     exact ⟨congrArg Multiset.toFinset ha, congrArg Multiset.toFinset hb⟩
 
 @[inherit_doc] notation "{" s " | " t "}ꟳ" => ofFinsets s t
+recommended_spelling "ofFinsets" for "{· | ·}ꟳ" in [«term{_|_}ꟳ»]
 
 private def moves_ofFinsets {s t : Finset FGame} :
     {s | t}ꟳ.leftMoves = s ∧ {s | t}ꟳ.rightMoves = t := by

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -301,7 +301,6 @@ instance : LE IGame where
 
 If `0 ⧏ x`, then Left can win `x` as the first player. `x ⧏ y` means that `0 ⧏ y - x`. -/
 notation:50 x:50 " ⧏ " y:50 => ¬ y ≤ x
-
 recommended_spelling "lf" for "⧏" in [«term_⧏_»]
 
 /-- Definition of `x ≤ y` on games, in terms of `⧏`. -/
@@ -392,12 +391,11 @@ theorem lf_rightMove {x y : IGame} (h : y ∈ x.rightMoves) : x ⧏ y :=
 /-- The equivalence relation `x ≈ y` means that `x ≤ y` and `y ≤ x`. This is notation for
 `AntisymmRel (⬝ ≤ ⬝) x y`. -/
 infix:50 " ≈ " => AntisymmRel (· ≤ ·)
+recommended_spelling "equiv" for "≈" in [«term_≈_»]
 
 /-- The "fuzzy" relation `x ‖ y` means that `x ⧏ y` and `y ⧏ x`. This is notation for
 `IncompRel (⬝ ≤ ⬝) x y`. -/
 notation:50 x:50 " ‖ " y:50 => IncompRel (· ≤ ·) x y
-
-recommended_spelling "equiv" for "≈" in [«term_≈_»]
 recommended_spelling "fuzzy" for "‖" in [«term_‖_»]
 
 open Lean PrettyPrinter Delaborator SubExpr Qq in

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -116,6 +116,7 @@ def ofSets (s t : Set IGame.{u}) [hs : Small.{u} s] [ht : Small.{u} t] : IGame.{
   QPF.Fix.mk ⟨⟨s, t⟩, ⟨hs, ht⟩⟩
 
 @[inherit_doc] notation "{" s " | " t "}ᴵ" => ofSets s t
+recommended_spelling "ofSets" for "{· | ·}ᴵ" in [«term{_|_}ᴵ»]
 
 /-- The set of left moves of the game. -/
 def leftMoves (x : IGame.{u}) : Set IGame.{u} := x.dest.1.1
@@ -296,38 +297,40 @@ instance : LE IGame where
     (∀ z (h : z ∈ x.leftMoves),  ¬le y z (Sym2.GameAdd.snd_fst (IsOption.of_mem_leftMoves h))) ∧
     (∀ z (h : z ∈ y.rightMoves), ¬le z x (Sym2.GameAdd.fst_snd (IsOption.of_mem_rightMoves h)))
 
-/-- The less or fuzzy relation on pre-games. `x ⧏ y` is notation for `¬ y ≤ x`.
+/-- The less or fuzzy relation on games. `x ⧏ y` is notation for `¬ y ≤ x`.
 
 If `0 ⧏ x`, then Left can win `x` as the first player. `x ⧏ y` means that `0 ⧏ y - x`. -/
 notation:50 x:50 " ⧏ " y:50 => ¬ y ≤ x
 
-/-- Definition of `x ≤ y` on pre-games, in terms of `⧏`. -/
+recommended_spelling "lf" for "⧏" in [«term_⧏_»]
+
+/-- Definition of `x ≤ y` on games, in terms of `⧏`. -/
 theorem le_iff_forall_lf {x y : IGame} :
     x ≤ y ↔ (∀ z ∈ x.leftMoves, z ⧏ y) ∧ (∀ z ∈ y.rightMoves, x ⧏ z) :=
   propext_iff.1 <| Sym2.GameAdd.fix_eq ..
 
-/-- Definition of `x ⧏ y` on pre-games, in terms of `≤`. -/
+/-- Definition of `x ⧏ y` on games, in terms of `≤`. -/
 theorem lf_iff_exists_le {x y : IGame} :
     x ⧏ y ↔ (∃ z ∈ y.leftMoves, x ≤ z) ∨ (∃ z ∈ x.rightMoves, z ≤ y) := by
   simpa [not_and_or, -not_and] using le_iff_forall_lf.not
 
-/-- The definition of `0 ≤ x` on pre-games, in terms of `0 ⧏`. -/
+/-- The definition of `0 ≤ x` on games, in terms of `0 ⧏`. -/
 theorem zero_le {x : IGame} : 0 ≤ x ↔ ∀ y ∈ x.rightMoves, 0 ⧏ y := by
   rw [le_iff_forall_lf]; simp
 
-/-- The definition of `x ≤ 0` on pre-games, in terms of `⧏ 0`. -/
+/-- The definition of `x ≤ 0` on games, in terms of `⧏ 0`. -/
 theorem le_zero {x : IGame} : x ≤ 0 ↔ ∀ y ∈ x.leftMoves, y ⧏ 0 := by
   rw [le_iff_forall_lf]; simp
 
-/-- The definition of `0 ⧏ x` on pre-games, in terms of `0 ≤`. -/
+/-- The definition of `0 ⧏ x` on games, in terms of `0 ≤`. -/
 theorem zero_lf {x : IGame} : 0 ⧏ x ↔ ∃ y ∈ x.leftMoves, 0 ≤ y := by
   rw [lf_iff_exists_le]; simp
 
-/-- The definition of `x ⧏ 0` on pre-games, in terms of `≤ 0`. -/
+/-- The definition of `x ⧏ 0` on games, in terms of `≤ 0`. -/
 theorem lf_zero {x : IGame} : x ⧏ 0 ↔ ∃ y ∈ x.rightMoves, y ≤ 0 := by
   rw [lf_iff_exists_le]; simp
 
-/-- The definition of `x ≤ y` on pre-games, in terms of `≤` two moves later.
+/-- The definition of `x ≤ y` on games, in terms of `≤` two moves later.
 
 Note that it's often more convenient to use `le_iff_forall_lf`, which only unfolds the definition by
 one step. -/
@@ -337,7 +340,7 @@ theorem le_def {x y : IGame} : x ≤ y ↔
   rw [le_iff_forall_lf]
   congr! 2 <;> rw [lf_iff_exists_le]
 
-/-- The definition of `x ⧏ y` on pre-games, in terms of `⧏` two moves later.
+/-- The definition of `x ⧏ y` on games, in terms of `⧏` two moves later.
 
 Note that it's often more convenient to use `lf_iff_exists_le`, which only unfolds the definition by
 one step. -/
@@ -393,6 +396,9 @@ infix:50 " ≈ " => AntisymmRel (· ≤ ·)
 /-- The "fuzzy" relation `x ‖ y` means that `x ⧏ y` and `y ⧏ x`. This is notation for
 `IncompRel (⬝ ≤ ⬝) x y`. -/
 notation:50 x:50 " ‖ " y:50 => IncompRel (· ≤ ·) x y
+
+recommended_spelling "equiv" for "≈" in [«term_≈_»]
+recommended_spelling "fuzzy" for "‖" in [«term_‖_»]
 
 open Lean PrettyPrinter Delaborator SubExpr Qq in
 @[delab app.AntisymmRel]

--- a/CombinatorialGames/Game/Loopy/Basic.lean
+++ b/CombinatorialGames/Game/Loopy/Basic.lean
@@ -331,6 +331,7 @@ noncomputable def ofSets (l : Set LGame.{u}) (r : Set LGame.{u})
   simpa [Option.forall] using ⟨inferInstance, inferInstance⟩
 
 @[inherit_doc] notation "{" s " | " t "}ᴸ" => ofSets s t
+recommended_spelling "ofSets" for "{· | ·}ᴸ" in [«term{_|_}ᴸ»]
 
 @[simp]
 theorem leftMoves_ofSets (l r : Set _) [Small.{u} l] [Small.{u} r] : {l | r}ᴸ.leftMoves = l := by

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -109,7 +109,7 @@ def tiny (x : IGame) : IGame :=
   {{0} | {{{0} | {-x}}ᴵ}}ᴵ
 
 @[inherit_doc] prefix:75 "⧾" => tiny
-recommended_spelling "tiny" for "⧾" in [«term⧾»]
+recommended_spelling "tiny" for "⧾" in [«term⧾_»]
 
 @[simp, game_cmp]
 theorem leftMoves_tiny (x : IGame) : leftMoves (⧾x) = {0} :=
@@ -129,7 +129,7 @@ def miny (x : IGame) : IGame :=
   {{{{x} | {0}}ᴵ} | {0}}ᴵ
 
 @[inherit_doc] prefix:75 "⧿" => miny
-recommended_spelling "miny" for "⧿" in [«term⧿»]
+recommended_spelling "miny" for "⧿" in [«term⧿_»]
 
 @[simp, game_cmp]
 theorem leftMoves_miny (x : IGame) : leftMoves (⧿x) = {{{x} | {0}}ᴵ} :=
@@ -160,7 +160,7 @@ def switch (x : IGame) : IGame :=
   {{x} | {-x}}ᴵ
 
 @[inherit_doc] prefix:75 "±" => switch
-recommended_spelling "switch" for "±" in [«term±»]
+recommended_spelling "switch" for "±" in [«term±_»]
 
 @[simp, game_cmp]
 theorem leftMoves_switch (x : IGame) : leftMoves (±x) = {x} :=

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -29,6 +29,7 @@ def star : IGame :=
   {{0} | {0}}ᴵ
 
 @[inherit_doc] notation "⋆" => star
+recommended_spelling "star" for "⋆" in [«term⋆»]
 
 @[simp, game_cmp] theorem leftMoves_star : leftMoves ⋆ = {0} := leftMoves_ofSets ..
 @[simp, game_cmp] theorem rightMoves_star : rightMoves ⋆ = {0} := rightMoves_ofSets ..
@@ -52,6 +53,7 @@ def half : IGame :=
   {{0} | {1}}ᴵ
 
 @[inherit_doc] notation "½" => half
+recommended_spelling "half" for "½" in [«term½»]
 
 @[simp, game_cmp] theorem leftMoves_half : leftMoves ½ = {0} := leftMoves_ofSets ..
 @[simp, game_cmp] theorem rightMoves_half : rightMoves ½ = {1} := rightMoves_ofSets ..
@@ -69,6 +71,7 @@ def up : IGame :=
   {{0} | {⋆}}ᴵ
 
 @[inherit_doc] notation "↑" => up
+recommended_spelling "up" for "↑" in [«term↑»]
 
 @[simp, game_cmp] theorem leftMoves_up : leftMoves ↑ = {0} := leftMoves_ofSets ..
 @[simp, game_cmp] theorem rightMoves_up : rightMoves ↑ = {⋆} := rightMoves_ofSets ..
@@ -84,6 +87,7 @@ def down : IGame :=
   {{⋆} | {0}}ᴵ
 
 @[inherit_doc] notation "↓" => down
+recommended_spelling "down" for "↓" in [«term↓»]
 
 @[simp, game_cmp] theorem leftMoves_down : leftMoves ↓ = {⋆} := leftMoves_ofSets ..
 @[simp, game_cmp] theorem rightMoves_down : rightMoves ↓ = {0} := rightMoves_ofSets ..
@@ -105,6 +109,7 @@ def tiny (x : IGame) : IGame :=
   {{0} | {{{0} | {-x}}ᴵ}}ᴵ
 
 @[inherit_doc] prefix:75 "⧾" => tiny
+recommended_spelling "tiny" for "⧾" in [«term⧾»]
 
 @[simp, game_cmp]
 theorem leftMoves_tiny (x : IGame) : leftMoves (⧾x) = {0} :=
@@ -124,6 +129,7 @@ def miny (x : IGame) : IGame :=
   {{{{x} | {0}}ᴵ} | {0}}ᴵ
 
 @[inherit_doc] prefix:75 "⧿" => miny
+recommended_spelling "miny" for "⧿" in [«term⧿»]
 
 @[simp, game_cmp]
 theorem leftMoves_miny (x : IGame) : leftMoves (⧿x) = {{{x} | {0}}ᴵ} :=
@@ -154,6 +160,7 @@ def switch (x : IGame) : IGame :=
   {{x} | {-x}}ᴵ
 
 @[inherit_doc] prefix:75 "±" => switch
+recommended_spelling "switch" for "±" in [«term±»]
 
 @[simp, game_cmp]
 theorem leftMoves_switch (x : IGame) : leftMoves (±x) = {x} :=

--- a/CombinatorialGames/Nimber/Basic.lean
+++ b/CombinatorialGames/Nimber/Basic.lean
@@ -66,8 +66,8 @@ def Ordinal.toNimber : Ordinal ≃o Nimber :=
 def Nimber.toOrdinal : Nimber ≃o Ordinal :=
   OrderIso.refl _
 
-@[inherit_doc]
-scoped[Nimber] prefix:75 "∗" => Ordinal.toNimber
+@[inherit_doc] scoped[Nimber] prefix:75 "∗" => Ordinal.toNimber
+recommended_spelling "toNimber" for "∗" in [Nimber.«term∗_»]
 
 namespace Nimber
 

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -440,6 +440,7 @@ def ofSets (s t : Set Surreal.{u}) [Small.{u} s] [Small.{u} t]
   exact H x hx y hy
 
 @[inherit_doc] notation "{" s " | " t "}ˢ" => ofSets s t (by aesop)
+recommended_spelling "ofSets" for "{· | ·}ˢ" in [«term{_|_}ˢ»]
 
 @[simp]
 theorem toGame_ofSets (s t : Set Surreal.{u}) [Small.{u} s] [Small.{u} t]

--- a/CombinatorialGames/Surreal/Pow.lean
+++ b/CombinatorialGames/Surreal/Pow.lean
@@ -29,6 +29,7 @@ class Wpow (α : Type*) where
   wpow : α → α
 
 prefix:75 "ω^ " => Wpow.wpow
+recommended_spelling "wpow" for "ω^" in [«termω^_»]
 
 noncomputable section
 namespace IGame


### PR DESCRIPTION
As a small drive-by fix, pre-games → games in docstrings (`PGame` does not exist anymore!)