### PR TITLE
feat: games of birthday one

### DIFF
--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -144,8 +144,8 @@ theorem mk_intCast (n : ℤ) : mk n = n := rfl
 theorem zero_def : (0 : Game) = !{fun _ ↦ ∅} := by apply (mk_ofSets' ..).trans; simp
 theorem one_def : (1 : Game) = !{{0} | ∅} := by apply (mk_ofSets ..).trans; simp
 
-theorem mk_eq_zero {x : IGame} : mk x = 0 ↔ x ≈ 0 := mk_eq_mk
-theorem zero_eq_mk {x : IGame} : 0 = mk x ↔ 0 ≈ x := mk_eq_mk
+@[simp] theorem mk_eq_zero {x : IGame} : mk x = 0 ↔ x ≈ 0 := mk_eq_mk
+@[simp] theorem zero_eq_mk {x : IGame} : 0 = mk x ↔ 0 ≈ x := mk_eq_mk
 
 instance : ZeroLEOneClass Game where
   zero_le_one := zero_le_one (α := IGame)

--- a/CombinatorialGames/Game/Basic.lean
+++ b/CombinatorialGames/Game/Basic.lean
@@ -144,6 +144,9 @@ theorem mk_intCast (n : ℤ) : mk n = n := rfl
 theorem zero_def : (0 : Game) = !{fun _ ↦ ∅} := by apply (mk_ofSets' ..).trans; simp
 theorem one_def : (1 : Game) = !{{0} | ∅} := by apply (mk_ofSets ..).trans; simp
 
+theorem mk_eq_zero {x : IGame} : mk x = 0 ↔ x ≈ 0 := mk_eq_mk
+theorem zero_eq_mk {x : IGame} : 0 = mk x ↔ 0 ≈ x := mk_eq_mk
+
 instance : ZeroLEOneClass Game where
   zero_le_one := zero_le_one (α := IGame)
 

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -418,16 +418,30 @@ theorem birthday_add_le (x y : Game) : (x + y).birthday ≤ x.birthday + y.birth
 theorem birthday_sub_le (x y : Game) : (x - y).birthday ≤ x.birthday + y.birthday := by
   simpa [sub_eq_add_neg] using birthday_add_le x (-y)
 
-theorem birthday_eq_one {x : Game} : birthday x = 1 ↔ x = 1 ∨ x = -1 ∨ x = mk ⋆ := by
+theorem mk_eq_zero {x : IGame} : mk x = 0 ↔ x ≈ 0 := mk_eq_mk
+theorem zero_eq_mk {x : IGame} : 0 = mk x ↔ 0 ≈ x := mk_eq_mk
+
+theorem mk_ofPred_birthday_lt (o : NatOrdinal) :
+    mk '' {x | x.birthday < o} = {x | x.birthday < o} := by
+  ext x
   constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact (birthday_mk_le x).trans_lt hx
   · intro hx
-    obtain ⟨x, rfl, hxb⟩ := birthday_eq_iGameBirthday x
-    rw [← hxb, IGame.birthday_eq_one] at hx
-    obtain rfl | rfl | rfl := hx <;> simp
-  · rintro (rfl | rfl | rfl) <;> simp
+    obtain ⟨x, rfl, hx⟩ := birthday_eq_iGameBirthday x
+    refine ⟨x, ?_, rfl⟩
+    rwa [mem_ofPred, hx]
+
+theorem mk_ofPred_birthday_le (o : NatOrdinal) :
+    mk '' {x | x.birthday ≤ o} = {x | x.birthday ≤ o} := by
+  simpa using mk_ofPred_birthday_lt (o + 1)
 
 theorem birthday_le_one {x : Game} : birthday x ≤ 1 ↔ x = 0 ∨ x = 1 ∨ x = -1 ∨ x = mk ⋆ := by
-  rw [le_one_iff, birthday_eq_one, birthday_eq_zero]
+  simpa [IGame.birthday_le_one, eq_comm] using Set.ext_iff.1 (mk_ofPred_birthday_le 1).symm x
+
+theorem birthday_eq_one {x : Game} : birthday x = 1 ↔ x = 1 ∨ x = -1 ∨ x = mk ⋆ := by
+  rw [le_antisymm_iff, one_le_iff_ne_zero, ne_eq, birthday_eq_zero, birthday_le_one]
+  aesop (add simp [zero_eq_mk])
 
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x | birthday x ≤ o} := by

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -205,18 +205,6 @@ theorem birthday_tiny (x : IGame) : (⧾x).birthday = x.birthday + 2 := by
 theorem birthday_miny (x : IGame) : (⧿x).birthday = x.birthday + 2 := by
   rw [← neg_tiny, birthday_neg, birthday_tiny]
 
-theorem birthday_le_one {x : IGame} : x.birthday ≤ 1 ↔ x = 0 ∨ x = 1 ∨ x = -1 ∨ x = ⋆ := by
-  rw [← Nat.cast_one, ← mem_birthdayFinset, birthdayFinset_one]
-  simp
-
-@[simp]
-theorem zero_ne_star : 0 ≠ ⋆ :=
-  zero_fuzzy_star.ne
-
-theorem birthday_eq_one {x : IGame} : x.birthday = 1 ↔ x = 1 ∨ x = -1 ∨ x = ⋆ := by
-  rw [le_antisymm_iff, one_le_iff_ne_zero, birthday_le_one]
-  aesop
-
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x | birthday x < o} := by
   induction o using SuccOrder.prelimitRecOn with
