### PR TITLE
feat: `IsField.embed`

### DIFF
--- a/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios, Daniel Weber
 -/
 import CombinatorialGames.Nimber.Field
+import Mathlib.Algebra.Field.Subfield.Defs
 import Mathlib.SetTheory.Ordinal.Principal
 
 /-!

--- a/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
@@ -201,6 +201,17 @@ theorem IsGroup.sum_lt {x : Nimber} (h : IsGroup x) (hx₀ : x ≠ 0) {ι} {s : 
     rw [Finset.sum_insert ha]
     apply h.add_lt <;> simp_all
 
+/-- `Iio x` as a subgroup of `Nimber`. -/
+def IsGroup.toAddSubgroup {x : Nimber} (h : IsGroup x) (hx₀ : x ≠ 0) : AddSubgroup Nimber where
+  carrier := Iio x
+  zero_mem' := Nimber.pos_iff_ne_zero.2 hx₀
+  add_mem' := @h.add_lt
+  neg_mem' := id
+
+@[simp]
+theorem val_toAddSubgroup_lt {x : Nimber} (h : IsGroup x) (hx₀ : x ≠ 0) (y : h.toAddSubgroup hx₀) :
+    y < x := y.2
+
 @[simp]
 theorem IsGroup.zero : IsGroup 0 where
   add_lt := by simp
@@ -379,6 +390,16 @@ theorem IsRing.pow_lt {x y : Nimber} (h : IsRing x) {n : ℕ} (hx : 1 < x) (hy :
   · simpa
   · exact h.pow_lt' hn hy
 
+/-- `Iio x` as a subring of `Nimber`. -/
+def IsRing.toSubring {x : Nimber} (h : IsRing x) (hx₁ : 1 < x) : Subring Nimber where
+  one_mem' := hx₁
+  mul_mem' := @h.mul_lt
+  __ := h.toAddSubgroup (by aesop)
+
+@[simp]
+theorem val_toSubring_lt {x : Nimber} (h : IsRing x) (hx₁ : 1 < x) (y : h.toSubring hx₁) :
+    y < x := y.2
+
 @[simp]
 theorem IsRing.zero : IsRing 0 where
   mul_lt := by simp
@@ -479,6 +500,15 @@ theorem IsField.inv_lt {x y : Nimber} (h : IsField x) (hy : y < x) : y⁻¹ < x 
 
 theorem IsField.div_lt {x y z : Nimber} (h : IsField x) (hy : y < x) (hz : z < x) : y / z < x :=
   h.toIsRing.mul_lt hy (h.inv_lt hz)
+
+/-- `Iio x` as a subring of `Nimber`. -/
+def IsField.toSubfield {x : Nimber} (h : IsField x) (hx₁ : 1 < x) : Subfield Nimber where
+  inv_mem' := @h.inv_lt
+  __ := h.toSubring hx₁
+
+@[simp]
+theorem val_toSubfield_lt {x : Nimber} (h : IsField x) (hx₁ : 1 < x) (y : h.toSubfield hx₁) :
+    y < x := y.2
 
 @[simp]
 theorem IsField.zero : IsField 0 where

--- a/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
@@ -38,38 +38,6 @@ theorem natDegree_eq_zero_iff : p.natDegree = 0 ↔ p = 0 ∨ p.degree = 0 := by
   rw [p.natDegree_eq_zero_iff_degree_le_zero, le_iff_lt_or_eq, ← WithBot.coe_zero, ← bot_eq_zero',
     WithBot.lt_coe_bot, p.degree_eq_bot]
 
-theorem degree_pos_of_mem_roots {R} [CommRing R] [IsDomain R] {p : R[X]} {r} (h : r ∈ p.roots) :
-    0 < p.degree := by
-  by_contra!
-  rw [p.eq_C_of_degree_le_zero this, roots_C] at h
-  cases h
-
-theorem monomial_induction {motive : R[X] → Prop} (zero : motive 0)
-    (add : ∀ a n q, degree q < .some n → motive q → motive (C a * X ^ n + q)) (p : R[X]) :
-    motive p := by
-  induction hn : p.degree using WellFoundedLT.induction generalizing p with | ind n IH
-  cases n with
-  | bot => simp_all
-  | coe n =>
-    rw [← eraseLead_add_C_mul_X_pow p, add_comm]
-    have hp₀ : p ≠ 0 := by aesop
-    have hpn : p.eraseLead.degree < .some n := hn ▸ degree_eraseLead_lt hp₀
-    apply add _ _ _ ((degree_eraseLead_lt hp₀).trans_eq _) (IH _ hpn _ rfl)
-    rw [hn, natDegree_eq_of_degree_eq_some hn]
-
-theorem eval_X_pow {R} [CommRing R] (x : R) (n : ℕ) : eval x (X ^ n : R[X]) = x ^ n := by simp
-
-theorem self_sub_X_pow_of_monic {R} [Ring R] {p : R[X]} (h : p.Monic) :
-    p - X ^ p.natDegree = p.eraseLead := by
-  rw [← self_sub_C_mul_X_pow, h, C_1, one_mul]
-
-@[aesop simp]
-theorem coeff_eraseLead (p : Polynomial R) (k : ℕ) :
-    p.eraseLead.coeff k = if k = p.natDegree then 0 else p.coeff k :=
-  p.coeff_erase ..
-
-alias ⟨_, IsRoot.mul_div_eq⟩ := mul_div_eq_iff_isRoot
-
 end Polynomial
 
 namespace Nimber

--- a/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
@@ -86,7 +86,7 @@ theorem IsRing.coeff_prod_lt {x : Nimber} {ι} {f : ι → Nimber[X]} {s : Finse
     aesop
   | insert y s hy IH =>
     rw [Finset.prod_insert hy]
-    apply h.coeff_mul_lt <;> aesop
+    apply h.coeff_mul_lt <;> simp_all
 
 /-! ### Embedding in a subfield -/
 

--- a/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
@@ -6,7 +6,6 @@ Authors: Violeta Hernández Palacios
 import CombinatorialGames.Nimber.SimplestExtension.Basic
 import Mathlib.Algebra.Polynomial.Eval.Defs
 import Mathlib.Algebra.Polynomial.Degree.Definitions
-import Mathlib.Algebra.Field.Subfield.Defs
 import Mathlib.Algebra.Polynomial.Eval.Coeff
 
 /-!

--- a/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
@@ -6,8 +6,8 @@ Authors: Violeta Hernández Palacios
 import CombinatorialGames.Nimber.SimplestExtension.Basic
 import Mathlib.Algebra.Polynomial.Eval.Defs
 import Mathlib.Algebra.Polynomial.Degree.Definitions
-import Mathlib.Algebra.Polynomial.Splits
 import Mathlib.Algebra.Field.Subfield.Defs
+import Mathlib.Algebra.Polynomial.Eval.Coeff
 
 /-!
 # Nimber polynomials

--- a/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
@@ -3,13 +3,18 @@ Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
+import CombinatorialGames.Nimber.SimplestExtension.Basic
+import Mathlib.Algebra.Polynomial.Eval.Defs
 import Mathlib.Algebra.Polynomial.Degree.Definitions
+import Mathlib.Algebra.Polynomial.Splits
+import Mathlib.Algebra.Field.Subfield.Defs
 
 /-!
 # Nimber polynomials
 
-This file will contain multiple auxiliary results and definitions for working with nimber
-polynomials. (Though right now it's just a stub.)
+This file contains multiple auxiliary results and definitions for working with nimber polynomials:
+
+- `IsField.embed`: embeds a polynomial `p : Nimber[X]` into the subfield `Iio x`, for `IsField x`.
 -/
 
 universe u
@@ -17,6 +22,9 @@ universe u
 open Order Polynomial
 
 /-! ### For Mathlib-/
+
+-- TODO: should some of these be global?
+attribute [local aesop simp] Function.update coeff_one coeff_C coeff_X
 
 namespace Polynomial
 
@@ -30,4 +38,129 @@ theorem natDegree_eq_zero_iff : p.natDegree = 0 ↔ p = 0 ∨ p.degree = 0 := by
   rw [p.natDegree_eq_zero_iff_degree_le_zero, le_iff_lt_or_eq, ← WithBot.coe_zero, ← bot_eq_zero',
     WithBot.lt_coe_bot, p.degree_eq_bot]
 
+theorem degree_pos_of_mem_roots {R} [CommRing R] [IsDomain R] {p : R[X]} {r} (h : r ∈ p.roots) :
+    0 < p.degree := by
+  by_contra!
+  rw [p.eq_C_of_degree_le_zero this, roots_C] at h
+  cases h
+
+theorem monomial_induction {motive : R[X] → Prop} (zero : motive 0)
+    (add : ∀ a n q, degree q < .some n → motive q → motive (C a * X ^ n + q)) (p : R[X]) :
+    motive p := by
+  induction hn : p.degree using WellFoundedLT.induction generalizing p with | ind n IH
+  cases n with
+  | bot => simp_all
+  | coe n =>
+    rw [← eraseLead_add_C_mul_X_pow p, add_comm]
+    have hp₀ : p ≠ 0 := by aesop
+    have hpn : p.eraseLead.degree < .some n := hn ▸ degree_eraseLead_lt hp₀
+    apply add _ _ _ ((degree_eraseLead_lt hp₀).trans_eq _) (IH _ hpn _ rfl)
+    rw [hn, natDegree_eq_of_degree_eq_some hn]
+
+theorem eval_X_pow {R} [CommRing R] (x : R) (n : ℕ) : eval x (X ^ n : R[X]) = x ^ n := by simp
+
+theorem self_sub_X_pow_of_monic {R} [Ring R] {p : R[X]} (h : p.Monic) :
+    p - X ^ p.natDegree = p.eraseLead := by
+  rw [← self_sub_C_mul_X_pow, h, C_1, one_mul]
+
+@[aesop simp]
+theorem coeff_eraseLead (p : Polynomial R) (k : ℕ) :
+    p.eraseLead.coeff k = if k = p.natDegree then 0 else p.coeff k :=
+  p.coeff_erase ..
+
+alias ⟨_, IsRoot.mul_div_eq⟩ := mul_div_eq_iff_isRoot
+
 end Polynomial
+
+namespace Nimber
+
+/-! ### Basic results -/
+
+theorem polynomial_eq_zero_of_le_one {x : Nimber} {p : Nimber[X]}
+    (hx₁ : x ≤ 1) (h : ∀ k, p.coeff k < x) : p = 0 := by
+  ext k; simpa using (h k).trans_le hx₁
+
+theorem IsRing.eval_lt {x y : Nimber} (h : IsRing x) {p : Nimber[X]} (hp : ∀ k, p.coeff k < x)
+    (hy : y < x) : p.eval y < x := by
+  obtain hx₁ | hx₁ := le_or_gt x 1
+  · have := polynomial_eq_zero_of_le_one hx₁ hp
+    simp_all
+  · rw [eval_eq_sum]
+    exact h.sum_lt hx₁.ne_bot fun n hn ↦ h.mul_lt (hp _) (h.pow_lt hx₁ hy)
+
+theorem coeff_X_pow_lt {x : Nimber} (n : ℕ) (h : 1 < x) : ∀ k, (X ^ n).coeff k < x := by
+  have : 0 < x := h.bot_lt
+  aesop
+
+theorem IsGroup.coeff_add_lt {x : Nimber} {p q : Nimber[X]} (h : IsGroup x)
+    (hp : ∀ k, p.coeff k < x) (hq : ∀ k, q.coeff k < x) : ∀ k, (p + q).coeff k < x := by
+  intro k
+  rw [coeff_add]
+  exact h.add_lt (hp k) (hq k)
+
+theorem IsGroup.coeff_sum_lt {x : Nimber} {ι} {f : ι → Nimber[X]} {s : Finset ι} (h : IsGroup x)
+    (hx₀ : x ≠ 0) (hs : ∀ y ∈ s, ∀ k, (f y).coeff k < x) : ∀ k, (s.sum f).coeff k < x := by
+  intro k
+  rw [finset_sum_coeff]
+  exact h.sum_lt hx₀ fun y hy ↦ (hs y hy k)
+
+theorem IsRing.coeff_mul_lt {x : Nimber} {p q : Nimber[X]} (h : IsRing x)
+    (hp : ∀ k, p.coeff k < x) (hq : ∀ k, q.coeff k < x) : ∀ k, (p * q).coeff k < x := by
+  intro k
+  rw [coeff_mul]
+  exact h.sum_lt (hp 0).ne_bot fun y hy ↦ h.mul_lt (hp _) (hq _)
+
+theorem IsRing.coeff_prod_lt {x : Nimber} {ι} {f : ι → Nimber[X]} {s : Finset ι} (h : IsRing x)
+    (hx₁ : 1 < x) (hs : ∀ y ∈ s, ∀ k, (f y).coeff k < x) : ∀ k, (s.prod f).coeff k < x := by
+  classical
+  induction s using Finset.induction with
+  | empty =>
+    have := zero_lt_one.trans hx₁
+    aesop
+  | insert y s hy IH =>
+    rw [Finset.prod_insert hy]
+    apply h.coeff_mul_lt <;> aesop
+
+/-! ### Embedding in a subfield -/
+
+/-- Reinterpret a polynomial in the nimbers as a polynomial in the subfield `x`.
+
+We could define this under the weaker assumption `IsRing`, but due to proof erasure, this leads to
+issues where `Field (h.toSubring ⋯)` can't be inferred, even if `h : IsField x`. -/
+def IsField.embed {x : Nimber} (h : IsField x) (hx₁ : 1 < x) (p : Nimber[X])
+    (hp : ∀ k, p.coeff k < x) : (h.toSubfield hx₁)[X] :=
+  .ofFinsupp <| .mk p.support (fun k ↦ ⟨p.coeff k, hp k⟩) (by simp [← Subtype.val_inj])
+
+@[simp]
+theorem IsField.coeff_embed {x : Nimber} (h : IsField x) (hx₁ : 1 < x) {p : Nimber[X]}
+    (hp : ∀ k, p.coeff k < x) (k : ℕ) : (h.embed hx₁ p hp).coeff k = ⟨p.coeff k, hp k⟩ :=
+  rfl
+
+@[simp]
+theorem IsField.degree_embed {x : Nimber} (h : IsField x) (hx₁ : 1 < x) {p : Nimber[X]}
+    (hp : ∀ k, p.coeff k < x) : (h.embed hx₁ p hp).degree = p.degree :=
+  rfl
+
+@[simp]
+theorem IsField.leadingCoeff_embed {x : Nimber} (h : IsField x) (hx₁ : 1 < x) {p : Nimber[X]}
+    (hp : ∀ k, p.coeff k < x) : (h.embed hx₁ p hp).leadingCoeff = ⟨p.leadingCoeff, hp _⟩ :=
+  rfl
+
+@[simp]
+theorem IsField.map_embed {x : Nimber} (h : IsField x) (hx₁ : 1 < x) {p : Nimber[X]}
+    (hp : ∀ k, p.coeff k < x) : (h.embed hx₁ p hp).map (Subfield.subtype _) = p := by
+  ext; simp
+
+@[simp]
+theorem IsField.embed_C {x : Nimber} (h : IsField x) (hx₁ : 1 < x) {y hy} :
+    h.embed hx₁ (C y) hy = C ⟨y, by simpa using hy 0⟩ := by
+  ext
+  simp_rw [h.coeff_embed, coeff_C]
+  split_ifs <;> rfl
+
+@[simp]
+theorem IsField.eval_embed {x : Nimber} (h : IsField x) (hx₁ : 1 < x) {p : Nimber[X]}
+    (hp : ∀ k, p.coeff k < x) (y) : (h.embed hx₁ p hp).eval y = ⟨_, h.eval_lt hp y.2⟩ := by
+  simp [← Subtype.val_inj, embed, sum, eval_eq_sum]
+
+end Nimber

--- a/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Polynomial.lean
@@ -20,7 +20,7 @@ universe u
 
 open Order Polynomial
 
-/-! ### For Mathlib-/
+/-! ### For Mathlib -/
 
 -- TODO: should some of these be global?
 attribute [local aesop simp] Function.update coeff_one coeff_C coeff_X


### PR DESCRIPTION
We introduce `IsField.embed`, which reinterprets a polynomial as existing in the subfield for an element `IsField x`.

We could have introduced this as `IsRing.embed` instead, but that has the trouble that Lean can't infer a field instance for `h.toSubring` even when `h : IsField x`, and some later results will require a field.