### PR TITLE
chore: remove redundant theorems on game equivalence 

### DIFF
--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -453,26 +453,15 @@ def delabFuzzy : Delab := do
     annotateGoToSyntaxDef stx
   catch _ => failure -- fail over to the default delaborator
 
-theorem equiv_of_forall_lf {x y : IGame}
-    (hl₁ : ∀ a ∈ x.leftMoves,  ¬y ≤ a)
-    (hr₁ : ∀ a ∈ x.rightMoves, ¬a ≤ y)
-    (hl₂ : ∀ b ∈ y.leftMoves,  ¬x ≤ b)
-    (hr₂ : ∀ b ∈ y.rightMoves, ¬b ≤ x) : x ≈ y := by
-  constructor <;> refine le_iff_forall_lf.2 ⟨?_, ?_⟩ <;> assumption
-
-theorem equiv_of_exists_le {x y : IGame}
-    (hl₁ : ∀ a ∈ x.leftMoves,  ∃ b ∈ y.leftMoves,  a ≤ b)
-    (hr₁ : ∀ a ∈ x.rightMoves, ∃ b ∈ y.rightMoves, b ≤ a)
-    (hl₂ : ∀ b ∈ y.leftMoves,  ∃ a ∈ x.leftMoves,  b ≤ a)
-    (hr₂ : ∀ b ∈ y.rightMoves, ∃ a ∈ x.rightMoves, a ≤ b) : x ≈ y := by
-  apply equiv_of_forall_lf <;> simp +contextual [hl₁, hl₂, hr₁, hr₂, lf_iff_exists_le]
-
+/-- The reverse implication is not necessarily true (e.g. `{-1 | 1} ≈ 0`). -/
 theorem equiv_of_exists {x y : IGame}
     (hl₁ : ∀ a ∈ x.leftMoves,  ∃ b ∈ y.leftMoves,  a ≈ b)
     (hr₁ : ∀ a ∈ x.rightMoves, ∃ b ∈ y.rightMoves, a ≈ b)
     (hl₂ : ∀ b ∈ y.leftMoves,  ∃ a ∈ x.leftMoves,  a ≈ b)
     (hr₂ : ∀ b ∈ y.rightMoves, ∃ a ∈ x.rightMoves, a ≈ b) : x ≈ y := by
-  apply equiv_of_exists_le <;> grind [AntisymmRel]
+  rw [AntisymmRel, le_iff_forall_lf, le_iff_forall_lf]
+  simp_rw [lf_iff_exists_le]
+  grind [AntisymmRel]
 
 @[simp]
 protected theorem zero_lt_one : (0 : IGame) < 1 := by


### PR DESCRIPTION
There's two things that irk me about `equiv_of_forall_lf` and `equiv_of_exists_le`:
1. These are actually mathematical equivalences, and I think they should have been stated as such. In the context of a longer proof, I would not feel comfortable applying these theorems without knowing they were iffs - what if I end up with a goal that's false?
2. They aren't really worth stating as iffs either, since they're straightforward to show by just unfolding definitions (admittedly you have to be slightly careful since `simp_rw [le_iff_forall_lf]` loops, but as the new proof of `equiv_of_exists` shows this isn't a huge problem).

Asking for @plp127's approval since he's the one who added these in the first place.