@@ -320,6 +308,14 @@ decreasing_by igame_wf
 
 theorem Short.birthday_lt_omega0 (x : IGame) [Short x] : birthday x < of .omega0 :=
   short_iff_birthday_finite.1 ‹_›
+
+theorem birthday_le_one {x : IGame} : x.birthday ≤ 1 ↔ x = 0 ∨ x = 1 ∨ x = -1 ∨ x = ⋆ := by
+  rw [← Nat.cast_one, ← mem_birthdayFinset, birthdayFinset_one]
+  simp
+
+theorem birthday_eq_one {x : IGame} : x.birthday = 1 ↔ x = 1 ∨ x = -1 ∨ x = ⋆ := by
+  rw [le_antisymm_iff, one_le_iff_ne_zero, birthday_le_one]
+  aesop
 
 end IGame
 

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -418,7 +418,7 @@ theorem birthday_add_le (x y : Game) : (x + y).birthday ≤ x.birthday + y.birth
 theorem birthday_sub_le (x y : Game) : (x - y).birthday ≤ x.birthday + y.birthday := by
   simpa [sub_eq_add_neg] using birthday_add_le x (-y)
 
-theorem birthday_eq_one {x : Game} : birthday x = 1 ↔ x = -1 ∨ x = mk ⋆ ∨ x = 1 := by
+theorem birthday_eq_one {x : Game} : birthday x = 1 ↔ x = 1 ∨ x = -1 ∨ x = mk ⋆ := by
   constructor
   · intro hx
     obtain ⟨x, rfl, hxb⟩ := birthday_eq_iGameBirthday x
@@ -426,10 +426,8 @@ theorem birthday_eq_one {x : Game} : birthday x = 1 ↔ x = -1 ∨ x = mk ⋆ �
     obtain rfl | rfl | rfl := hx <;> simp
   · rintro (rfl | rfl | rfl) <;> simp
 
-theorem birthday_le_one {x : Game} : birthday x ≤ 1 ↔ x = -1 ∨ x = 0 ∨ x = mk ⋆ ∨ x = 1 := by
+theorem birthday_le_one {x : Game} : birthday x ≤ 1 ↔ x = 0 ∨ x = 1 ∨ x = -1 ∨ x = mk ⋆ := by
   rw [le_one_iff, birthday_eq_one, birthday_eq_zero]
-  apply iff_of_eq
-  ac_rfl
 
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x | birthday x ≤ o} := by

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -418,19 +418,16 @@ theorem birthday_add_le (x y : Game) : (x + y).birthday ≤ x.birthday + y.birth
 theorem birthday_sub_le (x y : Game) : (x - y).birthday ≤ x.birthday + y.birthday := by
   simpa [sub_eq_add_neg] using birthday_add_le x (-y)
 
-theorem mk_eq_zero {x : IGame} : mk x = 0 ↔ x ≈ 0 := mk_eq_mk
-theorem zero_eq_mk {x : IGame} : 0 = mk x ↔ 0 ≈ x := mk_eq_mk
-
 theorem mk_ofPred_birthday_lt (o : NatOrdinal) :
     mk '' {x | x.birthday < o} = {x | x.birthday < o} := by
   ext x
   constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact (birthday_mk_le x).trans_lt hx
+  · revert x
+    exact Set.forall_mem_image.2 fun x hx => (birthday_mk_le x).trans_lt hx
   · intro hx
-    obtain ⟨x, rfl, hx⟩ := birthday_eq_iGameBirthday x
+    obtain ⟨x, rfl, hxb⟩ := birthday_eq_iGameBirthday x
     refine ⟨x, ?_, rfl⟩
