### PR TITLE
Revert "feat: make definitions computable"

### DIFF
--- a/CombinatorialGames/Counterexamples/Multiplication.lean
+++ b/CombinatorialGames/Counterexamples/Multiplication.lean
@@ -16,6 +16,7 @@ is colloquially known as `star`, so we use the name `star'` for the second. We p
 `star ≈ star'` and `star * star ≈ star`, but `star' * star ≉ star`.
 -/
 
+noncomputable section
 open IGame
 
 namespace IGame

--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -21,6 +21,8 @@ there exist `x₁ ≈ x₂` and `y₁ ≈ y₂` with `x₁ * y₁ ≉ x₂ * y�
 
 universe u
 
+noncomputable section
+
 open IGame Set Pointwise
 
 /-- Games up to equivalence.
@@ -49,7 +51,7 @@ theorem ind {motive : Game → Prop} (mk : ∀ y, motive (mk y)) (x : Game) : mo
   Quotient.ind mk x
 
 /-- Choose an element of the equivalence class using the axiom of choice. -/
-noncomputable def out (x : Game) : IGame := Quotient.out x
+def out (x : Game) : IGame := Quotient.out x
 @[simp] theorem out_eq (x : Game) : mk x.out = x := Quotient.out_eq x
 
 theorem mk_out_equiv (x : IGame) : (mk x).out ≈ x := Quotient.mk_out (s := AntisymmRel.setoid ..) x
@@ -96,7 +98,7 @@ instance : AddCommGroupWithOne Game where
 instance : IsOrderedAddMonoid Game where
   add_le_add_left := by rintro ⟨a⟩ ⟨b⟩ h ⟨c⟩; exact add_le_add_left (α := IGame) h _
 
-noncomputable instance : RatCast Game where
+instance : RatCast Game where
   ratCast q := mk q
 
 @[simp] theorem mk_zero : mk 0 = 0 := rfl
@@ -318,3 +320,4 @@ theorem intCast_le_zero {n : ℤ} : (n : IGame) ≤ 0 ↔ n ≤ 0 := by
   simpa using intCast_le (n := 0)
 
 end IGame
+end

--- a/CombinatorialGames/Game/Concrete.lean
+++ b/CombinatorialGames/Game/Concrete.lean
@@ -27,6 +27,8 @@ directly most of the time.
 
 universe u v
 
+noncomputable section
+
 open IGame Set
 
 variable {α : Type v}

--- a/CombinatorialGames/Game/Functor.lean
+++ b/CombinatorialGames/Game/Functor.lean
@@ -72,7 +72,7 @@ theorem map_def {α β} (f : α → β) (s : GameFunctor α) :
     f <$> s = ⟨(f '' s.1 ·), fun _ => inferInstance⟩ :=
   rfl
 
-instance : QPF GameFunctor where
+noncomputable instance : QPF GameFunctor where
   P := ⟨Player → Type u, fun x ↦ Σ p, PLift (x p)⟩
   abs x := ⟨fun p ↦ Set.range (x.2 ∘ .mk p ∘ PLift.up), fun _ ↦ inferInstance⟩
   repr x := ⟨fun p ↦ Shrink (x.1 p), Sigma.rec (fun _ y ↦ ((equivShrink _).symm y.1).1)⟩

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -70,18 +70,14 @@ defined by `-!{s | t} = !{-t | -s}`.
 The order structures interact in the expected way with arithmetic. In particular, `Game` is an
 `OrderedAddCommGroup`. Meanwhile, `IGame` satisfies the slightly weaker axioms of a
 `SubtractionCommMonoid`, since the equation `x - x = 0` is only true up to equivalence.
-
-## Computability
-
-The type `IGame` and the constructor arising from the `OfSets` instance are computable, yet carry
-no meaningful data. This is because `Set α` itself carries no meaningful data - it's defined as
-`α → Prop`, and any term in `Prop` is erased by the compiler. To perform comparisons between
-"simple" games, you can use the `game_cmp` tactic as described above.
 -/
 
 universe u
 
 open Set Pointwise
+
+-- Computations can be performed through the `game_cmp` tactic.
+noncomputable section
 
 /-! ### Game moves -/
 
@@ -110,7 +106,10 @@ def IGame : Type (u + 1) :=
 namespace IGame
 export Player (left right)
 
-/-- Construct an `IGame` from its left and right sets. -/
+/-- Construct an `IGame` from its left and right sets.
+
+This function is regrettably noncomputable. Among other issues, sets simply do not carry data in
+Lean. To perform computations on `IGame` we can instead make use of the `game_cmp` tactic. -/
 instance : OfSets IGame fun _ ↦ True where
   ofSets st _ := QPF.Fix.mk ⟨st, fun | left => inferInstance | right => inferInstance⟩
 
@@ -201,32 +200,6 @@ theorem IsOption.irrefl (x : IGame) : ¬ IsOption x x := _root_.irrefl x
 theorem self_notMem_moves (p : Player) (x : IGame) : x ∉ x.moves p :=
   fun hx ↦ IsOption.irrefl x (.of_mem_moves hx)
 
-/-- A (proper) subposition is any game in the transitive closure of `IsOption`. -/
-def Subposition : IGame → IGame → Prop :=
-  Relation.TransGen IsOption
-
-@[aesop unsafe apply 50%]
-theorem Subposition.of_mem_moves {p} {x y : IGame} (h : x ∈ y.moves p) : Subposition x y :=
-  Relation.TransGen.single (.of_mem_moves h)
-
-theorem Subposition.trans {x y z : IGame} (h₁ : Subposition x y) (h₂ : Subposition y z) :
-    Subposition x z :=
-  Relation.TransGen.trans h₁ h₂
-
-instance (x : IGame.{u}) : Small.{u} {y // Subposition y x} :=
-  small_transGen' _ x
-
-instance : IsTrans _ Subposition := inferInstanceAs (IsTrans _ (Relation.TransGen _))
-instance : IsWellFounded _ Subposition := inferInstanceAs (IsWellFounded _ (Relation.TransGen _))
-instance : WellFoundedRelation IGame := ⟨Subposition, instIsWellFoundedSubposition.wf⟩
-
-/-- Discharges proof obligations of the form `⊢ Subposition ..` arising in termination proofs
-of definitions using well-founded recursion on `IGame`. -/
-macro "igame_wf" : tactic =>
-  `(tactic| all_goals solve_by_elim (maxDepth := 8)
-    [Prod.Lex.left, Prod.Lex.right, PSigma.Lex.left, PSigma.Lex.right,
-    Subposition.of_mem_moves, Subposition.trans, Subtype.prop] )
-
 /-- **Conway recursion**: build data for a game by recursively building it on its
 left and right sets. You rarely need to use this explicitly, as the termination checker will handle
 things for you.
