### PR TITLE
feat: `switch_fuzzy_zero_iff` and `switch_fuzzy_self_iff`

### DIFF
--- a/CombinatorialGames/Game/Classes.lean
+++ b/CombinatorialGames/Game/Classes.lean
@@ -166,73 +166,73 @@ protected instance sub (x y : IGame) [Impartial x] [Impartial y] : Impartial (x 
 
 /- The product instance is proven in `Game.Impartial.Multiplication`. -/
 
-theorem _root_.le_comm_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) : x ≤ y ↔ y ≤ x := by
+theorem _root_.le_comm_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) : x ≤ y ↔ y ≤ x := by
   rw [← IGame.neg_le_neg_iff, hy.le_congr hx]
 
 theorem le_comm {x y} [Impartial x] [Impartial y] : x ≤ y ↔ y ≤ x :=
-  le_comm_of_equiv_neg (equiv_neg x) (equiv_neg y)
+  le_comm_of_neg_equiv (neg_equiv x) (neg_equiv y)
 
-theorem _root_.not_lt_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) : ¬x < y := by
+theorem _root_.not_lt_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) : ¬x < y := by
   apply (lt_asymm · ?_)
-  rwa [← IGame.neg_lt_neg_iff, ← hx.lt_congr hy]
+  rwa [← IGame.neg_lt_neg_iff, hx.lt_congr hy]
 
 @[simp]
 theorem not_lt : ¬x < y :=
-  not_lt_of_equiv_neg (equiv_neg x) (equiv_neg y)
+  not_lt_of_neg_equiv (neg_equiv x) (neg_equiv y)
 
-theorem _root_.equiv_or_fuzzy_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+theorem _root_.equiv_or_fuzzy_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) :
     x ≈ y ∨ x ‖ y := by
   obtain (h | h | h | h) := lt_or_antisymmRel_or_gt_or_incompRel x y
-  · cases not_lt_of_equiv_neg hx hy h
+  · cases not_lt_of_neg_equiv hx hy h
   · exact .inl h
-  · cases not_lt_of_equiv_neg hy hx h
+  · cases not_lt_of_neg_equiv hy hx h
   · exact .inr h
 
 /-- By setting `y = 0`, we find that in an impartial game, either the first player always wins, or
 the second player always wins. -/
 theorem equiv_or_fuzzy : x ≈ y ∨ x ‖ y :=
-  equiv_or_fuzzy_of_equiv_neg (equiv_neg x) (equiv_neg y)
+  equiv_or_fuzzy_of_neg_equiv (neg_equiv x) (neg_equiv y)
 
 variable {x y}
 
-theorem _root_.not_equiv_iff_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+theorem _root_.not_equiv_iff_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) :
     ¬x ≈ y ↔ x ‖ y :=
-  ⟨(equiv_or_fuzzy_of_equiv_neg hx hy).resolve_left, IncompRel.not_antisymmRel⟩
+  ⟨(equiv_or_fuzzy_of_neg_equiv hx hy).resolve_left, IncompRel.not_antisymmRel⟩
 
 @[simp]
 theorem not_equiv_iff : ¬ x ≈ y ↔ x ‖ y :=
-  not_equiv_iff_of_equiv_neg (equiv_neg x) (equiv_neg y)
+  not_equiv_iff_of_neg_equiv (neg_equiv x) (neg_equiv y)
 
-theorem _root_.not_fuzzy_iff_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+theorem _root_.not_fuzzy_iff_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) :
     ¬x ‖ y ↔ x ≈ y :=
-  not_iff_comm.1 (not_equiv_iff_of_equiv_neg hx hy)
+  not_iff_comm.1 (not_equiv_iff_of_neg_equiv hx hy)
 
 @[simp]
 theorem not_fuzzy_iff : ¬ x ‖ y ↔ x ≈ y :=
   not_iff_comm.1 not_equiv_iff
 
-theorem _root_.le_iff_equiv_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+theorem _root_.le_iff_equiv_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) :
     x ≤ y ↔ x ≈ y :=
-  ⟨fun h ↦ ⟨h, (le_comm_of_equiv_neg hx hy).1 h⟩, And.left⟩
+  ⟨fun h ↦ ⟨h, (le_comm_of_neg_equiv hx hy).1 h⟩, And.left⟩
 
 @[simp]
 theorem le_iff_equiv : x ≤ y ↔ x ≈ y :=
   ⟨fun h ↦ ⟨h, le_comm.1 h⟩, And.left⟩
 
-theorem _root_.ge_iff_equiv_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+theorem _root_.ge_iff_equiv_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) :
     y ≤ x ↔ x ≈ y :=
