### PR TITLE
feat(Cut): `leftSurreal_covBy_rightSurreal` is surjective

### DIFF
--- a/CombinatorialGames/Surreal/Cut.lean
+++ b/CombinatorialGames/Surreal/Cut.lean
@@ -602,6 +602,20 @@ theorem supLeft_lt_infRight_of_equiv_numeric {x y : IGame} [y.Numeric] (h : x �
 theorem supLeft_lt_infRight_of_numeric (x : IGame) [x.Numeric] : supLeft x < infRight x :=
   supLeft_lt_infRight_of_equiv_numeric .rfl
 
+theorem covBy_iff {x y : Cut} : x ⋖ y ↔ ∃ z, leftSurreal z = x ∧ rightSurreal z = y := by
+  refine ⟨fun h => ?_, by rintro ⟨z, rfl, rfl⟩; exact leftSurreal_covBy_rightSurreal z⟩
+  refine ⟨simplestBtwn h.lt, ?_, ?_⟩
+  · apply le_antisymm
+    · rw [h.le_iff_lt_left, lt_iff_nonempty_inter]
+      exact ⟨simplestBtwn h.lt, mem_right_leftSurreal.2 le_rfl, (fits_simplestBtwn h.lt).2⟩
+    · rw [le_leftSurreal_iff]
+      exact (fits_simplestBtwn h.lt).1
+  · apply le_antisymm
+    · rw [rightSurreal_le_iff]
+      exact (fits_simplestBtwn h.lt).2
+    · rw [h.le_iff_lt_right, lt_iff_nonempty_inter]
+      exact ⟨simplestBtwn h.lt, (fits_simplestBtwn h.lt).1, mem_left_rightSurreal.2 le_rfl⟩
+
 /-! ### Numeric cuts -/
 
 /-- We say that a cut is numeric when it's either a left or right cut from a surreal. -/


### PR DESCRIPTION
Prove that any relation of the form `x ⋖ y` must be of the form `leftSurreal z ⋖ rightSurreal z`.