### PR TITLE
refactor: rename `ConcreteGame` → `GameGraph`

### DIFF
--- a/CombinatorialGames.lean
+++ b/CombinatorialGames.lean
@@ -3,8 +3,8 @@ import CombinatorialGames.Game.Basic
 import CombinatorialGames.Game.Birthday
 import CombinatorialGames.Game.Canonical
 import CombinatorialGames.Game.Computability.FGame
-import CombinatorialGames.Game.Concrete
 import CombinatorialGames.Game.Functor
+import CombinatorialGames.Game.GameGraph
 import CombinatorialGames.Game.IGame
 import CombinatorialGames.Game.Impartial.Basic
 import CombinatorialGames.Game.Impartial.Grundy

--- a/CombinatorialGames/Game/Graph.lean
+++ b/CombinatorialGames/Game/Graph.lean
@@ -10,18 +10,18 @@ import CombinatorialGames.Game.Impartial.Basic
 # Combinatorial games from a type of states
 
 In the literature, mathematicians often describe games as graphs, consisting of a set of states, as
-well as move relations for the left and right players. We define a structure `ConcreteGame` which
+well as move relations for the left and right players. We define a structure `GameGraph` which
 facilitates this construction, bundling the left and right set functions along with the type, as
-well as functions `ConcreteGame.toLGame` and `ConcreteGame.toIGame` which turn them into the
-appropriate type of game.
+well as functions `GameGraph.toLGame` and `GameGraph.toIGame` which turn them into the appropriate
+type of game.
 
-Mathematically, `ConcreteGame.toLGame` is nothing but the corecursor on loopy games, while
-`ConcreteGame.toIGame` is defined inductively.
+Mathematically, `GameGraph.toLGame` is nothing but the corecursor on loopy games, while
+`GameGraph.toIGame` is defined inductively.
 
 ## Design notes
 
-When working with any "specific" game (nim, domineering, etc.) you can use  `ConcreteGame` to set up
-the basic theorems and definitions, but the intent is that you're not working with `ConcreteGame`
+When working with any "specific" game (nim, domineering, etc.) you can use  `GameGraph` to set up
+the basic theorems and definitions, but the intent is that you're not working with `GameGraph`
 directly most of the time.
 -/
 
@@ -31,19 +31,19 @@ open IGame Set
 
 variable {α : Type v}
 
-/-- A "concrete" game is a type of states endowed with move sets for the left and right players.
+/-- A game graph is a type of states endowed with move sets for the left and right players.
 
-You can use `ConcreteGame.toLGame` and `ConcreteGame.toIGame` to turn this structure into the
+You can use `GameGraph.toLGame` and `GameGraph.toIGame` to turn this structure into the
 appropriate game type. -/
-structure ConcreteGame (α : Type v) : Type v where
+structure GameGraph (α : Type v) : Type v where
   /-- The sets of options for the players. -/
   moves : Player → α → Set α
 
-namespace ConcreteGame
-variable {c : ConcreteGame.{v} α} {p : Player}
+namespace GameGraph
+variable {c : GameGraph.{v} α} {p : Player}
 
 /-- `IsOption a b` means that `a` is either a left or a right move for `b`. -/
-def IsOption (c : ConcreteGame α) (a b : α) : Prop :=
+def IsOption (c : GameGraph α) (a b : α) : Prop :=
   a ∈ ⋃ p, c.moves p b
 
 @[aesop simp]