-  (le_iff_equiv_of_equiv_neg hy hx).trans antisymmRel_comm
+  (le_iff_equiv_of_neg_equiv hy hx).trans antisymmRel_comm
 
 theorem ge_iff_equiv : y ≤ x ↔ x ≈ y :=
   ⟨fun h ↦ ⟨le_comm.2 h, h⟩, And.right⟩
 
-theorem _root_.lf_iff_fuzzy_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+theorem _root_.lf_iff_fuzzy_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) :
     x ⧏ y ↔ x ‖ y :=
-  (ge_iff_equiv_of_equiv_neg hx hy).not.trans (not_equiv_iff_of_equiv_neg hx hy)
+  (ge_iff_equiv_of_neg_equiv hx hy).not.trans (not_equiv_iff_of_neg_equiv hx hy)
 
-theorem _root_.gf_iff_fuzzy_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+theorem _root_.gf_iff_fuzzy_of_neg_equiv {x y : IGame} (hx : -x ≈ x) (hy : -y ≈ y) :
     y ⧏ x ↔ x ‖ y :=
-  (le_iff_equiv_of_equiv_neg hx hy).not.trans (not_equiv_iff_of_equiv_neg hx hy)
+  (le_iff_equiv_of_neg_equiv hx hy).not.trans (not_equiv_iff_of_neg_equiv hx hy)
 
 theorem lf_iff_fuzzy : x ⧏ y ↔ x ‖ y := by simp [comm]
 theorem gf_iff_fuzzy : y ⧏ x ↔ x ‖ y := by simp

--- a/CombinatorialGames/Game/Classes.lean
+++ b/CombinatorialGames/Game/Classes.lean
@@ -164,40 +164,74 @@ decreasing_by igame_wf
 protected instance sub (x y : IGame) [Impartial x] [Impartial y] : Impartial (x - y) :=
   .add x (-y)
 
+theorem _root_.le_comm_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) : x ≤ y ↔ y ≤ x := by
+  rw [← IGame.neg_le_neg_iff, hy.le_congr hx]
+
 /-- The product instance is proven in `Game.Impartial.Grundy`. -/
-theorem le_comm {x y} [Impartial x] [Impartial y] : x ≤ y ↔ y ≤ x := by
-  rw [← IGame.neg_le_neg_iff, (neg_equiv y).le_congr (neg_equiv x)]
+theorem le_comm {x y} [Impartial x] [Impartial y] : x ≤ y ↔ y ≤ x :=
+  le_comm_of_equiv_neg (equiv_neg x) (equiv_neg y)
+
+theorem _root_.not_lt_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) : ¬x < y := by
+  apply (lt_asymm · ?_)
+  rwa [← IGame.neg_lt_neg_iff, ← hx.lt_congr hy]
 
 @[simp]
-theorem not_lt : ¬x < y := by
-  apply (lt_asymm · ?_)
-  rwa [← IGame.neg_lt_neg_iff, (neg_equiv x).lt_congr (neg_equiv y)]
+theorem not_lt : ¬x < y :=
+  not_lt_of_equiv_neg (equiv_neg x) (equiv_neg y)
+
+theorem _root_.equiv_or_fuzzy_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+    x ≈ y ∨ x ‖ y := by
+  obtain (h | h | h | h) := lt_or_antisymmRel_or_gt_or_incompRel x y
+  · cases not_lt_of_equiv_neg hx hy h
+  · exact .inl h
+  · cases not_lt_of_equiv_neg hy hx h
+  · exact .inr h
 
 /-- By setting `y = 0`, we find that in an impartial game, either the first player always wins, or
 the second player always wins. -/
-theorem equiv_or_fuzzy : x ≈ y ∨ x ‖ y := by
-  obtain (h | h | h | h) := lt_or_antisymmRel_or_gt_or_incompRel x y
-  · cases not_lt x y h
-  · exact .inl h
-  · cases not_lt y x h
-  · exact .inr h
+theorem equiv_or_fuzzy : x ≈ y ∨ x ‖ y :=
+  equiv_or_fuzzy_of_equiv_neg (equiv_neg x) (equiv_neg y)
 
 variable {x y}
 
+theorem _root_.not_equiv_iff_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+    ¬x ≈ y ↔ x ‖ y :=
+  ⟨(equiv_or_fuzzy_of_equiv_neg hx hy).resolve_left, IncompRel.not_antisymmRel⟩
+
 @[simp]
 theorem not_equiv_iff : ¬ x ≈ y ↔ x ‖ y :=
