### PR TITLE
chore: symmetrize `IGame.birthday` API

### DIFF
--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -84,15 +84,10 @@ theorem birthday_eq_max (x : IGame) : birthday x =
   apply eq_of_forall_lt_iff
   simp [lt_birthday_iff, NatOrdinal.lt_iSup_iff]
 
-@[aesop apply unsafe 50%]
-theorem birthday_lt_of_mem_leftMoves {x y : IGame} (hy : y ∈ x.leftMoves) :
+@[aesop apply unsafe]
+theorem birthday_lt_of_mem_moves {p : Player} {x y : IGame} (hy : y ∈ x.moves p) :
     y.birthday < x.birthday :=
-  lt_birthday_iff.2 (.inl ⟨y, hy, le_rfl⟩)
-
-@[aesop apply unsafe 50%]
-theorem birthday_lt_of_mem_rightMoves {x y : IGame} (hy : y ∈ x.rightMoves) :
-    y.birthday < x.birthday :=
-  lt_birthday_iff.2 (.inr ⟨y, hy, le_rfl⟩)
+  lt_birthday_iff'.2 ⟨y, .of_mem_moves hy, le_rfl⟩
 
 theorem birthday_lt_of_isOption {x y : IGame} (hy : IsOption y x) : y.birthday < x.birthday :=
   lt_birthday_iff'.2 ⟨y, hy, le_rfl⟩
@@ -158,7 +153,7 @@ termination_by o
 theorem le_toIGame_birthday (x : IGame) : x ≤ x.birthday.toIGame := by
   rw [le_iff_forall_lf]
   refine ⟨fun y hy ↦ ((le_toIGame_birthday y).trans_lt ?_).not_ge, ?_⟩
-  · simpa using birthday_lt_of_mem_leftMoves hy
+  · simpa using birthday_lt_of_mem_moves hy
   · simp
 termination_by x
 decreasing_by igame_wf

--- a/CombinatorialGames/Game/Order.lean
+++ b/CombinatorialGames/Game/Order.lean
@@ -34,10 +34,10 @@ theorem tiny_toIGame_birthday_lt {x : IGame.{u}} (hx : 0 < x) : ⧾x.birthday.to
   apply lt_of_le_not_ge
   · refine tiny_le_of_pos_of_forall_neg_le hx
       fun y hy z hz ↦ (neg_toIGame_birthday_le z).trans' ?_
-    simpa using ((birthday_lt_of_mem_rightMoves hz).trans (birthday_lt_of_mem_rightMoves hy)).le
+    simpa using ((birthday_lt_of_mem_moves hz).trans (birthday_lt_of_mem_moves hy)).le
   · refine tiny_lf_of_not_nonpos_of_forall_neg_le hx.not_ge
       fun y hy ↦ (neg_toIGame_birthday_le y).trans' ?_
-    simpa using (birthday_lt_of_mem_rightMoves hy).le
+    simpa using (birthday_lt_of_mem_moves hy).le
 
 theorem lf_miny_of_not_nonneg_of_forall_le {x a : IGame} (hx : x ⧏ 0)
     (ha : ∀ y ∈ x.leftMoves, y ≤ a) : x ⧏ ⧿a := by

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -267,9 +267,8 @@ theorem Fits.equiv_of_forall_not_fits {x y : IGame} [Numeric x] (hx : x.Fits y)
 fits within `y`, then `x ≈ y`. -/
 theorem Fits.equiv_of_forall_birthday_le {x y : IGame} [Numeric x] (hx : x.Fits y)
     (H : ∀ z, Numeric z → z.Fits y → x.birthday ≤ z.birthday) : x ≈ y := by
-  apply hx.equiv_of_forall_not_fits
-  · exact fun z hz h ↦ (birthday_lt_of_mem_leftMoves hz).not_ge <| H z (.of_mem_moves hz) h
-  · exact fun z hz h ↦ (birthday_lt_of_mem_rightMoves hz).not_ge <| H z (.of_mem_moves hz) h
+  apply hx.equiv_of_forall_not_fits <;>
+    exact fun z hz h ↦ (birthday_lt_of_mem_moves hz).not_ge <| H z (.of_mem_moves hz) h
 
 /-- A specialization of the simplicity theorem to `0`. -/
 theorem fits_zero_iff_equiv {x : IGame} [Numeric x] : Fits 0 x ↔ x ≈ 0 := by

--- a/CombinatorialGames/Surreal/Birthday/Cut.lean
+++ b/CombinatorialGames/Surreal/Birthday/Cut.lean
@@ -241,12 +241,12 @@ private theorem birthday_game_le (x : IGame) :
     rw [supLeft, iSup_subtype']
     apply (birthday_iSup_le _).trans <| iSup_le fun i ↦ (birthday_game_le _).2.2.2.trans ?_
     rw [← WithTop.coe_add_one, WithTop.coe_le_coe, Order.add_one_le_iff]
-    exact IGame.birthday_lt_of_mem_leftMoves i.2
+    exact IGame.birthday_lt_of_mem_moves i.2
   have H₂ : (infRight x).birthday ≤ x.birthday := by
     rw [infRight, iInf_subtype']
     apply (birthday_iInf_le _).trans <| iSup_le fun i ↦ (birthday_game_le _).2.2.1.trans ?_
     rw [← WithTop.coe_add_one, WithTop.coe_le_coe, Order.add_one_le_iff]
-    exact IGame.birthday_lt_of_mem_rightMoves i.2
+    exact IGame.birthday_lt_of_mem_moves i.2
   use H₁, H₂
   obtain h | h := lt_or_ge (supLeft x) (infRight x)
   · rw [← simplestBtwn_supLeft_infRight h, leftGame_toGame, rightGame_toGame]

--- a/CombinatorialGames/Surreal/Dyadic/Basic.lean
+++ b/CombinatorialGames/Surreal/Dyadic/Basic.lean
@@ -501,10 +501,10 @@ private theorem equiv_dyadic (x : IGame) [Short x] [Numeric x] : ∃ y : Dyadic,
   use z
   apply (Fits.equiv_of_forall_not_fits H.1 ..).symm <;> intro _ hz' hz
   · obtain rfl := Dyadic.eq_lower_of_mem_leftMoves_toIGame hz'
-    have hz' := birthday_lt_of_mem_leftMoves hz'
+    have hz' := birthday_lt_of_mem_moves hz'
     exact (H.2 hz hz'.le).not_gt hz'
   · obtain rfl := Dyadic.eq_upper_of_mem_rightMoves_toIGame hz'
-    have hz' := birthday_lt_of_mem_rightMoves hz'
+    have hz' := birthday_lt_of_mem_moves hz'
     exact (H.2 hz hz'.le).not_gt hz'
 termination_by x
 decreasing_by igame_wf


### PR DESCRIPTION
That is, merge `birthday_lt_of_mem_leftMoves` and `birthday_lt_of_mem_rightMoves` into one.