-    rwa [mem_ofPred, hx]
+    rwa [mem_ofPred, hxb]
 
 theorem mk_ofPred_birthday_le (o : NatOrdinal) :
     mk '' {x | x.birthday ≤ o} = {x | x.birthday ≤ o} := by

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -438,7 +438,7 @@ theorem birthday_le_one {x : Game} : birthday x ≤ 1 ↔ x = 0 ∨ x = 1 ∨ x 
 
 theorem birthday_eq_one {x : Game} : birthday x = 1 ↔ x = 1 ∨ x = -1 ∨ x = mk ⋆ := by
   rw [le_antisymm_iff, one_le_iff_ne_zero, ne_eq, birthday_eq_zero, birthday_le_one]
-  aesop (add simp [zero_eq_mk])
+  aesop
 
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x | birthday x ≤ o} := by

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -205,6 +205,34 @@ theorem birthday_tiny (x : IGame) : (⧾x).birthday = x.birthday + 2 := by
 theorem birthday_miny (x : IGame) : (⧿x).birthday = x.birthday + 2 := by
   rw [← neg_tiny, birthday_neg, birthday_tiny]
 
+theorem birthday_eq_one {x : IGame} : birthday x = 1 ↔ x = -1 ∨ x = ⋆ ∨ x = 1 := by
+  constructor
+  · intro hx
+    have hxm (p : Player) : x.moves p ⊆ {0} := by
+      intro z hz
+      rw [Set.mem_singleton_iff, ← birthday_eq_zero, ← lt_one_iff, ← hx]
+      exact birthday_lt_of_mem_moves hz
+    have hxl := subset_singleton_iff_eq.1 (hxm left)
+    have hxr := subset_singleton_iff_eq.1 (hxm right)
+    rw [← ofSets_leftMoves_rightMoves x] at hx ⊢
+    obtain hxl | hxl := hxl <;> obtain hxr | hxr := hxr <;> simp_rw [hxl, hxr] at hx ⊢
+    · absurd hx
+      rw [← ofSets_eq_ofSets_cases (fun _ => ∅) trivial, ← zero_def]
+      simp
+    · refine .inl ?_
+      rw [one_def]
+      simp
+    · refine .inr (.inr ?_)
+      rw [one_def]
+    · refine .inr (.inl (ext fun p => ?_))
+      cases p <;> simp
+  · rintro (rfl | rfl | rfl) <;> simp
+
+theorem birthday_le_one {x : IGame} : birthday x ≤ 1 ↔ x = -1 ∨ x = 0 ∨ x = ⋆ ∨ x = 1 := by
+  rw [le_one_iff, birthday_eq_zero, birthday_eq_one]
+  apply iff_of_eq
+  ac_rfl
+
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x | birthday x < o} := by
   induction o using SuccOrder.prelimitRecOn with
@@ -409,6 +437,19 @@ theorem birthday_add_le (x y : Game) : (x + y).birthday ≤ x.birthday + y.birth
 
 theorem birthday_sub_le (x y : Game) : (x - y).birthday ≤ x.birthday + y.birthday := by
   simpa [sub_eq_add_neg] using birthday_add_le x (-y)
+
+theorem birthday_eq_one {x : Game} : birthday x = 1 ↔ x = -1 ∨ x = mk ⋆ ∨ x = 1 := by
+  constructor
+  · intro hx
+    obtain ⟨x, rfl, hxb⟩ := birthday_eq_iGameBirthday x
+    rw [← hxb, IGame.birthday_eq_one] at hx
+    obtain rfl | rfl | rfl := hx <;> simp
+  · rintro (rfl | rfl | rfl) <;> simp
+
+theorem birthday_le_one {x : Game} : birthday x ≤ 1 ↔ x = -1 ∨ x = 0 ∨ x = mk ⋆ ∨ x = 1 := by
+  rw [le_one_iff, birthday_eq_one, birthday_eq_zero]
+  apply iff_of_eq
+  ac_rfl
 
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x | birthday x ≤ o} := by

--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -205,33 +205,17 @@ theorem birthday_tiny (x : IGame) : (⧾x).birthday = x.birthday + 2 := by
 theorem birthday_miny (x : IGame) : (⧿x).birthday = x.birthday + 2 := by
   rw [← neg_tiny, birthday_neg, birthday_tiny]
 
