### PR TITLE
chore: fix defeqs of `nsmul`, `zsmul`, `natCast`, `intCast`

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -87,10 +87,15 @@ private theorem ofSets_cases (s t : Set Game.{u}) [Small.{u} s] [Small.{u} t] :
 
 instance : Zero Game := ⟨mk 0⟩
 instance : One Game := ⟨mk 1⟩
-instance : Add Game := ⟨Quotient.map₂ _ @add_congr⟩
-instance : Neg Game := ⟨Quotient.map _ @neg_congr⟩
+instance : Add Game := ⟨Quotient.map₂ (· + ·) @add_congr⟩
+instance : Neg Game := ⟨Quotient.map (-·) @neg_congr⟩
+instance : Sub Game := ⟨Quotient.map₂ (· - ·) @sub_congr⟩
 instance : PartialOrder Game := inferInstanceAs (PartialOrder (Antisymmetrization ..))
 instance : Inhabited Game := ⟨0⟩
+instance : NSMul Game := ⟨fun n => Quotient.map (n • ·) (@nsmul_congr n)⟩
+instance : ZSMul Game := ⟨fun n => Quotient.map (n • ·) (@zsmul_congr n)⟩
+instance : NatCast Game := ⟨fun n => mk n⟩
+instance : IntCast Game := ⟨fun n => mk n⟩
 
 instance : AddCommGroupWithOne Game where
   zero_add := by rintro ⟨x⟩; exact congr(mk $(zero_add _))
@@ -98,8 +103,12 @@ instance : AddCommGroupWithOne Game where
   add_comm := by rintro ⟨x⟩ ⟨y⟩; exact congr(mk $(add_comm _ _))
   add_assoc := by rintro ⟨x⟩ ⟨y⟩ ⟨z⟩; exact congr(mk $(add_assoc _ _ _))
   neg_add_cancel := by rintro ⟨a⟩; exact mk_eq (neg_add_equiv _)
-  nsmul := nsmulRec
-  zsmul := zsmulRec
+  nsmul_zero := by rintro ⟨a⟩; rfl
+  nsmul_succ := by rintro n ⟨a⟩; rfl
+  zsmul_zero' := by rintro ⟨a⟩; rfl
+  zsmul_succ' := by rintro n ⟨a⟩; rfl
+  zsmul_neg' := by rintro n ⟨a⟩; rfl
+  sub_eq_add_neg := by rintro ⟨a⟩ ⟨b⟩; rfl
 
 instance : IsOrderedAddMonoid Game where
   add_le_add_left := by rintro ⟨a⟩ ⟨b⟩ h ⟨c⟩; exact add_le_add_left (α := IGame) h _
@@ -112,6 +121,8 @@ instance : RatCast Game where
 @[simp] theorem mk_add (x y : IGame) : mk (x + y) = mk x + mk y := rfl
 @[simp] theorem mk_neg (x : IGame) : mk (-x) = -mk x := rfl
 @[simp] theorem mk_sub (x y : IGame) : mk (x - y) = mk x - mk y := rfl
+@[simp] theorem mk_nsmul (n : Nat) (x : IGame) : mk (n • x) = n • mk x := rfl
+@[simp] theorem mk_zsmul (n : Int) (x : IGame) : mk (n • x) = n • mk x := rfl
 
 theorem mk_mulOption (x y a b : IGame) :
     mk (mulOption x y a b) = mk (a * y) + mk (x * b) - mk (a * b) :=
@@ -122,13 +133,10 @@ theorem mk_mulOption (x y a b : IGame) :
 @[simp] theorem mk_fuzzy_mk {x y : IGame} : mk x ‖ mk y ↔ x ‖ y := .rfl
 
 @[simp, norm_cast]
-theorem mk_natCast : ∀ n : ℕ, mk n = n
-  | 0 => rfl
-  | n + 1 => by rw [Nat.cast_add, Nat.cast_add, mk_add, mk_natCast]; rfl
+theorem mk_natCast (n : Nat) : mk n = n := rfl
 
 @[simp, norm_cast]
