### PR TITLE
chore: symmetrize `Impartial` API further

### DIFF
--- a/CombinatorialGames/Game/Concrete.lean
+++ b/CombinatorialGames/Game/Concrete.lean
@@ -157,7 +157,7 @@ theorem neg_toIGame (h : c.moves left = c.moves right) (a : α) : -c.toIGame a =
 
 theorem impartial_toIGame (h : c.moves left = c.moves right) (a : α) : Impartial (c.toIGame a) := by
   refine c.moveRecOn a fun b IH ↦ ?_
-  rw [impartial_def', neg_toIGame h]
+  rw [impartial_def, neg_toIGame h]
   simp_all
 
 end ConcreteGame

--- a/CombinatorialGames/Game/Impartial/Basic.lean
+++ b/CombinatorialGames/Game/Impartial/Basic.lean
@@ -20,7 +20,7 @@ universe u
 namespace IGame
 
 private def ImpartialAux (x : IGame) : Prop :=
-  -x ≈ x ∧ ∀ p, ∀ i ∈ x.moves p, ImpartialAux i
+  -x ≈ x ∧ ∀ p, ∀ y ∈ x.moves p, ImpartialAux y
 termination_by x
 decreasing_by igame_wf
 
@@ -37,14 +37,14 @@ class Impartial (x : IGame) : Prop where of_ImpartialAux ::
   out : ImpartialAux x
 
 theorem impartial_def {x : IGame} :
-    x.Impartial ↔ -x ≈ x ∧ ∀ p, ∀ i ∈ x.moves p, Impartial i := by
+    x.Impartial ↔ -x ≈ x ∧ ∀ p, ∀ y ∈ x.moves p, Impartial y := by
   simp_rw [impartial_iff_aux]
   rw [ImpartialAux]
 
 namespace Impartial
 variable (x y : IGame) [hx : Impartial x] [hy : Impartial y]
 
-theorem mk {x : IGame} (h₁ : -x ≈ x) (h₂ : ∀ p, ∀ i ∈ x.moves p, Impartial i) : Impartial x :=
+theorem mk {x : IGame} (h₁ : -x ≈ x) (h₂ : ∀ p, ∀ y ∈ x.moves p, Impartial y) : Impartial x :=
   impartial_def.2 ⟨h₁, h₂⟩
 
 @[simp] theorem neg_equiv : -x ≈ x := (impartial_def.1 hx).1

--- a/CombinatorialGames/Game/Impartial/Basic.lean
+++ b/CombinatorialGames/Game/Impartial/Basic.lean
@@ -41,16 +41,11 @@ theorem impartial_def {x : IGame} :
   simp_rw [impartial_iff_aux]
   rw [ImpartialAux]
 
-theorem impartial_def' {x : IGame} :
-    x.Impartial ↔ -x ≈ x ∧ (∀ i ∈ xᴸ, Impartial i) ∧ ∀ j ∈ xᴿ, Impartial j := by
-  rw [impartial_def, Player.forall]
-
 namespace Impartial
 variable (x y : IGame) [hx : Impartial x] [hy : Impartial y]
 
-theorem mk {x : IGame} (h₁ : -x ≈ x)
-    (h₂ : ∀ i ∈ xᴸ, Impartial i) (h₃ : ∀ j ∈ xᴿ, Impartial j) : Impartial x :=
-  impartial_def'.2 ⟨h₁, h₂, h₃⟩
+theorem mk {x : IGame} (h₁ : -x ≈ x) (h₂ : ∀ p, ∀ i ∈ x.moves p, Impartial i) : Impartial x :=
+  impartial_def.2 ⟨h₁, h₂⟩
 
 @[simp] theorem neg_equiv : -x ≈ x := (impartial_def.1 hx).1
 @[simp] theorem equiv_neg : x ≈ -x := (neg_equiv _).symm
@@ -89,11 +84,9 @@ protected instance star : Impartial ⋆ := by
 protected instance neg (x : IGame) [Impartial x] : Impartial (-x) := by
   apply mk
   · simp
-  all_goals
-  · rw [moves_neg]
-    intro y hy
-    try have := Impartial.of_mem_moves hy
-    try have := Impartial.of_mem_moves hy
+  · simp_rw [moves_neg, Set.mem_neg]
+    intro p y hy
+    have := Impartial.of_mem_moves hy
     rw [← neg_neg y]
     exact .neg _
 termination_by x
@@ -103,8 +96,8 @@ protected instance add (x y : IGame) [Impartial x] [Impartial y] : Impartial (x 
   apply mk
   · rw [neg_add]
     exact add_congr (neg_equiv x) (neg_equiv y)
-  all_goals
-  · rw [forall_moves_add]
+  · simp_rw [forall_moves_add]
+    intro p
     constructor
     all_goals
       intro z hz

--- a/CombinatorialGames/Game/Impartial/Grundy.lean
+++ b/CombinatorialGames/Game/Impartial/Grundy.lean
@@ -12,13 +12,13 @@ import CombinatorialGames.Nimber.Field
 The Grundy value of an impartial game is recursively defined as the least nimber not among the
 Grundy values of either its left or right options. This map respects addition and multiplication.
 
-We provide three definitions for the Grundy value. `leftGrundy` and `rightGrundy` are computed using
-the left/right options of the game respectively, and are defined for all games. To make the API
-symmetric, we also provide `Impartial.grundy`, which enforces that the game is impartial, and is
-thus equal to either of `leftGrundy` or `rightGrundy`.
+We provide two definitions for the Grundy value. `grundyAux` is computed using either the left or
+right options of the game, and is defined for all games. To make the API symmetric, we also provide
+`Impartial.grundy`, which enforces that the game is impartial, and is thus equal to either of
+`grundyAux left` or `grundyAux right`.
 
-The **Sprague-Grundy** theorem `nim_grundy_equiv` shows that any impartial game is equivalent to a
-game of Nim, namely that corresponding to its Grundy value.
+The **Sprague-Grundy** theorem `Impartial.nim_grundy_equiv` shows that any impartial game is
+equivalent to a game of Nim, namely that corresponding to its Grundy value.
 -/
 
 universe u
@@ -230,7 +230,7 @@ theorem of_grundyAux_left_eq_grundyAux_right {x : IGame}
     (h : ∀ p, ∀ y ∈ x.moves p, Impartial y)
     (H : grundyAux left x = grundyAux right x) : Impartial x :=
   have H := of_grundyAux_left_eq_grundyAux_right' h H
-  .mk ((neg_congr H).symm.trans ((neg_nim _).symm ▸ H)) (h _) (h _)
+  .mk ((neg_congr H).symm.trans ((neg_nim _).symm ▸ H)) h
 
 /-! ### Multiplication -/
 


### PR DESCRIPTION
We make it so that the `Impartial.mk` constructor takes in an `∀ p, ∀ y ∈ x.moves p, Impartial y` argument, instead of separate arguments for left and right games. This removes some redundancy in our proofs.