### PR TITLE
fix(Game/Classes): comment incorrectly made into docstring

### DIFF
--- a/CombinatorialGames/Game/Classes.lean
+++ b/CombinatorialGames/Game/Classes.lean
@@ -164,7 +164,8 @@ decreasing_by igame_wf
 protected instance sub (x y : IGame) [Impartial x] [Impartial y] : Impartial (x - y) :=
   .add x (-y)
 
-/-- The product instance is proven in `Game.Impartial.Grundy`. -/
+/- The product instance is proven in `Game.Impartial.Multiplication`. -/
+
 theorem le_comm {x y} [Impartial x] [Impartial y] : x ≤ y ↔ y ≤ x := by
   rw [← IGame.neg_le_neg_iff, (neg_equiv y).le_congr (neg_equiv x)]
 


### PR DESCRIPTION
Fix some docstring which should've just been a comment. This was introduced in #139.