-   ⟨(equiv_or_fuzzy x y).resolve_left, IncompRel.not_antisymmRel⟩
+  not_equiv_iff_of_equiv_neg (equiv_neg x) (equiv_neg y)
+
+theorem _root_.not_fuzzy_iff_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+    ¬x ‖ y ↔ x ≈ y :=
+  not_iff_comm.1 (not_equiv_iff_of_equiv_neg hx hy)
 
 @[simp]
 theorem not_fuzzy_iff : ¬ x ‖ y ↔ x ≈ y :=
   not_iff_comm.1 not_equiv_iff
 
+theorem _root_.le_iff_equiv_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+    x ≤ y ↔ x ≈ y :=
+  ⟨fun h ↦ ⟨h, (le_comm_of_equiv_neg hx hy).1 h⟩, And.left⟩
+
 @[simp]
 theorem le_iff_equiv : x ≤ y ↔ x ≈ y :=
   ⟨fun h ↦ ⟨h, le_comm.1 h⟩, And.left⟩
 
+theorem _root_.ge_iff_equiv_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+    y ≤ x ↔ x ≈ y :=
+  (le_iff_equiv_of_equiv_neg hy hx).trans antisymmRel_comm
+
 theorem ge_iff_equiv : y ≤ x ↔ x ≈ y :=
   ⟨fun h ↦ ⟨le_comm.2 h, h⟩, And.right⟩
+
+theorem _root_.lf_iff_fuzzy_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+    x ⧏ y ↔ x ‖ y :=
+  (ge_iff_equiv_of_equiv_neg hx hy).not.trans (not_equiv_iff_of_equiv_neg hx hy)
+
+theorem _root_.gf_iff_fuzzy_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) :
+    y ⧏ x ↔ x ‖ y :=
+  (le_iff_equiv_of_equiv_neg hx hy).not.trans (not_equiv_iff_of_equiv_neg hx hy)
 
 theorem lf_iff_fuzzy : x ⧏ y ↔ x ‖ y := by simp [comm]
 theorem gf_iff_fuzzy : y ⧏ x ↔ x ‖ y := by simp

--- a/CombinatorialGames/Game/Classes.lean
+++ b/CombinatorialGames/Game/Classes.lean
@@ -164,7 +164,7 @@ decreasing_by igame_wf
 protected instance sub (x y : IGame) [Impartial x] [Impartial y] : Impartial (x - y) :=
   .add x (-y)
 
-/- The product instance is proven in `Game.Impartial.Grundy`. -/
+/- The product instance is proven in `Game.Impartial.Multiplication`. -/
 
 theorem _root_.le_comm_of_equiv_neg {x y : IGame} (hx : x ≈ -x) (hy : y ≈ -y) : x ≤ y ↔ y ≤ x := by
   rw [← IGame.neg_le_neg_iff, hy.le_congr hx]

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -238,10 +238,9 @@ theorem switch_equiv_zero_iff {x : IGame} : ±x ≈ 0 ↔ ¬0 ≤ x := by
 alias ⟨_, switch_equiv_zero⟩ := switch_equiv_zero_iff
 
 theorem switch_fuzzy_zero_iff {x : IGame} : ±x ‖ 0 ↔ 0 ≤ x := by
-  refine Iff.trans ?_ switch_equiv_zero_iff.not_left
-  unfold AntisymmRel IncompRel
-  beta_reduce
-  rw [← IGame.zero_le_neg, neg_switch, and_self, and_self]
+  rw [← not_iff_not, ← switch_equiv_zero_iff]
+  exact not_fuzzy_iff_of_equiv_neg
+    (neg_switch x).symm.antisymmRel neg_zero.symm.antisymmRel
 
 alias ⟨_, switch_fuzzy_zero⟩ := switch_fuzzy_zero_iff
 
@@ -252,10 +251,8 @@ theorem switch_fuzzy_self_iff {x : IGame} : ±x ‖ x ↔ ¬x < 0 := by
       · apply left_lf
         simp
       · intro h
-        have hlt : 0 < ±x := h0x.trans_lt (lt_of_le_not_ge h (left_lf (by simp)))
-        apply hlt.not_gt
-        rw [← neg_switch, IGame.neg_lt_zero]
-        exact hlt
+        absurd h0x.trans_lt (lt_of_le_not_ge h (left_lf (by simp)))
+        exact not_lt_of_equiv_neg neg_zero.symm.antisymmRel (neg_switch x).symm.antisymmRel
     · exact h0x.not_gt
   · rw [lt_iff_le_not_ge, and_iff_left h0x]
     exact ⟨fun hx => mt (switch_equiv_zero h0x).ge.trans' hx.2,

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -239,8 +239,8 @@ alias ⟨_, switch_equiv_zero⟩ := switch_equiv_zero_iff
 
 theorem switch_fuzzy_zero_iff {x : IGame} : ±x ‖ 0 ↔ 0 ≤ x := by
   rw [← not_iff_not, ← switch_equiv_zero_iff]