-theorem mk_intCast (n : ℤ) : mk n = n := by
-  cases n <;> simp
+theorem mk_intCast (n : ℤ) : mk n = n := rfl
 
 @[simp, norm_cast] theorem mk_ratCast (q : ℚ) : mk q = q := rfl
 @[simp, norm_cast] theorem ratCast_neg (q : ℚ) : ((-q : ℚ) : Game) = -q := by simp [← mk_ratCast]

--- a/CombinatorialGames/Game/Classes.lean
+++ b/CombinatorialGames/Game/Classes.lean
@@ -434,6 +434,16 @@ protected instance intCast : ∀ n : ℤ, Numeric n
   | .ofNat n => inferInstanceAs (Numeric n)
   | .negSucc n => inferInstanceAs (Numeric (-(n + 1)))
 
+protected instance nsmul (n : Nat) (x : IGame) [Numeric x] : Numeric (n • x) := by
+  induction n with
+  | zero => simp
+  | succ n ih => rw [succ_nsmul]; exact .add (n • x) x
+
+protected instance zsmul (n : Int) (x : IGame) [Numeric x] : Numeric (n • x) := by
+  induction n using Int.negInduction with
+  | nat n => rw [natCast_zsmul]; infer_instance
+  | neg ih n => rw [neg_zsmul]; infer_instance
+
 end Numeric
 
 /-! ### Short games -/

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -791,6 +791,7 @@ instance : AddCommMonoid IGame where
 
 /-- The subtraction of `x` and `y` is defined as `x + (-y)`. -/
 instance : SubNegMonoid IGame where
+  sub a b := a + -b
   zsmul := zsmulRec
 
 @[simp]
@@ -921,11 +922,28 @@ theorem sub_congr_left {a b c : IGame} (h : a ≈ b) : a - c ≈ b - c :=
 theorem sub_congr_right {a b c : IGame} (h : a ≈ b) : c - a ≈ c - b :=
   sub_congr .rfl h
 
+theorem nsmul_congr {n : Nat} {a b : IGame} (h : a ≈ b) : n • a ≈ n • b := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [succ_nsmul, succ_nsmul]
+    exact add_congr ih h
+
+theorem zsmul_congr {n : Int} {a b : IGame} (h : a ≈ b) : n • a ≈ n • b := by
+  induction n using Int.negInduction with
+  | nat n =>
+    rw [natCast_zsmul, natCast_zsmul]
+    exact nsmul_congr h
+  | neg ih n =>
+    rw [neg_zsmul, neg_zsmul]
+    exact neg_congr (ih n)
+
 /-- We define the `NatCast` instance as `↑0 = 0` and `↑(n + 1) = !{{↑n} | ∅}`.
 
 Note that this is equivalent, but not identical, to the more common definition `↑n = !{Iio n | ∅}`.
 For that, use `NatOrdinal.toIGame`. -/
 instance : AddCommMonoidWithOne IGame where
+  natCast := Nat.unaryCast
 
 /-- This version of the theorem is more convenient for the `game_cmp` tactic. -/
 @[game_cmp]

--- a/CombinatorialGames/Surreal/Basic.lean
+++ b/CombinatorialGames/Surreal/Basic.lean
@@ -152,12 +152,23 @@ theorem equiv_mk_out (x : IGame) [Numeric x] : x ≈ (mk x).out :=
 instance : Zero Surreal := ⟨mk 0⟩
 instance : One Surreal := ⟨mk 1⟩
 instance : Inhabited Surreal := ⟨0⟩
+instance : NatCast Surreal := ⟨fun n => mk n⟩
+instance : IntCast Surreal := ⟨fun n => mk n⟩
 
 instance : Add Surreal where
   add := Quotient.map₂ (fun a b ↦ ⟨a.1 + b.1, inferInstance⟩) fun _ _ h₁ _ _ h₂ ↦ add_congr h₁ h₂
 
 instance : Neg Surreal where
   neg := Quotient.map (fun a ↦ ⟨-a.1, inferInstance⟩) fun _ _ ↦ neg_congr
