### PR TITLE
refactor: `Ordinal.toNatOrdinal → NatOrdinal.of` and `NatOrdinal.toOrdinal → NatOrdinal.val`

### DIFF
--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -72,11 +72,11 @@ protected theorem NatOrdinal.iSup_eq_zero_iff {ι : Type*} [Small.{u} ι] {f : �
   Ordinal.iSup_eq_zero_iff
 
 theorem NatOrdinal.lt_omega0 {o : NatOrdinal} :
-    o < Ordinal.omega0.toNatOrdinal ↔ ∃ n : ℕ, o = n := by
-  rw [← o.toOrdinal_toNatOrdinal, OrderIso.lt_iff_lt, Ordinal.lt_omega0]
+    o < of Ordinal.omega0 ↔ ∃ n : ℕ, o = n := by
+  rw [← val_of o, OrderIso.lt_iff_lt, Ordinal.lt_omega0]
   simp [← toOrdinal_cast_nat]
 
-theorem NatOrdinal.nat_lt_omega0 (n : ℕ) : n < Ordinal.omega0.toNatOrdinal := by
+theorem NatOrdinal.nat_lt_omega0 (n : ℕ) : n < of Ordinal.omega0 := by
   rw [NatOrdinal.lt_omega0]
   use n
 
@@ -321,7 +321,7 @@ theorem strictMono_birthdayFinset : StrictMono birthdayFinset := by
     exact (Nat.lt_pow_self (Nat.one_lt_succ_succ 2)).not_ge this
 
 theorem short_iff_birthday_finite {x : IGame} :
-    x.Short ↔ x.birthday < Ordinal.omega0.toNatOrdinal := by
+    x.Short ↔ x.birthday < of Ordinal.omega0 := by
   refine ⟨fun h ↦ ?_, ?_⟩
   · have (y : {y // IsOption y x}) : ∃ n : ℕ, birthday y = n := by
       rw [← NatOrdinal.lt_omega0, ← short_iff_birthday_finite]
@@ -338,7 +338,7 @@ theorem short_iff_birthday_finite {x : IGame} :
 termination_by x
 decreasing_by igame_wf
 
-theorem Short.birthday_lt_omega0 (x : IGame) [Short x] : birthday x < Ordinal.omega0.toNatOrdinal :=
+theorem Short.birthday_lt_omega0 (x : IGame) [Short x] : birthday x < of Ordinal.omega0 :=
   short_iff_birthday_finite.1 ‹_›
 
 end IGame

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -74,7 +74,7 @@ protected theorem NatOrdinal.iSup_eq_zero_iff {ι : Type*} [Small.{u} ι] {f : �
 theorem NatOrdinal.lt_omega0 {o : NatOrdinal} :
     o < of Ordinal.omega0 ↔ ∃ n : ℕ, o = n := by
   rw [← val_of o, OrderIso.lt_iff_lt, Ordinal.lt_omega0]
-  simp [← toOrdinal_cast_nat]
+  simp [← val_natCast]
 
 theorem NatOrdinal.nat_lt_omega0 (n : ℕ) : n < of Ordinal.omega0 := by
   rw [NatOrdinal.lt_omega0]

--- a/CombinatorialGames/Game/Ordinal.lean
+++ b/CombinatorialGames/Game/Ordinal.lean
@@ -52,10 +52,10 @@ theorem Ordinal.Iio_natCast (n : ℕ) : Iio (n : Ordinal) = Nat.cast '' Iio n :=
     simp_all
 
 theorem NatOrdinal.Iio_natCast (n : ℕ) : Iio (n : NatOrdinal) = Nat.cast '' Iio n := by
-  rw [← Ordinal.toNatOrdinal_cast_nat]
+  rw [← NatOrdinal.of_natCast]
   apply (Ordinal.Iio_natCast _).trans
   congr! 1
-  exact Ordinal.toNatOrdinal_cast_nat _
+  exact NatOrdinal.of_natCast
 
 namespace NatOrdinal
 
@@ -255,13 +255,12 @@ theorem Short.exists_neg_natCast_lt (x : IGame) [Short x] : ∃ n : ℕ, -n < x 
   use n
   rwa [IGame.neg_lt]
 
-local notation "ω" => toIGame Ordinal.omega0.toNatOrdinal
+local notation "ω" => toIGame (NatOrdinal.of Ordinal.omega0)
 
 theorem Short.lt_omega0 (x : IGame) [Short x] : x < ω := by
   obtain ⟨n, hn⟩ := exists_lt_natCast x
   apply hn.trans
-  rw [← (toIGame_natCast_equiv n).lt_congr_left, toIGame.lt_iff_lt,
-    ← Ordinal.toNatOrdinal_cast_nat n]
+  rw [← (toIGame_natCast_equiv n).lt_congr_left, toIGame.lt_iff_lt, ← NatOrdinal.of_natCast n]
   exact Ordinal.nat_lt_omega0 n
 
 theorem Short.neg_omega0_lt (x : IGame) [Short x] : -ω < x := by

--- a/CombinatorialGames/NatOrdinal.lean
+++ b/CombinatorialGames/NatOrdinal.lean
@@ -52,97 +52,64 @@ def NatOrdinal : Type _ :=
   -- Porting note: used to derive LinearOrder & SuccOrder but need to manually define
   Ordinal deriving Zero, Inhabited, One, WellFoundedRelation
 
-instance NatOrdinal.instLinearOrder : LinearOrder NatOrdinal := Ordinal.instLinearOrder
-instance NatOrdinal.instSuccOrder : SuccOrder NatOrdinal := Ordinal.instSuccOrder
-instance NatOrdinal.instOrderBot : OrderBot NatOrdinal := Ordinal.instOrderBot
-instance NatOrdinal.instNoMaxOrder : NoMaxOrder NatOrdinal := Ordinal.instNoMaxOrder
-instance NatOrdinal.instZeroLEOneClass : ZeroLEOneClass NatOrdinal := Ordinal.instZeroLEOneClass
-instance NatOrdinal.instNeZeroOne : NeZero (1 : NatOrdinal) := Ordinal.instNeZeroOne
+namespace NatOrdinal
+open Ordinal
 
-instance NatOrdinal.uncountable : Uncountable NatOrdinal :=
-  Ordinal.uncountable
+instance : LinearOrder NatOrdinal := Ordinal.instLinearOrder
+instance : SuccOrder NatOrdinal := Ordinal.instSuccOrder
+instance : OrderBot NatOrdinal := Ordinal.instOrderBot
+instance : NoMaxOrder NatOrdinal := Ordinal.instNoMaxOrder
+instance : ZeroLEOneClass NatOrdinal := Ordinal.instZeroLEOneClass
+instance : NeZero (1 : NatOrdinal) := Ordinal.instNeZeroOne
+instance : Uncountable NatOrdinal := Ordinal.uncountable
+instance : WellFoundedLT NatOrdinal := Ordinal.wellFoundedLT
+instance : ConditionallyCompleteLinearOrderBot NatOrdinal :=
+  Ordinal.instConditionallyCompleteLinearOrderBot
 
 /-- The identity function between `Ordinal` and `NatOrdinal`. -/
 @[match_pattern]
-def Ordinal.toNatOrdinal : Ordinal ≃o NatOrdinal :=
-  OrderIso.refl _
+def of : Ordinal ≃o NatOrdinal := .refl _
 
 /-- The identity function between `NatOrdinal` and `Ordinal`. -/
 @[match_pattern]
-def NatOrdinal.toOrdinal : NatOrdinal ≃o Ordinal :=
-  OrderIso.refl _
+def val : NatOrdinal ≃o Ordinal := .refl _
 
-namespace NatOrdinal
+@[simp] theorem of_symm : of.symm = val := rfl
+@[simp] theorem val_symm : val.symm = of := rfl
 
-open Ordinal
+@[simp] theorem of_val (a : NatOrdinal) : of (val a) = a := rfl
+@[simp] theorem val_of (a : Ordinal) : val (of a) = a := rfl
 
-@[simp]
-theorem toOrdinal_symm_eq : NatOrdinal.toOrdinal.symm = Ordinal.toNatOrdinal :=
-  rfl
+theorem lt_wf : @WellFounded NatOrdinal (· < ·) := Ordinal.lt_wf
 
-@[simp]
-theorem toOrdinal_toNatOrdinal (a : NatOrdinal) : a.toOrdinal.toNatOrdinal = a :=
-  rfl
-
-theorem lt_wf : @WellFounded NatOrdinal (· < ·) :=
-  Ordinal.lt_wf
-
-instance : WellFoundedLT NatOrdinal :=
-  Ordinal.wellFoundedLT
-
-instance : ConditionallyCompleteLinearOrderBot NatOrdinal :=
-  WellFoundedLT.conditionallyCompleteLinearOrderBot _
-
-instance (o : NatOrdinal.{u}) : Small.{u} (Iio o) :=
-  inferInstanceAs (Small (Iio o.toOrdinal))
+instance (o : NatOrdinal.{u}) : Small.{u} (Iio o) := inferInstanceAs (Small (Iio o.val))
 
 theorem bddAbove_of_small (s : Set NatOrdinal.{u}) [Small.{u} s] : BddAbove s :=
   Ordinal.bddAbove_of_small s
 
-@[simp]
-theorem bot_eq_zero : ⊥ = 0 :=
-  rfl
+@[simp] theorem bot_eq_zero : ⊥ = 0 := rfl
 
-@[simp]
-theorem toOrdinal_zero : toOrdinal 0 = 0 :=
-  rfl
+@[simp] theorem of_zero : of 0 = 0 := rfl
+@[simp] theorem val_zero : val 0 = 0 := rfl
 
-@[simp]
-theorem toOrdinal_one : toOrdinal 1 = 1 :=
-  rfl
+@[simp] theorem of_one : of 1 = 1 := rfl
+@[simp] theorem val_one : val 1 = 1 := rfl
 
-@[simp]
-theorem toOrdinal_eq_zero {a} : toOrdinal a = 0 ↔ a = 0 :=
-  Iff.rfl
+@[simp] theorem of_eq_zero {a} : of a = 0 ↔ a = 0 := .rfl
+@[simp] theorem val_eq_zero {a} : val a = 0 ↔ a = 0 := .rfl
 
-@[simp]
-theorem toOrdinal_eq_one {a} : toOrdinal a = 1 ↔ a = 1 :=
-  Iff.rfl
+@[simp] theorem of_eq_one {a} : of a = 1 ↔ a = 1 := .rfl
+@[simp] theorem val_eq_one {a} : val a = 1 ↔ a = 1 := .rfl
 
-theorem toOrdinal_max (a b : NatOrdinal) : toOrdinal (max a b) = max (toOrdinal a) (toOrdinal b) :=
-  rfl
+theorem succ_def (a : NatOrdinal) : succ a = of (val a + 1) := rfl
 
-theorem toOrdinal_min (a b : NatOrdinal) : toOrdinal (min a b) = min (toOrdinal a) (toOrdinal b) :=
-  rfl
-
-theorem succ_def (a : NatOrdinal) : succ a = toNatOrdinal (toOrdinal a + 1) :=
-  rfl
-
-@[simp]
-theorem zero_le (o : NatOrdinal) : 0 ≤ o :=
-  Ordinal.zero_le o
-
-theorem not_lt_zero (o : NatOrdinal) : ¬ o < 0 :=
-  Ordinal.not_lt_zero o
-
-@[simp]
-theorem lt_one_iff_zero {o : NatOrdinal} : o < 1 ↔ o = 0 :=
-  Ordinal.lt_one_iff_zero
+@[simp] theorem zero_le (o : NatOrdinal) : 0 ≤ o := Ordinal.zero_le o
+theorem not_lt_zero (o : NatOrdinal) : ¬ o < 0 := Ordinal.not_lt_zero o
+@[simp] theorem lt_one_iff_zero {o : NatOrdinal} : o < 1 ↔ o = 0 := Ordinal.lt_one_iff_zero
 
 /-- A recursor for `NatOrdinal`. Use as `induction x`. -/
 @[elab_as_elim, cases_eliminator, induction_eliminator]
-protected def rec {β : NatOrdinal → Sort*} (h : ∀ a, β (toNatOrdinal a)) : ∀ a, β a := fun a =>
-  h (toOrdinal a)
+protected def rec {β : NatOrdinal → Sort*} (h : ∀ a, β (of a)) : ∀ a, β a := fun a ↦ h (val a)
 
 /-- `Ordinal.induction` but for `NatOrdinal`. -/
 theorem induction {p : NatOrdinal → Prop} : ∀ (i) (_ : ∀ j, (∀ k, k < j → p k) → p j), p i :=
@@ -153,38 +120,6 @@ end NatOrdinal
 namespace Ordinal
 
 variable {a b c : Ordinal.{u}}
-
-@[simp]
-theorem toNatOrdinal_symm_eq : toNatOrdinal.symm = NatOrdinal.toOrdinal :=
-  rfl
-
-@[simp]
-theorem toNatOrdinal_toOrdinal (a : Ordinal) : a.toNatOrdinal.toOrdinal = a :=
-  rfl
-
-@[simp]
-theorem toNatOrdinal_zero : toNatOrdinal 0 = 0 :=
-  rfl
-
-@[simp]
-theorem toNatOrdinal_one : toNatOrdinal 1 = 1 :=
-  rfl
-
-@[simp]
-theorem toNatOrdinal_eq_zero (a) : toNatOrdinal a = 0 ↔ a = 0 :=
-  Iff.rfl
-
-@[simp]
-theorem toNatOrdinal_eq_one (a) : toNatOrdinal a = 1 ↔ a = 1 :=
-  Iff.rfl
-
-theorem toNatOrdinal_max (a b : Ordinal) :
-    toNatOrdinal (max a b) = max (toNatOrdinal a) (toNatOrdinal b) :=
-  rfl
-
-theorem toNatOrdinal_min (a b : Ordinal) :
-    toNatOrdinal (min a b) = min (toNatOrdinal a) (toNatOrdinal b) :=
-  rfl
 
 /-! We place the definitions of `nadd` and `nmul` before actually developing their API, as this
 guarantees we only need to open the `NaturalOps` locale once. -/
@@ -372,15 +307,15 @@ theorem add_le_iff {a b c : NatOrdinal} :
   Ordinal.nadd_le_iff
 
 @[simp]
-theorem toOrdinal_cast_nat (n : ℕ) : toOrdinal n = n := by
+theorem val_natCast (n : ℕ) : val n = n := by
   induction' n with n hn
   · rfl
-  · change (toOrdinal n) ♯ 1 = n + 1
+  · change (val n) ♯ 1 = n + 1
     rw [hn]; exact nadd_one n
 
 instance : CharZero NatOrdinal where
   cast_injective m n h := by
-    apply_fun toOrdinal at h
+    apply_fun val at h
     simpa using h
 
 end NatOrdinal
@@ -391,12 +326,12 @@ open NaturalOps
 
 namespace Ordinal
 
-theorem nadd_eq_add (a b : Ordinal) : a ♯ b = toOrdinal (toNatOrdinal a + toNatOrdinal b) :=
+theorem nadd_eq_add (a b : Ordinal) : a ♯ b = val (of a + of b) :=
   rfl
 
 @[simp]
-theorem toNatOrdinal_cast_nat (n : ℕ) : toNatOrdinal n = n := by
-  rw [← toOrdinal_cast_nat n]
+theorem of_natCast (n : ℕ) : of n = n := by
+  rw [← val_natCast n]
   rfl
 
 theorem lt_of_nadd_lt_nadd_left : ∀ {a b c}, a ♯ b < a ♯ c → b < c :=
@@ -609,15 +544,7 @@ private theorem nmul_nadd_lt₃' {a' b' c' : Ordinal} (ha : a' < a) (hb : b' < b
       a ⨳ (b ⨳ c) ♯ a' ⨳ (b' ⨳ c) ♯ a' ⨳ (b ⨳ c') ♯ a ⨳ (b' ⨳ c') := by
   simp only [nmul_comm _ (_ ⨳ _)]
   convert nmul_nadd_lt₃ hb hc ha using 1 <;>
-    (simp only [nadd_eq_add, NatOrdinal.toOrdinal_toNatOrdinal]; abel_nf)
-
-@[deprecated nmul_nadd_le₃ (since := "2024-11-19")]
-theorem nmul_nadd_le₃' {a' b' c' : Ordinal} (ha : a' ≤ a) (hb : b' ≤ b) (hc : c' ≤ c) :
-    a' ⨳ (b ⨳ c) ♯ a ⨳ (b' ⨳ c) ♯ a ⨳ (b ⨳ c') ♯ a' ⨳ (b' ⨳ c') ≤
-      a ⨳ (b ⨳ c) ♯ a' ⨳ (b' ⨳ c) ♯ a' ⨳ (b ⨳ c') ♯ a ⨳ (b' ⨳ c') := by
-  simp only [nmul_comm _ (_ ⨳ _)]
-  convert nmul_nadd_le₃ hb hc ha using 1 <;>
-    (simp only [nadd_eq_add, NatOrdinal.toOrdinal_toNatOrdinal]; abel_nf)
+    (simp only [nadd_eq_add, NatOrdinal.of_val]; abel_nf)
 
 theorem lt_nmul_iff₃ : d < a ⨳ b ⨳ c ↔ ∃ a' < a, ∃ b' < b, ∃ c' < c,
     d ♯ a' ⨳ b' ⨳ c ♯ a' ⨳ b ⨳ c' ♯ a ⨳ b' ⨳ c' ≤
