### PR TITLE
chore: review `ConcreteGame` API

### DIFF
--- a/CombinatorialGames/Game/Specific/Nim.lean
+++ b/CombinatorialGames/Game/Specific/Nim.lean
@@ -28,13 +28,11 @@ open Nimber Set
 namespace ConcreteGame
 
 /-- The game of nim as a `ConcreteGame`. -/
-abbrev nim : ConcreteGame Nimber :=
-  .ofImpartial Iio
+abbrev nim : ConcreteGame Nimber where
+  moves _ := Iio
 
-instance : IsWellFounded _ nim.IsOption := by
-  rw [ConcreteGame.isOption_ofImpartial]
-  change WellFoundedLT Nimber
-  infer_instance
+instance : IsWellFounded _ nim.IsOption :=
+  isWellFounded_isOption_of_eq (· < ·) fun _ _ ↦ rfl
 
 end ConcreteGame
 
@@ -48,7 +46,7 @@ noncomputable def nim : Nimber.{u} → IGame.{u} :=
   ConcreteGame.nim.toIGame
 
 theorem nim_def (o : Nimber) : nim o = !{nim '' Iio o | nim '' Iio o} :=
-  ConcreteGame.toIGame_def o
+  ConcreteGame.toIGame_def (c := .nim) o
 
 @[simp]
 theorem moves_nim (p : Player) (o : Nimber) : (nim o).moves p = nim '' Iio o :=
@@ -138,10 +136,10 @@ termination_by o
 
 @[simp, game_cmp]
 theorem neg_nim (o : Nimber) : -nim o = nim o :=
-  ConcreteGame.neg_toIGame_ofImpartial ..
+  ConcreteGame.neg_toIGame rfl ..
 
 protected instance Impartial.nim (o : Nimber) : Impartial (nim o) :=
-  ConcreteGame.impartial_toIGame_ofImpartial ..
+  ConcreteGame.impartial_toIGame rfl ..
 
 protected instance Dicotic.nim (o : Nimber) : Dicotic (nim o) := by
   rw [dicotic_def]

--- a/CombinatorialGames/Game/Specific/Nim.lean
+++ b/CombinatorialGames/Game/Specific/Nim.lean
@@ -46,7 +46,7 @@ noncomputable def nim : Nimber.{u} → IGame.{u} :=
   ConcreteGame.nim.toIGame
 
 theorem nim_def (o : Nimber) : nim o = !{nim '' Iio o | nim '' Iio o} :=
-  ConcreteGame.toIGame_def (c := .nim) o
+  ConcreteGame.toIGame_def ..
 
 @[simp]
 theorem moves_nim (p : Player) (o : Nimber) : (nim o).moves p = nim '' Iio o :=

--- a/CombinatorialGames/Game/Specific/Poset.lean
+++ b/CombinatorialGames/Game/Specific/Poset.lean
@@ -96,11 +96,11 @@ variable [WellQuasiOrderedLE α]
 
 variable (α) in
 /-- The poset game, played on a poset `α`. -/
-abbrev _root_.ConcreteGame.poset : ConcreteGame (Set α) :=
-  .ofImpartial fun x ↦ {y | Poset.Rel y x}
+abbrev _root_.ConcreteGame.poset : ConcreteGame (Set α) where
+  moves _ x := {y | Poset.Rel y x}
 
-instance : IsWellFounded _ (poset α).IsOption := by
-  simpa using isWellFounded_rel
+instance : IsWellFounded _ (poset α).IsOption :=
+  isWellFounded_isOption_of_eq Poset.Rel fun _ _ ↦ rfl
 
 /-- A state of the poset game on `α`. -/
 noncomputable def toIGame (s : Set α) : IGame :=
@@ -110,12 +110,16 @@ noncomputable def toIGame (s : Set α) : IGame :=
 theorem moves_toIGame (p) (s : Set α) : (toIGame s).moves p = toIGame '' {t | Rel t s} :=
   ConcreteGame.moves_toIGame ..
 
+theorem mem_moves_toIGame_of_rel (p) {s t : Set α} (h : Rel t s) :
+    toIGame t ∈ (toIGame s).moves p :=
+  ConcreteGame.mem_moves_toIGame_of_mem h
+
 @[simp]
 protected theorem neg_toIGame (s : Set α) : -toIGame s = toIGame s :=
-  neg_toIGame_ofImpartial _ s
+  neg_toIGame rfl ..
 
 protected instance impartial_toIGame (s : Set α) : (toIGame s).Impartial :=
-  impartial_toIGame_ofImpartial _ s
+  impartial_toIGame rfl ..
 
 -- TODO: this should generalize to a `Preorder`.
 -- A game should be equal to its antisymmetrization.
@@ -125,9 +129,9 @@ a strategy stealing argument with `{⊤}ᶜ`. -/
 theorem univ_fuzzy_zero {α : Type*} [PartialOrder α] [WellQuasiOrderedLE α] [OrderTop α] :
     toIGame (@univ α) ‖ 0 := by
   apply IGame.Impartial.fuzzy_zero_of_forall_exists_moveLeft
-    (mem_moves_toIGame_of_mem (top_compl_rel_univ))
+    (mem_moves_toIGame_of_rel _ top_compl_rel_univ)
   refine fun z hz ↦ ⟨z, ?_, by rfl⟩
-  rw [IGame.leftMoves, ConcreteGame.moves_toIGame, mem_image] at hz ⊢
+  rw [IGame.leftMoves, moves_toIGame, mem_image] at hz ⊢
   exact ⟨_, rel_univ_of_rel_top_compl hz.choose_spec.1, hz.choose_spec.2⟩
 
 end IGame


### PR DESCRIPTION
This API mainly does two things:
- redefine `ConcreteGame.toIGame` using `movesRecOn` to avoid an absolutely awful 18-case `aesop` proof (why does that even happen?)
- remove `ConcreteGame.ofImpartial` and its API, since @astrainfinita's refactor basically trivialized it by merging `leftMoves` and `rightMoves` into a single function.