+
+instance : Sub Surreal where
+  sub := Quotient.map₂ (fun a b ↦ ⟨a.1 - b.1, inferInstance⟩) fun _ _ h₁ _ _ h₂ ↦ sub_congr h₁ h₂
+
+instance : NSMul Surreal where
+  nsmul n := Quotient.map (fun a ↦ ⟨n • a.1, inferInstance⟩) fun _ _ ↦ nsmul_congr
+
+instance : ZSMul Surreal where
+  zsmul n := Quotient.map (fun a ↦ ⟨n • a.1, inferInstance⟩) fun _ _ ↦ zsmul_congr
 
 instance : PartialOrder Surreal :=
   inferInstanceAs (PartialOrder (Antisymmetrization ..))
@@ -166,16 +177,18 @@ instance : LinearOrder Surreal where
   le_total := by rintro ⟨x⟩ ⟨y⟩; exact Numeric.le_total x y
   toDecidableLE := Classical.decRel _
 
-instance : AddCommGroup Surreal where
+instance : AddCommGroupWithOne Surreal where
   zero_add := by rintro ⟨x⟩; change mk (0 + x) = mk x; simp_rw [zero_add]
   add_zero := by rintro ⟨x⟩; change mk (x + 0) = mk x; simp_rw [add_zero]
   add_comm := by rintro ⟨x⟩ ⟨y⟩; change mk (x + y) = mk (y + x); simp_rw [add_comm]
   add_assoc := by rintro ⟨x⟩ ⟨y⟩ ⟨z⟩; change mk (x + y + z) = mk (x + (y + z)); simp_rw [add_assoc]
   neg_add_cancel := by rintro ⟨a⟩; exact mk_eq (neg_add_equiv _)
-  nsmul := nsmulRec
-  zsmul := zsmulRec
-
-instance : AddGroupWithOne Surreal where
+  nsmul_zero := by rintro ⟨a⟩; rfl
+  nsmul_succ := by rintro n ⟨a⟩; rfl
+  zsmul_zero' := by rintro ⟨a⟩; rfl
+  zsmul_succ' := by rintro n ⟨a⟩; rfl
+  zsmul_neg' := by rintro n ⟨a⟩; rfl
+  sub_eq_add_neg := by rintro ⟨a⟩ ⟨b⟩; rfl
 
 instance : IsOrderedAddMonoid Surreal where
   add_le_add_left := by rintro ⟨a⟩ ⟨b⟩ h ⟨c⟩; exact add_le_add_left (α := IGame) h _
@@ -185,18 +198,17 @@ instance : IsOrderedAddMonoid Surreal where
 @[simp] theorem mk_add (x y : IGame) [Numeric x] [Numeric y] : mk (x + y) = mk x + mk y := rfl
 @[simp] theorem mk_neg (x : IGame) [Numeric x] : mk (-x) = -mk x := rfl
 @[simp] theorem mk_sub (x y : IGame) [Numeric x] [Numeric y] : mk (x - y) = mk x - mk y := rfl
+@[simp] theorem mk_nsmul (n : Nat) (x : IGame) [Numeric x] : mk (n • x) = n • mk x := rfl
+@[simp] theorem mk_zsmul (n : Int) (x : IGame) [Numeric x] : mk (n • x) = n • mk x := rfl
 
 @[simp] theorem mk_le_mk {x y : IGame} [Numeric x] [Numeric y] : mk x ≤ mk y ↔ x ≤ y := Iff.rfl
 @[simp] theorem mk_lt_mk {x y : IGame} [Numeric x] [Numeric y] : mk x < mk y ↔ x < y := Iff.rfl
 
 @[simp]
-theorem mk_natCast : ∀ n : ℕ, mk n = n
-  | 0 => rfl
-  | n + 1 => by simp_rw [Nat.cast_add_one, mk_add, mk_one, mk_natCast n]
+theorem mk_natCast (n : ℕ) : mk n = n := rfl
 
 @[simp]
-theorem mk_intCast (n : ℤ) : mk n = n := by
-  cases n <;> simp
+theorem mk_intCast (n : ℤ) : mk n = n := rfl
 
 instance : ZeroLEOneClass Surreal where
   zero_le_one := zero_le_one (α := IGame)


### PR DESCRIPTION
Fix defeqs of `nsmul`, `zsmul`, `natCast`, `intCast` for `IGame`, `Game`, `Surreal`.