@@ -644,16 +571,10 @@ theorem nmul_le_iff₃ : a ⨳ b ⨳ c ≤ d ↔ ∀ a' < a, ∀ b' < b, ∀ c' 
 private theorem nmul_le_iff₃' : a ⨳ (b ⨳ c) ≤ d ↔ ∀ a' < a, ∀ b' < b, ∀ c' < c,
     a' ⨳ (b ⨳ c) ♯ a ⨳ (b' ⨳ c) ♯ a ⨳ (b ⨳ c') ♯ a' ⨳ (b' ⨳ c') <
       d ♯ a' ⨳ (b' ⨳ c) ♯ a' ⨳ (b ⨳ c') ♯ a ⨳ (b' ⨳ c') := by
-  simp only [nmul_comm _ (_ ⨳ _), nmul_le_iff₃, nadd_eq_add, toOrdinal_toNatOrdinal]
+  simp only [nmul_comm _ (_ ⨳ _), nmul_le_iff₃, nadd_eq_add, of_val]
   constructor <;> intro h a' ha b' hb c' hc
   · convert h b' hb c' hc a' ha using 1 <;> abel_nf
   · convert h c' hc a' ha b' hb using 1 <;> abel_nf
-
-@[deprecated lt_nmul_iff₃ (since := "2024-11-19")]
-theorem lt_nmul_iff₃' : d < a ⨳ (b ⨳ c) ↔ ∃ a' < a, ∃ b' < b, ∃ c' < c,
-    d ♯ a' ⨳ (b' ⨳ c) ♯ a' ⨳ (b ⨳ c') ♯ a ⨳ (b' ⨳ c') ≤
-      a' ⨳ (b ⨳ c) ♯ a ⨳ (b' ⨳ c) ♯ a ⨳ (b ⨳ c') ♯ a' ⨳ (b' ⨳ c') := by
-  simpa using nmul_le_iff₃'.not
 
 theorem nmul_assoc (a b c : Ordinal) : a ⨳ b ⨳ c = a ⨳ (b ⨳ c) := by
   apply le_antisymm
@@ -711,7 +632,7 @@ end NatOrdinal
 
 namespace Ordinal
 
-theorem nmul_eq_mul (a b) : a ⨳ b = toOrdinal (toNatOrdinal a * toNatOrdinal b) :=
+theorem nmul_eq_mul (a b) : a ⨳ b = val (of a * of b) :=
   rfl
 
 theorem nmul_nadd_one : ∀ a b, a ⨳ (b ♯ 1) = a ⨳ b ♯ a :=

--- a/CombinatorialGames/Surreal/Dyadic/Birthday.lean
+++ b/CombinatorialGames/Surreal/Dyadic/Birthday.lean
@@ -12,7 +12,7 @@ import CombinatorialGames.Surreal.Birthday.Cut
 We prove that a surreal number has a finite birthday iff it's a dyadic number.
 -/
 
-local notation "ω" => Ordinal.omega0.toNatOrdinal
+local notation "ω" => NatOrdinal.of Ordinal.omega0
 
 @[simp]
 theorem Game.birthday_ratCast (x : ℚ) : Game.birthday x = Surreal.birthday x := by


### PR DESCRIPTION
These much shorter names should save a lot of keyboard strokes.