@@ -69,7 +69,7 @@ instance (b : α) : Small.{u} {a // c.IsOption a b} := by
 /-! ### Loopy games -/
 
 variable (c) in
-/-- Turns a state of a `ConcreteLGame` into an `LGame`. -/
+/-- Turns a state of a `GameGraph` into an `LGame`. -/
 def toLGame (a : α) : LGame.{u} :=
   .corec c.moves a
 
@@ -115,7 +115,7 @@ theorem moveRecOn_eq {motive : α → Sort*} (x)
   rfl
 
 variable (c) in
-/-- Turns a state of a `ConcreteIGame` into an `IGame`. -/
+/-- Turns a state of a `GameGraph` into an `IGame`. -/
 def toIGame (a : α) : IGame.{u} :=
   c.moveRecOn a fun x IH ↦ !{fun p ↦ .range fun b : c.moves p x ↦ IH p b b.2}
 
@@ -158,4 +158,4 @@ theorem impartial_toIGame (h : c.moves left = c.moves right) (a : α) : Impartia
   rw [impartial_def, neg_toIGame h]
   simp_all
 
-end ConcreteGame
+end GameGraph

--- a/CombinatorialGames/Game/Specific/Closure.lean
+++ b/CombinatorialGames/Game/Specific/Closure.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Violeta Hernández Palacios, Junyan Xu
+-/
+import CombinatorialGames.Game.GameGraph
+import Mathlib.Order.Closure
+
+/-!
+# Closure games
+
+We define a very broad class of impartial games we call closure games. These are defined in terms of
+a closure operator on `Set α`. A valid move is to insert an element to the set and take the closure.
+
+These games generalize the setup of at least two other important games in combinatorial game theory:
+poset games, and Sylver coinage.
+-/
+
+variable {α : Type*}
+
+namespace GameGraph
+
+/-- The relation in `ClosureGame`. -/
+def ClosureGame.Rel (f : ClosureOperator (Set α)) (t s : f.Closeds) : Prop :=
+  ∃ a ∉ s.1, f.toCloseds (insert a s.1) = t
+
+/-- The "closure game" on a closure operator `f` is such that a valid move is to move from a set `s`
+to the closure of `insert a s`, where `a ∉ f s`. -/
+@[simps!]
+def closureGame (f : ClosureOperator (Set α)) : GameGraph f.Closeds where
+  moves _ s := {t | ClosureGame.Rel f t s}
+
+namespace ClosureGame
+variable {f : ClosureOperator (Set α)} {s t : Set α} {p : Player}
+
+-- TODO: upstream to Mathlib?
+theorem mem_of_mem {a : α} (h : a ∈ s) : a ∈ f s := by
+  simp_rw [← Set.singleton_subset_iff] at *
+  exact h.trans <| f.le_closure _
+
+theorem Rel.irrefl (f : ClosureOperator (Set α)) (s : f.Closeds) : ¬ Rel f s s :=
+  fun ⟨a, ha, has⟩ ↦ ha <| has ▸ mem_of_mem (Set.mem_insert a _)
+
+#exit
+instance : IsIrrefl _ (Rel f) where
+  irrefl := Rel.irrefl f
+
+@[simp]
+theorem isOption_eq : (closureGame f).IsOption = Rel f := by
+  ext; simp [isOption_iff_mem_union]
+
+open Function in
+variable (f) in
+theorem subrelation_rel_gt : Subrelation (Rel f) ((· > ·) on f.toCloseds) := by
+  intro a b h
+  obtain ⟨a, ha, rfl⟩ := h
+  refine ⟨f.mono ?_, ?_⟩
+  · simp
+  · have h' : {a} ⊆ insert a b := by simp
+    refine fun h ↦ ha (h <| f.mono h' ?_)
+    rw [← Set.singleton_subset_iff]
+    exact f.le_closure _
+
+instance (f : ClosureOperator (Set α)) [H : WellFoundedGT f.Closeds] :
+    IsWellFounded _ (Rel f) :=
+  @Subrelation.isWellFounded _ _ ⟨InvImage.wf _ H.wf⟩ _ (subrelation_rel_gt f)
+
+instance (f : ClosureOperator (Set α)) [WellFoundedGT f.Closeds] :
+    IsWellFounded _ (closureGame f).IsOption := by
+  rw [isOption_eq]
+  infer_instance
+
+theorem toLGame_congr (h : f s = f t) :
+    (closureGame f).toLGame s = (closureGame f).toLGame t := by
+  sorry
+  ext
+  simp_rw [moves_toLGame, closureGame_moves, Set.mem_image, Set.mem_setOf_eq]
+  congr! 3
+  simp [Rel, h]
+
+
+theorem toIGame_congr [WellFoundedGT f.Closeds] (h : f s = f t) :
+    (closureGame f).toIGame s = (closureGame f).toIGame t := by
+  apply IGame.toLGame.injective
+  simpa using toLGame_congr h
+
+#exit
+
+end ClosureGame
+end GameGraph

--- a/CombinatorialGames/Game/Specific/Domineering.lean
+++ b/CombinatorialGames/Game/Specific/Domineering.lean
@@ -158,5 +158,5 @@ open IGame Domineering
 -- TODO: this should probably go much earlier in the file.
 
 /-- The game of domineering. -/
-def ConcreteGame.domineering : ConcreteGame Domineering where
+def GameGraph.domineering : GameGraph Domineering where
   moves p x := p.cases {y | relLeft y x} {y | relRight y x}

--- a/CombinatorialGames/Game/Specific/Domineering.lean
+++ b/CombinatorialGames/Game/Specific/Domineering.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Violeta Hernández Palacios
 -/
-import CombinatorialGames.Game.Concrete
+import CombinatorialGames.Game.GameGraph
 import Mathlib.Algebra.Group.Units.Equiv
 import Mathlib.Algebra.Order.Group.Nat
 import Mathlib.Data.Finset.Sort
@@ -23,7 +23,7 @@ disjoint parts of the chessboard give sums of games.
 
 ## Todo
 
-Refactor this file to adhere to the design notes specified in `CombinatorialGames.Game.Concrete`.
+Refactor this file to adhere to the design notes specified in `CombinatorialGames.Game.GameGraph`.
 -/
 
 namespace IGame

--- a/CombinatorialGames/Game/Specific/Nim.lean
+++ b/CombinatorialGames/Game/Specific/Nim.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Fox Thomson, Markus Himmel, Violeta Hernández Palacios
 -/
 import CombinatorialGames.Game.Birthday
-import CombinatorialGames.Game.Concrete
+import CombinatorialGames.Game.GameGraph
 import CombinatorialGames.Game.Small
 import CombinatorialGames.Nimber.Basic
 

--- a/CombinatorialGames/Game/Specific/Nim.lean
+++ b/CombinatorialGames/Game/Specific/Nim.lean
@@ -25,16 +25,16 @@ universe u
 
 open Nimber Set
 
-namespace ConcreteGame
+namespace GameGraph
 
-/-- The game of nim as a `ConcreteGame`. -/
-abbrev nim : ConcreteGame Nimber where
+/-- The game of nim as a `GameGraph`. -/
+abbrev nim : GameGraph Nimber where
   moves _ := Iio
 
 instance : IsWellFounded _ nim.IsOption :=
   isWellFounded_isOption_of_eq (· < ·) fun _ _ ↦ rfl
 
-end ConcreteGame
+end GameGraph
 
 namespace IGame
 
@@ -43,14 +43,14 @@ namespace IGame
 /-- The definition of single-heap nim, which can be viewed as a pile of stones where each player can
 take a positive number of stones from it on their turn. -/
 noncomputable def nim : Nimber.{u} → IGame.{u} :=
-  ConcreteGame.nim.toIGame
+  GameGraph.nim.toIGame
 
 theorem nim_def (o : Nimber) : nim o = !{fun _ ↦ nim '' Iio o} :=
-  ConcreteGame.toIGame_def' ..
+  GameGraph.toIGame_def' ..
 
 @[simp]
 theorem moves_nim (p : Player) (o : Nimber) : (nim o).moves p = nim '' Iio o :=
-  ConcreteGame.moves_toIGame ..
+  GameGraph.moves_toIGame ..
 
 theorem forall_moves_nim {p : Player} {P : IGame → Prop} {o : Nimber} :
     (∀ x ∈ (nim o).moves p, P x) ↔ (∀ a < o, P (nim a)) := by
@@ -108,10 +108,10 @@ proof_wanted _root_.Game.birthday_nim (o : Nimber) : Game.birthday (.mk (nim o))
 
 @[simp, game_cmp]
 theorem neg_nim (o : Nimber) : -nim o = nim o :=
-  ConcreteGame.neg_toIGame rfl ..
+  GameGraph.neg_toIGame rfl ..
 
 protected instance Impartial.nim (o : Nimber) : Impartial (nim o) :=
-  ConcreteGame.impartial_toIGame rfl ..
+  GameGraph.impartial_toIGame rfl ..
 
 protected instance Dicotic.nim (o : Nimber) : Dicotic (nim o) := by
   rw [dicotic_def]

--- a/CombinatorialGames/Game/Specific/Poset.lean
+++ b/CombinatorialGames/Game/Specific/Poset.lean
@@ -23,8 +23,8 @@ poset game on `(Fin m × Fin n) \ {⊥}`.
 
 ## Main results
 
-* `ConcreteGame.Poset.impartial_toIGame`: poset games are impartial
-* `ConcreteGame.Poset.univ_fuzzy_zero`: any poset game with a top element is won by the second
+* `GameGraph.Poset.impartial_toIGame`: poset games are impartial
+* `GameGraph.Poset.univ_fuzzy_zero`: any poset game with a top element is won by the second
   player, shown via a strategy stealing argument
 -/
 
@@ -32,7 +32,7 @@ variable {α : Type*} [Preorder α]
 
 open Set
 
-namespace ConcreteGame.Poset
+namespace GameGraph.Poset
 
 /-! ### Poset relation -/
 
@@ -96,7 +96,7 @@ variable [WellQuasiOrderedLE α]
 
 variable (α) in
 /-- The poset game, played on a poset `α`. -/
-abbrev _root_.ConcreteGame.poset : ConcreteGame (Set α) where
+abbrev _root_.GameGraph.poset : GameGraph (Set α) where
   moves _ x := {y | Poset.Rel y x}
 
 instance : IsWellFounded _ (poset α).IsOption :=
@@ -108,11 +108,11 @@ noncomputable def toIGame (s : Set α) : IGame :=
 
 @[simp]
 theorem moves_toIGame (p) (s : Set α) : (toIGame s).moves p = toIGame '' {t | Rel t s} :=
-  ConcreteGame.moves_toIGame ..
+  GameGraph.moves_toIGame ..
 
 theorem mem_moves_toIGame_of_rel (p) {s t : Set α} (h : Rel t s) :
     toIGame t ∈ (toIGame s).moves p :=
-  ConcreteGame.mem_moves_toIGame_of_mem h
+  GameGraph.mem_moves_toIGame_of_mem h
 
 @[simp]
 protected theorem neg_toIGame (s : Set α) : -toIGame s = toIGame s :=
@@ -135,4 +135,4 @@ theorem univ_fuzzy_zero {α : Type*} [PartialOrder α] [WellQuasiOrderedLE α] [
   exact ⟨_, rel_univ_of_rel_top_compl hz.choose_spec.1, hz.choose_spec.2⟩
 
 end IGame
-end ConcreteGame.Poset
+end GameGraph.Poset

--- a/CombinatorialGames/Game/Specific/Poset.lean
+++ b/CombinatorialGames/Game/Specific/Poset.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Violeta Hernández Palacios. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Violeta Hernández Palacios
 -/
-import CombinatorialGames.Game.Concrete
+import CombinatorialGames.Game.GameGraph
 import CombinatorialGames.Game.Impartial.Basic
 import Mathlib.Order.WellQuasiOrder
 


### PR DESCRIPTION
The design of this type has changed quite a lot over time. In its existing state, I think describing it as a game graph outright is quite reasonable.