### PR TITLE
feat: more general version of `IsField.mul_eq_of_lt`

### DIFF
--- a/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
@@ -503,13 +503,13 @@ theorem IsField.one : IsField 1 where
 theorem IsField.of_le_one {x : Nimber} (h : x ≤ 1) : IsField x := by
   cases Nimber.le_one_iff.1 h <;> simp_all
 
-theorem IsField.mul_eq_of_lt {x y : Nimber} (h : IsField x) (hyx : y < x) : x *ₒ y = x * y :=
-  h.toIsRing.mul_eq_of_lt h.toIsGroup le_rfl hyx @h.inv_lt
+theorem IsField.mul_eq_of_lt {x y z : Nimber} (hx : IsRing x) (hy : IsField y)
+    (hyx : y ≤ x) (hzy : z < y) : x *ₒ z = x * z :=
+  hx.mul_eq_of_lt' hy.toIsGroup hyx hzy fun _ hw ↦ (hy.inv_lt hw).trans_le hyx
 
-/-- A version of `IsField.mul_eq_of_lt` stated in terms of `Ordinal`. -/
-theorem IsField.mul_eq_of_lt' {x y : Ordinal} (hx : IsField (∗x)) (hyx : y < x) :
-    x * y = val (∗x * ∗y) :=
-  hx.mul_eq_of_lt hyx
+theorem IsField.mul_eq_of_lt' {x y z : Ordinal} (hx : IsRing (∗x)) (hy : IsField (∗y))
+    (hyx : y ≤ x) (hzy : z < y) : x * z = val (∗x * ∗z) :=
+  hy.mul_eq_of_lt hx hyx hzy
 
 private theorem inv_lt_of_not_isField_aux {x : Nimber} (h' : IsRing x) (h : ¬ IsField x) :
     x⁻¹ < x ∧ ∀ y < x⁻¹, y⁻¹ < x := by

--- a/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
@@ -507,6 +507,7 @@ theorem IsField.mul_eq_of_lt {x y z : Nimber} (hx : IsRing x) (hy : IsField y)
     (hyx : y ≤ x) (hzy : z < y) : x *ₒ z = x * z :=
   hx.mul_eq_of_lt' hy.toIsGroup hyx hzy fun _ hw ↦ (hy.inv_lt hw).trans_le hyx
 
+/-- A version of `IsField.mul_eq_of_lt` stated in terms of `Ordinal`. -/
 theorem IsField.mul_eq_of_lt' {x y z : Ordinal} (hx : IsRing (∗x)) (hy : IsField (∗y))
     (hyx : y ≤ x) (hzy : z < y) : x * z = val (∗x * ∗z) :=
   hy.mul_eq_of_lt hx hyx hzy

--- a/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
+++ b/CombinatorialGames/Nimber/SimplestExtension/Basic.lean
@@ -505,7 +505,7 @@ theorem IsField.of_le_one {x : Nimber} (h : x ≤ 1) : IsField x := by
 
 theorem IsField.mul_eq_of_lt {x y z : Nimber} (hx : IsRing x) (hy : IsField y)
     (hyx : y ≤ x) (hzy : z < y) : x *ₒ z = x * z :=
-  hx.mul_eq_of_lt' hy.toIsGroup hyx hzy fun _ hw ↦ (hy.inv_lt hw).trans_le hyx
+  hx.mul_eq_of_lt hy.toIsGroup hyx hzy fun _ hw ↦ (hy.inv_lt hw).trans_le hyx
 
 /-- A version of `IsField.mul_eq_of_lt` stated in terms of `Ordinal`. -/
 theorem IsField.mul_eq_of_lt' {x y z : Ordinal} (hx : IsRing (∗x)) (hy : IsField (∗y))


### PR DESCRIPTION
The previous version was just the special case `x = y`.