### PR TITLE
feat: indexing the support of `SurrealHahnSeries` by ordinals

### DIFF
--- a/CombinatorialGames/Surreal/HahnSeries/Basic.lean
+++ b/CombinatorialGames/Surreal/HahnSeries/Basic.lean
@@ -38,6 +38,36 @@ attribute [aesop simp] Pi.single_apply
 
 theorem Set.IsWF.to_subtype {α : Type*} [LT α] {s : Set α} (h : IsWF s) : WellFoundedLT s := ⟨h⟩
 
+@[simp]
+theorem equivShrink_le_equivShrink_iff {α : Type*} [Preorder α] [Small.{u} α] {x y : α} :
+    equivShrink α x ≤ equivShrink α y ↔ x ≤ y :=
+  (orderIsoShrink α).map_rel_iff
+
+@[simp]
+theorem equivShrink_lt_equivShrink_iff {α : Type*} [Preorder α] [Small.{u} α] {x y : α} :
+    equivShrink α x < equivShrink α y ↔ x < y :=
+  (orderIsoShrink α).toRelIsoLT.map_rel_iff
+
+open Ordinal in
+@[simp]
+theorem Ordinal.type_lt_Iio (o : Ordinal.{u}) : typeLT (Set.Iio o) = lift.{u + 1} o := by
+  convert ToType.mk.toRelIsoLT.ordinal_lift_type_eq
+  · rw [lift_id'.{u, u+1}]
+  · rw [type_toType]
+
+-- This is like `RelIso.cast` with better def-eqs.
+def RelIso.subrel {α : Type*} (r : α → α → Prop) {p q : α → Prop} (H : ∀ x, p x ↔ q x) :
+    Subrel r p ≃r Subrel r q where
+  map_rel_iff' := .rfl
+  __ := Equiv.subtypeEquiv (Equiv.refl _) H
+
+instance {α β : Type*} {r : α → α → Prop} {s} [IsWellOrder β s] : Subsingleton (r ≃r s) where
+  allEq f g := by
+    ext x
+    change f.toInitialSeg x = g.toInitialSeg x
+    congr 1
+    subsingleton
+
 open Order Set
 
 /-! ### Basic defs and instances -/

--- a/CombinatorialGames/Surreal/HahnSeries/Basic.lean
+++ b/CombinatorialGames/Surreal/HahnSeries/Basic.lean
@@ -61,13 +61,6 @@ def RelIso.subrel {α : Type*} (r : α → α → Prop) {p q : α → Prop} (H :
   map_rel_iff' := .rfl
   __ := Equiv.subtypeEquiv (Equiv.refl _) H
 
-instance {α β : Type*} {r : α → α → Prop} {s} [IsWellOrder β s] : Subsingleton (r ≃r s) where
-  allEq f g := by
-    ext x
-    change f.toInitialSeg x = g.toInitialSeg x
-    congr 1
-    subsingleton
-
 open Order Set
 
 /-! ### Basic defs and instances -/

--- a/CombinatorialGames/Surreal/HahnSeries/Basic.lean
+++ b/CombinatorialGames/Surreal/HahnSeries/Basic.lean
@@ -305,10 +305,7 @@ local instance (x : SurrealHahnSeries.{u}) : IsWellOrder (Shrink.{u} x.support) 
 
 /-! #### `length` -/
 
-/-- The length of a surreal Hahn series is the order type of its support.
-
-Reasoning about `Ordinal.type` directly is often quite tedious. To prove things about `length`, it's
-often easier to use `HahnSeries.ofSeqRecOn` and the `HahnSeries.ofSeq` API. -/
+/-- The length of a surreal Hahn series is the order type of its support. -/
 def length (x : SurrealHahnSeries.{u}) : Ordinal.{u} :=
   type (α := Shrink.{u} x.support) (· > ·)
 
@@ -395,7 +392,7 @@ theorem typein_support {x : SurrealHahnSeries.{u}} (i : x.support) :
 
 /-- Returns the coefficient which corresponds to the `i`-th largest exponent, or `0` if no such
 coefficient exists. -/
-def coeffIdx (x : SurrealHahnSeries) (i : Ordinal.{u}) : ℝ :=
+def coeffIdx (x : SurrealHahnSeries) (i : Ordinal) : ℝ :=
   if h : i < x.length then x.coeff (x.exp ⟨i, h⟩) else 0
 
 theorem coeffIdx_of_lt {x : SurrealHahnSeries} {i : Ordinal} (h : i < x.length) :
@@ -480,12 +477,12 @@ theorem length_truncIdx (x : SurrealHahnSeries) (i : Ordinal) :
     (x.truncIdx i).length = min i x.length := by
   obtain hi | hi := lt_or_ge i x.length
   · rw [← lift_inj, ← type_support]
-    trans type (Subrel (· > · : x.support → _ → _) (· > x.exp ⟨i, hi⟩))
+    trans type (Subrel (· > · : x.support → _) (· > x.exp ⟨i, hi⟩))
     · apply ((RelIso.subrel (q := fun y ↦ ∃ h : y ∈ x.support, ⟨y, h⟩ ∈ Ioi (x.exp ⟨i, hi⟩))
         (· > ·) _).trans _).ordinal_type_eq
       · rw [truncIdx_of_lt hi, support_trunc]
         aesop
-      · use (Equiv.subtypeSubtypeEquivSubtypeExists _ _).symm
+      · use (Equiv.subtypeSubtypeEquivSubtypeExists ..).symm
         aesop
     · simpa using hi.le
   · rw [truncIdx_of_le hi, min_eq_right hi]

--- a/CombinatorialGames/Surreal/HahnSeries/Basic.lean
+++ b/CombinatorialGames/Surreal/HahnSeries/Basic.lean
@@ -300,7 +300,7 @@ theorem trunc_add_single {x : SurrealHahnSeries} {i : Surreal} (hi : i ∈ lower
 
 open Ordinal
 
-local instance (x : SurrealHahnSeries) : IsWellOrder (Shrink.{u} x.support) (· > ·) :=
+local instance (x : SurrealHahnSeries.{u}) : IsWellOrder (Shrink.{u} x.support) (· > ·) :=
   (orderIsoShrink x.support).dual.symm.toRelIsoLT.toRelEmbedding.isWellOrder
 
 /-! #### `length` -/


### PR DESCRIPTION
A lot of the proofs here are kind of horrible. On a subsequent PR I will introduce `SurrealHahnSeries.ofSeq` for creating a Hahn series out of a decreasing ordinal-indexed sequence of exponents and coefficients; this turns out to be a much more convenient representation for proving results about length.

We opt to define `SurrealHahnSeries.length` as an `Ordinal` rather than a `NatOrdinal`.  The reasoning being that the former is a more natural type to describe order types, and the conversion is basically trivial anyways.