@@ -234,15 +207,14 @@ things for you.
 See `ofSetsRecOn` for an alternate form. -/
 @[elab_as_elim]
 def moveRecOn {motive : IGame → Sort*} (x)
-    (mk : Π x, (Π p, Π y ∈ x.moves p, motive y) → motive x) : motive x :=
-  mk x (fun p y _ ↦ moveRecOn y mk)
-termination_by x
-decreasing_by igame_wf
+    (mk : Π x, (Π p, Π y ∈ x.moves p, motive y) → motive x) :
+    motive x :=
+  isOption_wf.recursion x fun x IH ↦ mk x (fun _ _ h ↦ IH _ (.of_mem_moves h))
 
 theorem moveRecOn_eq {motive : IGame → Sort*} (x)
     (mk : Π x, (Π p, Π y ∈ x.moves p, motive y) → motive x) :
-    moveRecOn x mk = mk x (fun _ y _ ↦ moveRecOn y mk) := by
-  rw [moveRecOn]
+    moveRecOn x mk = mk x (fun _ y _ ↦ moveRecOn y mk) :=
+  isOption_wf.fix_eq ..
 
 /-- **Conway recursion**: build data for a game by recursively building it on its
 left and right sets. You rarely need to use this explicitly, as the termination checker will handle
@@ -273,6 +245,32 @@ theorem ofSetsRecOn_ofSets {motive : IGame.{u} → Sort*}
     refine Function.hfunext ?_ fun _ _ _ ↦ ?_
     · simp
     · rw [ofSetsRecOn, cast_heq_iff_heq, heq_cast_iff_heq]
