### PR TITLE
fix: `le_of_not_lt` → `le_of_not_gt`

### DIFF
--- a/CombinatorialGames/Game/Small.lean
+++ b/CombinatorialGames/Game/Small.lean
@@ -90,7 +90,7 @@ theorem lt_of_numeric_of_pos (x) [Dicotic x] {y} [Numeric y] (hy : 0 < y) : x < 
   · have := Dicotic.of_mem_leftMoves hz
     exact (lt_of_numeric_of_pos z hy).not_ge
   · have := Numeric.of_mem_rightMoves hz
-    obtain (h | h) := Numeric.le_or_lt z 0
+    obtain (h | h) := Numeric.le_or_gt z 0
     · cases ((Numeric.lt_rightMove hz).trans_le h).not_gt hy
     · exact (lt_of_numeric_of_pos x h).not_ge
   · obtain rfl | h := eq_or_ne x 0

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -117,22 +117,22 @@ protected theorem le_total (x y : IGame) [Numeric x] [Numeric y] : x ≤ y ∨ y
   rw [or_iff_not_imp_left]
   exact Numeric.le_of_not_le
 
-protected theorem lt_of_not_le [Numeric x] [Numeric y] (h : ¬ x ≤ y) : y < x :=
+protected theorem lt_of_not_ge [Numeric x] [Numeric y] (h : ¬ x ≤ y) : y < x :=
   (Numeric.le_of_not_le h).lt_of_not_ge h
 
 @[simp]
 protected theorem not_le [Numeric x] [Numeric y] : ¬ x ≤ y ↔ y < x :=
-  ⟨Numeric.lt_of_not_le, not_le_of_gt⟩
+  ⟨Numeric.lt_of_not_ge, not_le_of_gt⟩
 
 @[simp]
 protected theorem not_lt [Numeric x] [Numeric y] : ¬ x < y ↔ y ≤ x :=
   not_iff_comm.1 Numeric.not_le
 
-protected theorem le_or_lt (x y : IGame) [Numeric x] [Numeric y] : x ≤ y ∨ y < x := by
+protected theorem le_or_gt (x y : IGame) [Numeric x] [Numeric y] : x ≤ y ∨ y < x := by
   rw [← Numeric.not_le]
   exact em _
 
-protected theorem lt_or_le (x y : IGame) [Numeric x] [Numeric y] : x < y ∨ y ≤ x := by
+protected theorem lt_or_ge (x y : IGame) [Numeric x] [Numeric y] : x < y ∨ y ≤ x := by
   rw [← Numeric.not_lt]
   exact em _
 

--- a/CombinatorialGames/Surreal/Division.lean
+++ b/CombinatorialGames/Surreal/Division.lean
@@ -168,7 +168,7 @@ lemma option_mul_inv_lt {x : IGame} [Numeric x] (hx : 0 < x)
     first | have := Numeric.of_mem_leftMoves hyx | have := Numeric.of_mem_rightMoves hyx
     first | have := Hl a ha | have := Hr a ha
     try (have := hr y hyx; have hy := hx.trans (Numeric.lt_rightMove hyx))
-  · obtain hy | hy := Numeric.lt_or_le 0 y
+  · obtain hy | hy := Numeric.lt_or_ge 0 y
     · have := hl y hyx hy
       rw [(mulOption_self_inv x (hl' y hyx hy) a).lt_congr_left, add_comm,
         ← IGame.lt_sub_iff_add_lt, (IGame.sub_self_equiv _).lt_congr_right]
@@ -182,7 +182,7 @@ lemma option_mul_inv_lt {x : IGame} [Numeric x] (hx : 0 < x)
     apply Numeric.mul_neg_of_neg_of_pos _ hy
     rw [IGame.sub_neg]
     exact Numeric.lt_rightMove (invOption_right_right_mem_rightMoves_inv hx hy hyx ha)
-  · obtain hy | hy := Numeric.lt_or_le 0 y
+  · obtain hy | hy := Numeric.lt_or_ge 0 y
     · have := hl y hyx hy
       rw [(mulOption_self_inv x (hl' y hyx hy) a).lt_congr_right, add_comm,
         ← IGame.sub_lt_iff_lt_add, (IGame.sub_self_equiv _).lt_congr_left]


### PR DESCRIPTION
To match the new Mathlib convention.