-  exact not_fuzzy_iff_of_equiv_neg
-    (neg_switch x).symm.antisymmRel neg_zero.symm.antisymmRel
+  exact not_fuzzy_iff_of_neg_equiv
+    (neg_switch x).antisymmRel neg_zero.antisymmRel
 
 alias ⟨_, switch_fuzzy_zero⟩ := switch_fuzzy_zero_iff
 
@@ -252,7 +252,7 @@ theorem switch_fuzzy_self_iff {x : IGame} : ±x ‖ x ↔ ¬x < 0 := by
         simp
       · intro h
         absurd h0x.trans_lt (lt_of_le_not_ge h (left_lf (by simp)))
-        exact not_lt_of_equiv_neg neg_zero.symm.antisymmRel (neg_switch x).symm.antisymmRel
+        exact not_lt_of_neg_equiv neg_zero.antisymmRel (neg_switch x).antisymmRel
     · exact h0x.not_gt
   · rw [lt_iff_le_not_ge, and_iff_left h0x]
     exact ⟨fun hx => mt (switch_equiv_zero h0x).ge.trans' hx.2,

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -237,5 +237,31 @@ theorem switch_equiv_zero_iff {x : IGame} : ±x ≈ 0 ↔ ¬0 ≤ x := by
 
 alias ⟨_, switch_equiv_zero⟩ := switch_equiv_zero_iff
 
+theorem switch_fuzzy_zero_iff {x : IGame} : ±x ‖ 0 ↔ 0 ≤ x := by
+  refine Iff.trans ?_ switch_equiv_zero_iff.not_left
+  unfold AntisymmRel IncompRel
+  beta_reduce
+  rw [← IGame.zero_le_neg, neg_switch, and_self, and_self]
+
+alias ⟨_, switch_fuzzy_zero⟩ := switch_fuzzy_zero_iff
+
+theorem switch_fuzzy_self_iff {x : IGame} : ±x ‖ x ↔ ¬x < 0 := by
+  by_cases h0x : 0 ≤ x
+  · apply iff_of_true
+    · constructor
+      · apply left_lf
+        simp
+      · intro h
+        have hlt : 0 < ±x := h0x.trans_lt (lt_of_le_not_ge h (left_lf (by simp)))
+        apply hlt.not_gt
+        rw [← neg_switch, IGame.neg_lt_zero]
+        exact hlt
+    · exact h0x.not_gt
+  · rw [lt_iff_le_not_ge, and_iff_left h0x]
+    exact ⟨fun hx => mt (switch_equiv_zero h0x).ge.trans' hx.2,
+      fun hx0 => (switch_equiv_zero h0x).trans_incompRel ⟨h0x, hx0⟩⟩
+
+alias ⟨_, switch_fuzzy_self⟩ := switch_fuzzy_self_iff
+
 end IGame
 end

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -246,14 +246,10 @@ alias ⟨_, switch_fuzzy_zero⟩ := switch_fuzzy_zero_iff
 
 theorem switch_fuzzy_self_iff {x : IGame} : ±x ‖ x ↔ ¬x < 0 := by
   by_cases h0x : 0 ≤ x
-  · apply iff_of_true
-    · constructor
-      · apply left_lf
-        simp
-      · intro h
-        absurd h0x.trans_lt (lt_of_le_not_ge h (left_lf (by simp)))
-        exact not_lt_of_neg_equiv neg_zero.antisymmRel (neg_switch x).antisymmRel
-    · exact h0x.not_gt
+  · refine iff_of_true ⟨left_lf ?_, fun h ↦ ?_⟩ h0x.not_gt
+    · simp
+    · absurd h0x.trans_lt (lt_of_le_not_ge h (left_lf (by simp)))
+      exact not_lt_of_neg_equiv neg_zero.antisymmRel (neg_switch x).antisymmRel
   · rw [lt_iff_le_not_ge, and_iff_left h0x]
     exact ⟨fun hx => mt (switch_equiv_zero h0x).ge.trans' hx.2,
       fun hx0 => (switch_equiv_zero h0x).trans_incompRel ⟨h0x, hx0⟩⟩


### PR DESCRIPTION
Characterize when `switch x` is confused to `0` and when it's confused to `x`. Follow-up to #421.

---

- [x] depends on: #424