### PR TITLE
doc: update docstrings

### DIFF
--- a/CombinatorialGames/Game/Computability/FGame.lean
+++ b/CombinatorialGames/Game/Computability/FGame.lean
@@ -43,9 +43,6 @@ universe u
 
 /-- The type of "short pre-games", before we have quotiented by equivalence (`identicalSetoid`).
 
-This serves the exact purpose that `PGame` does for `IGame`. However, unlike `PGame`'s relatively
-short construction, we must prove some extra definitions for computing on top of `SGame`.
-
 This could perfectly well have been in `Type 0`, but we make it universe polymorphic for
 convenience when building quotient types. However, conversions from computable games to their
 noncomputable counterparts are squeezed to `Type 0`. -/
@@ -103,7 +100,7 @@ instance : DecidableEq SGame
       rw [mk.injEq, Fin.heq_fun_iff h.1, Fin.heq_fun_iff h.2]
   else .isFalse (by simp_all)
 
-/-- The identical relation on short games. See `PGame.Identical`. -/
+/-- The identical relation on short games. -/
 def Identical : SGame.{u} → SGame.{u} → Prop
   | mk _ _ xL xR, mk _ _ yL yR =>
       Relator.BiTotal (fun i j ↦ Identical (xL i) (yL j)) ∧
@@ -162,9 +159,6 @@ end SGame
 /-! ### Game moves -/
 
 /-- Short games up to identity.
-
-`FGame` uses the set-theoretic notion of equality on short games,
-similarly to how `IGame` is defined on top of `PGame`.
 
 Here, we have the distinct advantage of being able to use finsets as our
 backing left and right sets over `IGame`'s small sets.

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -12,6 +12,7 @@ import CombinatorialGames.Tactic.GameCmp
 This file defines some simple yet notable combinatorial games:
 
 * `⋆ = {0 | 0}`
+* `½ = {0 | 1}`
 * `↑ = {0 | ⋆}`
 * `↓ = {⋆ | 0}`
 -/

--- a/CombinatorialGames/Surreal/Multiplication.lean
+++ b/CombinatorialGames/Surreal/Multiplication.lean
@@ -24,7 +24,7 @@ well-defined as an operation on the quotient by `IGame.Equiv`, namely the surrea
 an axiom that needs to be satisfied for the surreals to be a `OrderedRing`.
 
 We follow the proof in [SchleicherStoll], except that we use the well-foundedness of the hydra
-relation `CutExpand` on `Multiset PGame` instead of the argument based on a depth function in the
+relation `CutExpand` on `Multiset IGame` instead of the argument based on a depth function in the
 paper. As in said argument, P3 is proven by proxy of an auxiliary P4, which states that for
 `x₁ < x₂` and `y`, then `x₁ * y + x₂ * a < x₁ * a + x₂ * y` when `a ∈ yᴸ`, and
 `x₁ * b + x₂ * y < x₁ * y + x₂ * b` when `b ∈ yᴿ`.


### PR DESCRIPTION
This PR mostly just removes references to `PGame`, which no longer exists.