### PR TITLE
chore: remove `small_subtype_` lemmas

### DIFF
--- a/CombinatorialGames/Game/Birthday.lean
+++ b/CombinatorialGames/Game/Birthday.lean
@@ -222,16 +222,7 @@ instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x | birthday 
 
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x | birthday x ≤ o} := by
-  convert small_setOf_birthday_lt (succ o) using 1
-  simp
-
-/-- A variant of `small_setOf_birthday_le` in simp-normal form -/
-instance small_subtype_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x // birthday x ≤ o} :=
-  small_setOf_birthday_le o
-
-/-- A variant of `small_setOf_birthday_lt` in simp-normal form -/
-instance small_subtype_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x // birthday x < o} :=
-  small_setOf_birthday_lt o
+  simpa using small_setOf_birthday_lt (succ o)
 
 /-! #### Short games -/
 
@@ -419,14 +410,6 @@ instance small_setOf_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x | birthday 
 /-- Games with a bounded birthday form a small set. -/
 instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x | birthday x < o} :=
   small_subset (s := {x | birthday x ≤ o}) <| ofPred_subset_ofPred.2 fun _ => le_of_lt
-
-/-- A variant of `small_setOf_birthday_le` in simp-normal form -/
-instance small_subtype_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x // birthday x ≤ o} :=
-  small_setOf_birthday_le o
-
-/-- A variant of `small_setOf_birthday_lt` in simp-normal form -/
-instance small_subtype_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x // birthday x < o} :=
-  small_setOf_birthday_lt o
 
 end Game
 end

--- a/CombinatorialGames/Game/IGame.lean
+++ b/CombinatorialGames/Game/IGame.lean
@@ -198,10 +198,6 @@ instance : IsTrans _ Subposition := inferInstanceAs (IsTrans _ (Relation.TransGe
 instance small_setOf_subposition (x : IGame.{u}) : Small.{u} {y | Subposition y x} :=
   small_transGen' _ x
 
-/-- A variant of `small_setOf_subposition` in simp-normal form -/
-instance small_subtype_subposition (x : IGame.{u}) : Small.{u} {y // Subposition y x} :=
-  small_transGen' _ x
-
 theorem subposition_wf : WellFounded Subposition := by
   refine ⟨fun x => Acc.transGen ?_⟩
   apply QPF.Fix.ind
@@ -241,10 +237,6 @@ theorem subposition_iff_exists {x y : IGame} : Subposition x y ↔
 
 /-- The set of games reachable from a given game is small. -/
 instance small_setOf_wsubposition (x : IGame.{u}) : Small.{u} {y | WSubposition y x} :=
-  small_insert x {y | Subposition y x}
-
-/-- A variant of `small_setOf_wsubposition` in simp-normal form -/
-instance small_subtype_wsubposition (x : IGame.{u}) : Small.{u} {y // WSubposition y x} :=
   small_insert x {y | Subposition y x}
 
 @[simp, refl] theorem WSubposition.refl (x : IGame) : WSubposition x x := .inl rfl

--- a/CombinatorialGames/Game/Loopy/Basic.lean
+++ b/CombinatorialGames/Game/Loopy/Basic.lean
@@ -114,7 +114,7 @@ theorem Subposition.trans {x y z : LGame} (h₁ : Subposition x y) (h₂ : Subpo
     Subposition x z :=
   Relation.TransGen.trans h₁ h₂
 
-instance (x : LGame.{u}) : Small.{u} {y // Subposition y x} :=
+instance (x : LGame.{u}) : Small.{u} {y | Subposition y x} :=
   small_transGen' _ x
 
 @[elab_as_elim]

--- a/CombinatorialGames/Surreal/Birthday/Basic.lean
+++ b/CombinatorialGames/Surreal/Birthday/Basic.lean
@@ -151,12 +151,4 @@ instance small_setOf_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x | birthday 
   refine small_subset (?_ : {x : Surreal | x.birthday < o} ⊆ {x : Surreal | x.birthday ≤ o})
   simp +contextual [le_of_lt]
 
-/-- A variant of `small_setOf_birthday_le` in simp-normal form -/
-instance small_subtype_birthday_le (o : NatOrdinal.{u}) : Small.{u} {x // birthday x ≤ o} :=
-  small_setOf_birthday_le o
-
-/-- A variant of `small_setOf_birthday_lt` in simp-normal form -/
-instance small_subtype_birthday_lt (o : NatOrdinal.{u}) : Small.{u} {x // birthday x < o} :=
-  small_setOf_birthday_lt o
-
 end Surreal


### PR DESCRIPTION
After leanprover-community/mathlib4#39582 `↑{x | p x}` no longer simplifies to `{x // p x}`, so we can remove these lemmas.