+
+/-- A (proper) subposition is any game in the transitive closure of `IsOption`. -/
+def Subposition : IGame → IGame → Prop :=
+  Relation.TransGen IsOption
+
+@[aesop unsafe apply 50%]
+theorem Subposition.of_mem_moves {p} {x y : IGame} (h : x ∈ y.moves p) : Subposition x y :=
+  Relation.TransGen.single (.of_mem_moves h)
+
+theorem Subposition.trans {x y z : IGame} (h₁ : Subposition x y) (h₂ : Subposition y z) :
+    Subposition x z :=
+  Relation.TransGen.trans h₁ h₂
+
+instance (x : IGame.{u}) : Small.{u} {y // Subposition y x} :=
+  small_transGen' _ x
+
+instance : IsTrans _ Subposition := inferInstanceAs (IsTrans _ (Relation.TransGen _))
+instance : IsWellFounded _ Subposition := inferInstanceAs (IsWellFounded _ (Relation.TransGen _))
+instance : WellFoundedRelation IGame := ⟨Subposition, instIsWellFoundedSubposition.wf⟩
+
+/-- Discharges proof obligations of the form `⊢ Subposition ..` arising in termination proofs
+of definitions using well-founded recursion on `IGame`. -/
+macro "igame_wf" : tactic =>
+  `(tactic| all_goals solve_by_elim (maxDepth := 8)
+    [Prod.Lex.left, Prod.Lex.right, PSigma.Lex.left, PSigma.Lex.right,
+    Subposition.of_mem_moves, Subposition.trans, Subtype.prop] )
 
 /-! ### Basic games -/
 
@@ -1101,10 +1099,10 @@ If `x` is negative, we define `x⁻¹ = -(-x)⁻¹`. For any other game, we set 
 
 If `x` is a non-zero numeric game, then `x * x⁻¹ ≈ 1`. The value of this function on any non-numeric
 game should be treated as a junk value. -/
-noncomputable instance : Inv IGame where
+instance : Inv IGame where
   inv x := by classical exact if 0 < x then inv' x else if x < 0 then -inv' (-x) else 0
 
-noncomputable instance : Div IGame where
+instance : Div IGame where
   div x y := x * y⁻¹
 
 open Classical in
@@ -1141,7 +1139,7 @@ protected theorem inv_neg (x : IGame) : (-x)⁻¹ = -x⁻¹ := by
 /-- The general option of `x⁻¹` looks like `(1 + (y - x) * a) / y`, for `y` an option of `x`, and
 `a` some other "earlier" option of `x⁻¹`. -/
 @[pp_nodot]
-noncomputable def invOption (x y a : IGame) : IGame :=
+def invOption (x y a : IGame) : IGame :=
   (1 + (y - x) * a) / y
 
 private theorem invOption_eq {x y a : IGame} (hy : 0 < y) :
@@ -1193,7 +1191,7 @@ theorem invRec {x : IGame} (hx : 0 < x)
   convert mk using 8 with _ _ _ ha
   simp_rw [invOption_eq ha]
 
-noncomputable instance : RatCast IGame where
+instance : RatCast IGame where
   ratCast q := q.num / q.den
 
 theorem ratCast_def (q : ℚ) : (q : IGame) = q.num / q.den := rfl
@@ -1202,3 +1200,4 @@ theorem ratCast_def (q : ℚ) : (q : IGame) = q.num / q.den := rfl
 @[simp] theorem ratCast_neg (q : ℚ) : ((-q : ℚ) : IGame) = -(q : IGame) := by simp [ratCast_def]
 
 end IGame
+end

--- a/CombinatorialGames/Game/Loopy/Basic.lean
+++ b/CombinatorialGames/Game/Loopy/Basic.lean
@@ -65,6 +65,8 @@ theorem QPF.Cofix.unique {F : Type u → Type u} [QPF F] {α : Type u}
   rw [hf, hg, ← QPF.comp_map, ← QPF.comp_map]
   exact ⟨rfl, rfl⟩
 
+noncomputable section
+
 /-! ### Game moves -/
 
 /-- The type of loopy games.
@@ -79,7 +81,7 @@ def LGame := QPF.Cofix GameFunctor
 namespace LGame
 export Player (left right)
 
-noncomputable instance : DecidableEq LGame := Classical.decEq _
+instance : DecidableEq LGame := Classical.decEq _
 
 /-- The set of moves of the game. -/
 def moves (p : Player) (x : LGame.{u}) : Set LGame.{u} := x.dest.1 p
@@ -910,7 +912,7 @@ and `(a₂, b₂) ∈ s₁ ×ˢ t₂ ∪ t₁ ×ˢ s₂`.
 
 Using `LGame.mulOption`, this can alternatively be written as
 `x * y = !{mulOption x y a₁ b₁ | mulOption x y a₂ b₂}`. -/
-noncomputable instance _root_.LGame.instMul : Mul LGame where
+instance _root_.LGame.instMul : Mul LGame where
   mul x y := toLGame moves moves (right, x, y)
 
 theorem _root_.LGame.corec_mul_corec (initα : α) (initβ : β) :
@@ -926,7 +928,7 @@ end MulTy
 /-- The general option of `x * y` looks like `a * y + x * b - a * b`, for `a` and `b` options of
 `x` and `y`, respectively. -/
 @[pp_nodot]
-noncomputable def mulOption (x y a b : LGame) : LGame :=
+def mulOption (x y a b : LGame) : LGame :=
   a * y + x * b - a * b
 
 @[simp]
@@ -942,10 +944,10 @@ theorem moves_mulOption (p : Player) (x y a b : LGame) :
     (mulOption x y a b).moves p = (a * y + x * b - a * b).moves p :=
   rfl
 
-noncomputable instance : CommMagma LGame where
+instance : CommMagma LGame where
   mul_comm _ _ := (MulTy.corec_swap ..).symm
 
-noncomputable instance : MulZeroClass LGame where
+instance : MulZeroClass LGame where
   zero_mul x := by ext p; cases p <;> simp
   mul_zero x := by ext p; cases p <;> simp
 
@@ -955,7 +957,7 @@ private theorem one_mul' (x : LGame) : 1 * x = x := by
   use (fun z ↦ (1 * z, z)) '' x.moves p
   aesop
 
-noncomputable instance : MulOneClass LGame where
+instance : MulOneClass LGame where
   one_mul := one_mul'
   mul_one x := mul_comm x _ ▸ one_mul' x
 

--- a/CombinatorialGames/Game/Loopy/IGame.lean
+++ b/CombinatorialGames/Game/Loopy/IGame.lean
@@ -16,6 +16,8 @@ arithmetic.
 
 open Set
 
+noncomputable section
+
 namespace IGame
 
 private def toLGame' (x : IGame) : LGame :=
@@ -155,3 +157,4 @@ theorem toLGame_mulOption (x y a b : IGame) :
   simp [mulOption, LGame.mulOption]
 
 end IGame
+end

--- a/CombinatorialGames/Game/Order.lean
+++ b/CombinatorialGames/Game/Order.lean
@@ -14,6 +14,7 @@ We provide instances of `DenselyOrdered` for `IGame` and `Game`.
 
 universe u
 
+noncomputable section
 namespace IGame
 
 theorem tiny_lf_of_not_nonpos_of_forall_neg_le {x a : IGame} (hx : 0 ⧏ x)

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -14,10 +14,12 @@ This file defines some simple yet notable combinatorial games:
 * `⋆ = {0 | 0}`
 * `½ = {0 | 1}`
 * `↑ = {0 | ⋆}`
-* `↓ = {⋆ | 0}`
+* `↓ = {⋆ | 0}`.
 -/
 
 universe u
+
+noncomputable section
 
 namespace IGame
 
@@ -182,3 +184,4 @@ theorem switch_zero : ±0 = ⋆ := by
   ext p; cases p <;> simp
 
 end IGame
+end

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -38,6 +38,8 @@ form a linear ordered commutative ring.
 
 universe u
 
+noncomputable section
+
 /-! ### Numeric games -/
 
 namespace IGame
@@ -293,7 +295,7 @@ theorem ind {motive : Surreal → Prop} (mk : ∀ y [Numeric y], motive (mk y)) 
     motive x := Quotient.ind (fun h ↦ @mk _ h.2) x
 
 /-- Choose an element of the equivalence class using the axiom of choice. -/
-noncomputable def out (x : Surreal) : IGame := (Quotient.out x).1
+def out (x : Surreal) : IGame := (Quotient.out x).1
 @[simp] instance (x : Surreal) : Numeric x.out := (Quotient.out x).2
 @[simp] theorem out_eq (x : Surreal) : mk x.out = x := Quotient.out_eq x
 
@@ -316,7 +318,7 @@ instance : Neg Surreal where
 instance : PartialOrder Surreal :=
   inferInstanceAs (PartialOrder (Antisymmetrization ..))
 
-noncomputable instance : LinearOrder Surreal where
+instance : LinearOrder Surreal where
   le_total := by rintro ⟨x⟩ ⟨y⟩; exact Numeric.le_total x y
   toDecidableLE := Classical.decRel _
 
@@ -473,3 +475,4 @@ instance : DenselyOrdered Surreal where
     lt_ofSets_of_mem_left (Set.mem_singleton a), ofSets_lt_of_mem_right (Set.mem_singleton b)⟩
 
 end Surreal
+end


### PR DESCRIPTION
`Shrink` was re-made noncomputable only a few days after due to a soundness issue.

Reverts vihdzp/combinatorial-games#232