-theorem birthday_eq_one {x : IGame} : birthday x = 1 ↔ x = -1 ∨ x = ⋆ ∨ x = 1 := by
-  constructor
-  · intro hx
-    have hxm (p : Player) : x.moves p ⊆ {0} := by
-      intro z hz
-      rw [Set.mem_singleton_iff, ← birthday_eq_zero, ← lt_one_iff, ← hx]
-      exact birthday_lt_of_mem_moves hz
-    have hxl := subset_singleton_iff_eq.1 (hxm left)
-    have hxr := subset_singleton_iff_eq.1 (hxm right)
-    rw [← ofSets_leftMoves_rightMoves x] at hx ⊢
-    obtain hxl | hxl := hxl <;> obtain hxr | hxr := hxr <;> simp_rw [hxl, hxr] at hx ⊢
-    · absurd hx
-      rw [← ofSets_eq_ofSets_cases (fun _ => ∅) trivial, ← zero_def]
-      simp
-    · refine .inl ?_
-      rw [one_def]
-      simp
-    · refine .inr (.inr ?_)
-      rw [one_def]
-    · refine .inr (.inl (ext fun p => ?_))
-      cases p <;> simp
-  · rintro (rfl | rfl | rfl) <;> simp
+theorem birthday_le_one {x : IGame} : x.birthday ≤ 1 ↔ x = 0 ∨ x = 1 ∨ x = -1 ∨ x = ⋆ := by
+  rw [← Nat.cast_one, ← mem_birthdayFinset, birthdayFinset_one]
+  simp
 
-theorem birthday_le_one {x : IGame} : birthday x ≤ 1 ↔ x = -1 ∨ x = 0 ∨ x = ⋆ ∨ x = 1 := by
-  rw [le_one_iff, birthday_eq_zero, birthday_eq_one]
-  apply iff_of_eq
-  ac_rfl
+@[simp]
+theorem zero_ne_star : 0 ≠ ⋆ :=
+  zero_fuzzy_star.ne
+
+theorem birthday_eq_one {x : IGame} : x.birthday = 1 ↔ x = 1 ∨ x = -1 ∨ x = ⋆ := by
+  rw [le_antisymm_iff, one_le_iff_ne_zero, birthday_le_one]
+  aesop
 
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x | birthday x < o} := by

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -44,8 +44,11 @@ theorem star_lf_zero : ⋆ ⧏ 0 := by rw [lf_zero]; simp
 theorem star_fuzzy_zero : ⋆ ‖ 0 := ⟨zero_lf_star, star_lf_zero⟩
 theorem zero_fuzzy_star : 0 ‖ ⋆ := ⟨star_lf_zero, zero_lf_star⟩
 
+@[simp] theorem zero_ne_star : 0 ≠ ⋆ := zero_fuzzy_star.ne
+@[simp] theorem star_ne_zero : ⋆ ≠ 0 := star_fuzzy_zero.ne
 @[simp] theorem not_star_equiv_zero : ¬⋆ ≈ 0 := star_fuzzy_zero.not_antisymmRel
 @[simp] theorem not_zero_equiv_star : ¬0 ≈ ⋆ := zero_fuzzy_star.not_antisymmRel
+
 
 @[simp, game_cmp] theorem neg_star : -⋆ = ⋆ := by simp [star]
 

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -49,7 +49,6 @@ theorem zero_fuzzy_star : 0 ‖ ⋆ := ⟨star_lf_zero, zero_lf_star⟩
 @[simp] theorem not_star_equiv_zero : ¬⋆ ≈ 0 := star_fuzzy_zero.not_antisymmRel
 @[simp] theorem not_zero_equiv_star : ¬0 ≈ ⋆ := zero_fuzzy_star.not_antisymmRel
 
-
 @[simp, game_cmp] theorem neg_star : -⋆ = ⋆ := by simp [star]
 
 @[simp] theorem star_mul_star : ⋆ * ⋆ = ⋆ := by ext p; cases p <;> simp [mulOption]

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -44,8 +44,8 @@ theorem star_lf_zero : ⋆ ⧏ 0 := by rw [lf_zero]; simp
 theorem star_fuzzy_zero : ⋆ ‖ 0 := ⟨zero_lf_star, star_lf_zero⟩
 theorem zero_fuzzy_star : 0 ‖ ⋆ := ⟨star_lf_zero, zero_lf_star⟩
 
-@[simp] theorem zero_ne_star : 0 ≠ ⋆ := zero_fuzzy_star.ne
 @[simp] theorem star_ne_zero : ⋆ ≠ 0 := star_fuzzy_zero.ne
+@[simp] theorem zero_ne_star : 0 ≠ ⋆ := zero_fuzzy_star.ne
 @[simp] theorem not_star_equiv_zero : ¬⋆ ≈ 0 := star_fuzzy_zero.not_antisymmRel
 @[simp] theorem not_zero_equiv_star : ¬0 ≈ ⋆ := zero_fuzzy_star.not_antisymmRel
 

