### PR TITLE
feat: make definitions computable

### DIFF
--- a/CombinatorialGames/Counterexamples/Multiplication.lean
+++ b/CombinatorialGames/Counterexamples/Multiplication.lean
@@ -16,7 +16,6 @@ is colloquially known as `star`, so we use the name `star'` for the second. We p
 `star ≈ star'` and `star * star ≈ star`, but `star' * star ≉ star`.
 -/
 
-noncomputable section
 open IGame
 
 namespace IGame

--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -21,8 +21,6 @@ there exist `x₁ ≈ x₂` and `y₁ ≈ y₂` with `x₁ * y₁ ≉ x₂ * y�
 
 universe u
 
-noncomputable section
-
 open IGame Set Pointwise
 
 /-- Games up to equivalence.
@@ -51,7 +49,7 @@ theorem ind {motive : Game → Prop} (mk : ∀ y, motive (mk y)) (x : Game) : mo
   Quotient.ind mk x
 
 /-- Choose an element of the equivalence class using the axiom of choice. -/
-def out (x : Game) : IGame := Quotient.out x
+noncomputable def out (x : Game) : IGame := Quotient.out x
 @[simp] theorem out_eq (x : Game) : mk x.out = x := Quotient.out_eq x
 
 theorem mk_out_equiv (x : IGame) : (mk x).out ≈ x := Quotient.mk_out (s := AntisymmRel.setoid ..) x
@@ -98,7 +96,7 @@ instance : AddCommGroupWithOne Game where
 instance : IsOrderedAddMonoid Game where
   add_le_add_left := by rintro ⟨a⟩ ⟨b⟩ h ⟨c⟩; exact add_le_add_left (α := IGame) h _
 
-instance : RatCast Game where
+noncomputable instance : RatCast Game where
   ratCast q := mk q
 
 @[simp] theorem mk_zero : mk 0 = 0 := rfl
@@ -320,4 +318,3 @@ theorem intCast_le_zero {n : ℤ} : (n : IGame) ≤ 0 ↔ n ≤ 0 := by
   simpa using intCast_le (n := 0)
 
 end IGame
-end

--- a/CombinatorialGames/Game/Concrete.lean
+++ b/CombinatorialGames/Game/Concrete.lean
@@ -27,8 +27,6 @@ directly most of the time.
 
 universe u v
 
-noncomputable section
-
 open IGame Set
 
 variable {α : Type v}

--- a/CombinatorialGames/Game/Functor.lean
+++ b/CombinatorialGames/Game/Functor.lean
@@ -72,7 +72,7 @@ theorem map_def {α β} (f : α → β) (s : GameFunctor α) :
     f <$> s = ⟨(f '' s.1 ·), fun _ => inferInstance⟩ :=
   rfl
 
-noncomputable instance : QPF GameFunctor where
+instance : QPF GameFunctor where
   P := ⟨Player → Type u, fun x ↦ Σ p, PLift (x p)⟩
   abs x := ⟨fun p ↦ Set.range (x.2 ∘ .mk p ∘ PLift.up), fun _ ↦ inferInstance⟩
   repr x := ⟨fun p ↦ Shrink (x.1 p), Sigma.rec (fun _ y ↦ ((equivShrink _).symm y.1).1)⟩

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -70,6 +70,13 @@ defined by `-!{s | t} = !{-t | -s}`.
 The order structures interact in the expected way with arithmetic. In particular, `Game` is an
 `OrderedAddCommGroup`. Meanwhile, `IGame` satisfies the slightly weaker axioms of a
 `SubtractionCommMonoid`, since the equation `x - x = 0` is only true up to equivalence.
+
+## Computability
+
+The type `IGame` and the constructor arising from the `OfSets` instance are computable, yet carry
+no meaningful data. This is because `Set α` itself carries no meaningful data - it's defined as
+`α → Prop`, and any term in `Prop` is erased by the compiler. To perform comparisons between
+"simple" games, you can use the `game_cmp` tactic as described above.
 -/
 
 universe u
@@ -103,10 +110,7 @@ def IGame : Type (u + 1) :=
 namespace IGame
 export Player (left right)
 
-/-- Construct an `IGame` from its left and right sets.
-
-This function is regrettably noncomputable. Among other issues, sets simply do not carry data in
-Lean. To perform computations on `IGame` we can instead make use of the `game_cmp` tactic. -/
+/-- Construct an `IGame` from its left and right sets. -/
 instance : OfSets IGame fun _ ↦ True where
   ofSets st _ := QPF.Fix.mk ⟨st, fun | left => inferInstance | right => inferInstance⟩
 

--- a/CombinatorialGames/Game/Loopy/Basic.lean
+++ b/CombinatorialGames/Game/Loopy/Basic.lean
@@ -65,8 +65,6 @@ theorem QPF.Cofix.unique {F : Type u → Type u} [QPF F] {α : Type u}
   rw [hf, hg, ← QPF.comp_map, ← QPF.comp_map]
   exact ⟨rfl, rfl⟩
 
-noncomputable section
-
 /-! ### Game moves -/
 
 /-- The type of loopy games.
@@ -81,7 +79,7 @@ def LGame := QPF.Cofix GameFunctor
 namespace LGame
 export Player (left right)
 
-instance : DecidableEq LGame := Classical.decEq _
+noncomputable instance : DecidableEq LGame := Classical.decEq _
 
 /-- The set of moves of the game. -/
 def moves (p : Player) (x : LGame.{u}) : Set LGame.{u} := x.dest.1 p
@@ -914,7 +912,7 @@ and `(a₂, b₂) ∈ s₁ ×ˢ t₂ ∪ t₁ ×ˢ s₂`.
 
 Using `LGame.mulOption`, this can alternatively be written as
 `x * y = !{mulOption x y a₁ b₁ | mulOption x y a₂ b₂}`. -/
-instance _root_.LGame.instMul : Mul LGame where
+noncomputable instance _root_.LGame.instMul : Mul LGame where
   mul x y := toLGame moves moves (right, x, y)
 
 theorem _root_.LGame.corec_mul_corec (initα : α) (initβ : β) :
@@ -930,7 +928,7 @@ end MulTy
 /-- The general option of `x * y` looks like `a * y + x * b - a * b`, for `a` and `b` options of
 `x` and `y`, respectively. -/
 @[pp_nodot]
-def mulOption (x y a b : LGame) : LGame :=
+noncomputable def mulOption (x y a b : LGame) : LGame :=
   a * y + x * b - a * b
 
 @[simp]
@@ -946,10 +944,10 @@ theorem moves_mulOption (p : Player) (x y a b : LGame) :
     (mulOption x y a b).moves p = (a * y + x * b - a * b).moves p :=
   rfl
 
-instance : CommMagma LGame where
+noncomputable instance : CommMagma LGame where
   mul_comm _ _ := (MulTy.corec_swap ..).symm
 
-instance : MulZeroClass LGame where
+noncomputable instance : MulZeroClass LGame where
   zero_mul x := by ext p; cases p <;> simp
   mul_zero x := by ext p; cases p <;> simp
 
@@ -959,7 +957,7 @@ private theorem one_mul' (x : LGame) : 1 * x = x := by
   use (fun z ↦ (1 * z, z)) '' x.moves p
   aesop
 
-instance : MulOneClass LGame where
+noncomputable instance : MulOneClass LGame where
   one_mul := one_mul'
   mul_one x := mul_comm x _ ▸ one_mul' x
 

--- a/CombinatorialGames/Game/Loopy/IGame.lean
+++ b/CombinatorialGames/Game/Loopy/IGame.lean
@@ -16,8 +16,6 @@ arithmetic.
 
 open Set
 
-noncomputable section
-
 namespace IGame
 
 private def toLGame' (x : IGame) : LGame :=
@@ -148,4 +146,3 @@ theorem toLGame_mulOption (x y a b : IGame) :
   simp [mulOption, LGame.mulOption]
 
 end IGame
-end

--- a/CombinatorialGames/Game/Order.lean
+++ b/CombinatorialGames/Game/Order.lean
@@ -14,7 +14,6 @@ We provide instances of `DenselyOrdered` for `IGame` and `Game`.
 
 universe u
 
-noncomputable section
 namespace IGame
 
 theorem tiny_lf_of_not_nonpos_of_forall_neg_le {x a : IGame} (hx : 0 ⧏ x)

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -12,13 +12,12 @@ import CombinatorialGames.Tactic.GameCmp
 This file defines some simple yet notable combinatorial games:
 
 * `⋆ = {0 | 0}`
+* `¼ = {0 | 1}`
 * `↑ = {0 | ⋆}`
-* `↓ = {⋆ | 0}`.
+* `↓ = {⋆ | 0}`
 -/
 
 universe u
-
-noncomputable section
 
 namespace IGame
 
@@ -183,4 +182,3 @@ theorem switch_zero : ±0 = ⋆ := by
   ext p; cases p <;> simp
 
 end IGame
-end

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -12,7 +12,6 @@ import CombinatorialGames.Tactic.GameCmp
 This file defines some simple yet notable combinatorial games:
 
 * `⋆ = {0 | 0}`
-* `¼ = {0 | 1}`
 * `↑ = {0 | ⋆}`
 * `↓ = {⋆ | 0}`
 -/

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -38,8 +38,6 @@ form a linear ordered commutative ring.
 
 universe u
 
-noncomputable section
-
 /-! ### Numeric games -/
 
 namespace IGame
@@ -295,7 +293,7 @@ theorem ind {motive : Surreal → Prop} (mk : ∀ y [Numeric y], motive (mk y)) 
     motive x := Quotient.ind (fun h ↦ @mk _ h.2) x
 
 /-- Choose an element of the equivalence class using the axiom of choice. -/
-def out (x : Surreal) : IGame := (Quotient.out x).1
+noncomputable def out (x : Surreal) : IGame := (Quotient.out x).1
 @[simp] instance (x : Surreal) : Numeric x.out := (Quotient.out x).2
 @[simp] theorem out_eq (x : Surreal) : mk x.out = x := Quotient.out_eq x
 
@@ -318,7 +316,7 @@ instance : Neg Surreal where
 instance : PartialOrder Surreal :=
   inferInstanceAs (PartialOrder (Antisymmetrization ..))
 
-instance : LinearOrder Surreal where
+noncomputable instance : LinearOrder Surreal where
   le_total := by rintro ⟨x⟩ ⟨y⟩; exact Numeric.le_total x y
   toDecidableLE := Classical.decRel _
 
@@ -475,4 +473,3 @@ instance : DenselyOrdered Surreal where
     lt_ofSets_of_mem_left (Set.mem_singleton a), ofSets_lt_of_mem_right (Set.mem_singleton b)⟩
 
 end Surreal
-end


### PR DESCRIPTION
A recent Mathlib PR made [`Shrink`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Logic/Small/Defs.html#Shrink) computable, which through a domino effect now means that a lot of our basic definitions on games are computable too.

This doesn't really do much for us. But at least we don't have to write `noncomputable section` literally everywhere!