--- a/CombinatorialGames/Game/Special.lean
+++ b/CombinatorialGames/Game/Special.lean
@@ -54,6 +54,7 @@ theorem zero_fuzzy_star : 0 ‖ ⋆ := ⟨star_lf_zero, zero_lf_star⟩
 @[simp] protected instance Dicotic.star : Dicotic ⋆ := by rw [dicotic_def]; simp
 protected instance Impartial.star : Impartial ⋆ := by rw [impartial_def]; simp
 @[simp] protected instance Short.star : Short ⋆ := by rw [short_def]; simp
+@[simp] theorem not_numeric_star : ¬Numeric ⋆ := by rw [numeric_def]; simp
 
 /-! ### Half -/
 

--- a/CombinatorialGames/Surreal/Birthday/Basic.lean
+++ b/CombinatorialGames/Surreal/Birthday/Basic.lean
@@ -128,6 +128,23 @@ theorem birthday_add_le (x y : Surreal) : (x + y).birthday ≤ x.birthday + y.bi
 theorem birthday_sub_le (x y : Surreal) : (x - y).birthday ≤ x.birthday + y.birthday := by
   simpa [sub_eq_add_neg] using birthday_add_le x (-y)
 
+theorem birthday_eq_one {x : Surreal} : birthday x = 1 ↔ x = -1 ∨ x = 1 := by
+  constructor
+  · intro hx
+    obtain ⟨x, nx, rfl, hxb⟩ := birthday_eq_iGameBirthday x
+    rw [← hxb, IGame.birthday_eq_one] at hx
+    obtain rfl | rfl | rfl := hx
+    · simp
+    · absurd nx
+      exact not_numeric_star
+    · simp
+  · rintro (rfl | rfl) <;> simp
+
+theorem birthday_le_one {x : Surreal} : birthday x ≤ 1 ↔ x = -1 ∨ x = 0 ∨ x = 1 := by
+  rw [le_one_iff, birthday_eq_one, birthday_eq_zero]
+  apply iff_of_eq
+  ac_rfl
+
 /- This is currently an open problem, see https://mathoverflow.net/a/476829/147705. -/
 proof_wanted birthday_mul_le (x y : Surreal) : (x * y).birthday ≤ x.birthday * y.birthday
 

--- a/CombinatorialGames/Surreal/Birthday/Basic.lean
+++ b/CombinatorialGames/Surreal/Birthday/Basic.lean
@@ -128,22 +128,20 @@ theorem birthday_add_le (x y : Surreal) : (x + y).birthday ≤ x.birthday + y.bi
 theorem birthday_sub_le (x y : Surreal) : (x - y).birthday ≤ x.birthday + y.birthday := by
   simpa [sub_eq_add_neg] using birthday_add_le x (-y)
 
-theorem birthday_eq_one {x : Surreal} : birthday x = 1 ↔ x = -1 ∨ x = 1 := by
+theorem birthday_eq_one {x : Surreal} : birthday x = 1 ↔ x = 1 ∨ x = -1 := by
   constructor
   · intro hx
     obtain ⟨x, nx, rfl, hxb⟩ := birthday_eq_iGameBirthday x
     rw [← hxb, IGame.birthday_eq_one] at hx
     obtain rfl | rfl | rfl := hx
     · simp
+    · simp
     · absurd nx
       exact not_numeric_star
-    · simp
   · rintro (rfl | rfl) <;> simp
 
-theorem birthday_le_one {x : Surreal} : birthday x ≤ 1 ↔ x = -1 ∨ x = 0 ∨ x = 1 := by
+theorem birthday_le_one {x : Surreal} : birthday x ≤ 1 ↔ x = 0 ∨ x = 1 ∨ x = -1 := by
   rw [le_one_iff, birthday_eq_one, birthday_eq_zero]
-  apply iff_of_eq
-  ac_rfl
 
 /- This is currently an open problem, see https://mathoverflow.net/a/476829/147705. -/
 proof_wanted birthday_mul_le (x y : Surreal) : (x * y).birthday ≤ x.birthday * y.birthday


### PR DESCRIPTION
Prove that the games of birthday one are exactly `-1`, `⋆`, and `1`. Prove that the games of birthday at most one are `-1`, `0`, `⋆`, and `1`. Prove that the numbers of birthday `1` are `-1` and `1`, and that the numbers of birthday at most `1` are `-1`, `0`, and `1`.